### PR TITLE
chore: Ensure python versions are installed and used when running tests

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -9,14 +9,18 @@ jobs:
 
     strategy:
       matrix:
-        python-version:
-          - "3.12"
-          - "3.11"
-          - "3.10"
-          - "3.9"
+        python-version: ["3.12", "3.11", "3.10", "3.9"]
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
+        run: python --version
 
       - name: Install dependencies
         run: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 env =
     AWS_DEFAULT_REGION=eu-west-2
-;addopts = --tb=short --numprocesses auto --dist loadgroup
-addopts = --tb=short
+addopts = --tb=short --numprocesses auto --dist loadgroup
+;addopts = --tb=short

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,5 @@
 env =
     AWS_DEFAULT_REGION=eu-west-2
 addopts = --tb=short --numprocesses auto --dist loadgroup
-;addopts = --tb=short
+; You may need to use the addopts setting below to unbreak debugging in your IDE
+; addopts = --tb=short


### PR DESCRIPTION
Me and @JohnStainsby noticed that currently all 4 test runs are run with python version `3.10.12` so effectively, 3 are redundant.

This PR addresses this.