### PR TITLE
fix: otel metric collection errors

### DIFF
--- a/dbt_platform_helper/templates/svc/manifest-backend.yml
+++ b/dbt_platform_helper/templates/svc/manifest-backend.yml
@@ -46,8 +46,8 @@ variables:                    # Pass environment variables as key value pairs.
   OTEL_PROPAGATORS: xray
   OTEL_PYTHON_ID_GENERATOR: xray
   OTEL_SERVICE_NAME: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-{{ name }}
-  OTEL_METRICS_EXPORTER: console,otlp
-  OTEL_TRACES_EXPORTER: console,otlp
+  OTEL_METRICS_EXPORTER: none
+  OTEL_TRACES_EXPORTER: otlp
   OTEL_TRACES_SAMPLER: traceidratio
   OTEL_TRACES_SAMPLER_ARG: "0.05"
 {%- for envvar, value in env_vars.items() %}

--- a/dbt_platform_helper/templates/svc/manifest-public.yml
+++ b/dbt_platform_helper/templates/svc/manifest-public.yml
@@ -83,8 +83,8 @@ variables:                    # Pass environment variables as key value pairs.
   OTEL_PROPAGATORS: xray
   OTEL_PYTHON_ID_GENERATOR: xray
   OTEL_SERVICE_NAME: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-{{ name }}
-  OTEL_METRICS_EXPORTER: console,otlp
-  OTEL_TRACES_EXPORTER: console,otlp
+  OTEL_METRICS_EXPORTER: none
+  OTEL_TRACES_EXPORTER: otlp
   OTEL_TRACES_SAMPLER: traceidratio
   OTEL_TRACES_SAMPLER_ARG: "0.05"
 {%- for envvar, value in env_vars.items() %}

--- a/tests/platform_helper/fixtures/test_backend_service_manifest.yml
+++ b/tests/platform_helper/fixtures/test_backend_service_manifest.yml
@@ -46,8 +46,8 @@ variables:                    # Pass environment variables as key value pairs.
   OTEL_PROPAGATORS: xray
   OTEL_PYTHON_ID_GENERATOR: xray
   OTEL_SERVICE_NAME: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-test-backend-service
-  OTEL_METRICS_EXPORTER: console,otlp
-  OTEL_TRACES_EXPORTER: console,otlp
+  OTEL_METRICS_EXPORTER: none
+  OTEL_TRACES_EXPORTER: otlp
   OTEL_TRACES_SAMPLER: traceidratio
   OTEL_TRACES_SAMPLER_ARG: "0.05"
   TEST_VAR: TEST_VAR_VALUE

--- a/tests/platform_helper/fixtures/test_public_service_manifest.yml
+++ b/tests/platform_helper/fixtures/test_public_service_manifest.yml
@@ -83,8 +83,8 @@ variables:                    # Pass environment variables as key value pairs.
   OTEL_PROPAGATORS: xray
   OTEL_PYTHON_ID_GENERATOR: xray
   OTEL_SERVICE_NAME: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-test-public-service
-  OTEL_METRICS_EXPORTER: console,otlp
-  OTEL_TRACES_EXPORTER: console,otlp
+  OTEL_METRICS_EXPORTER: none
+  OTEL_TRACES_EXPORTER: otlp
   OTEL_TRACES_SAMPLER: traceidratio
   OTEL_TRACES_SAMPLER_ARG: "0.05"
   TEST_VAR: TEST_VAR_VALUE


### PR DESCRIPTION
Two issues in one:

- cyber overwhelmed by tracing data in sentinel processed logs
- An exception thrown in sentry about metric collection not being implemented
  - Flooding sentry
  - Metric collection appears to need additional setup to work