### PR TITLE
chore: update opensearch & Redis supported versions & references

### DIFF
--- a/dbt_platform_helper/templates/addons/env/opensearch.yml
+++ b/dbt_platform_helper/templates/addons/env/opensearch.yml
@@ -40,6 +40,14 @@ Mappings:
       EngineVersion: 'OpenSearch_1.3'
     '2.3':
       EngineVersion: 'OpenSearch_2.3'
+    '2.5':
+      EngineVersion: 'OpenSearch_2.5'
+    '2.7':
+      EngineVersion: 'OpenSearch_2.7'
+    '2.9':
+      EngineVersion: 'OpenSearch_2.9'
+    '2.11':
+      EngineVersion: 'OpenSearch_2.11'
 
 Conditions:
   {{ addon_config.prefix }}EnableHA: !Not [!Equals [!FindInMap [{{ addon_config.prefix }}EnvironmentConfigMap, !Ref Env, InstanceCount], 1]]

--- a/dbt_platform_helper/templates/addons/env/redis-cluster.yml
+++ b/dbt_platform_helper/templates/addons/env/redis-cluster.yml
@@ -28,6 +28,10 @@ Mappings:
 {%- endfor %}
 
   {{ addon_config.prefix }}EngineVersionMap:
+    '7.1':
+      CacheParameterGroupFamily: 'redis7.x'
+    '7.0':
+      CacheParameterGroupFamily: 'redis7.x'
     '6.2':
       CacheParameterGroupFamily: 'redis6.x'
     '6.0':

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -307,13 +307,13 @@ REDIS_PLANS = Or(
     "x-large-ha",
 )
 
-REDIS_ENGINE_VERSIONS = Or("4.0.10", "5.0.6", "6.0", "6.2")
+REDIS_ENGINE_VERSIONS = Or("4.0.10", "5.0.6", "6.0", "6.2", "7.0", "7.1")
 
 OPENSEARCH_PLANS = Or(
     "tiny", "small", "small-ha", "medium", "medium-ha", "large", "large-ha", "x-large", "x-large-ha"
 )
 
-OPENSEARCH_ENGINE_VERSIONS = Or("2.5", "2.3", "1.3", "1.2", "1.1", "1.0")
+OPENSEARCH_ENGINE_VERSIONS = Or("2.11", "2.9", "2.7", "2.5", "2.3", "1.3", "1.2", "1.1", "1.0")
 
 S3_BASE = {
     Optional("readonly"): bool,

--- a/tests/platform_helper/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
+++ b/tests/platform_helper/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
@@ -45,10 +45,34 @@ Mappings:
       EngineVersion: 'OpenSearch_1.3'
     '2.3':
       EngineVersion: 'OpenSearch_2.3'
+    '2.5':
+      EngineVersion: 'OpenSearch_2.5'
+    '2.7':
+      EngineVersion: 'OpenSearch_2.7'
+    '2.9':
+      EngineVersion: 'OpenSearch_2.9'
+    '2.11':
+      EngineVersion: 'OpenSearch_2.11'
 
 Conditions:
-  myOpensearchLongerEnableHA: !Not [!Equals [!FindInMap [myOpensearchLongerEnvironmentConfigMap, !Ref Env, InstanceCount], 1]]
-  myOpensearchLongerCreateProdSubFilter: !Or [!Equals [!Ref Env, prod], !Equals [!Ref Env, production], !Equals [!Ref Env, PROD], !Equals [!Ref Env, PRODUCTION]]
+  myOpensearchLongerEnableHA:
+    !Not [
+      !Equals [
+        !FindInMap [
+          myOpensearchLongerEnvironmentConfigMap,
+          !Ref Env,
+          InstanceCount
+        ],
+        1
+      ]
+    ]
+  myOpensearchLongerCreateProdSubFilter:
+    !Or [
+      !Equals [!Ref Env, prod],
+      !Equals [!Ref Env, production],
+      !Equals [!Ref Env, PROD],
+      !Equals [!Ref Env, PRODUCTION]
+    ]
 
 Resources:
   myOpensearchLongerOpenSearchSecret:
@@ -60,7 +84,7 @@ Resources:
       Description: !Sub OpenSearch main user secret for ${AWS::StackName}
       GenerateSecretString:
         SecretStringTemplate: '{"username": "opensearch"}'
-        GenerateStringKey: "password"
+        GenerateStringKey: 'password'
         ExcludePunctuation: false
         RequireEachIncludedType: true
         IncludeSpace: false
@@ -73,7 +97,12 @@ Resources:
     Metadata:
       'aws:copilot:description': 'A security group to access OS'
     Type: AWS::EC2::SecurityGroup
-    DeletionPolicy: !FindInMap [myOpensearchLongerEnvironmentConfigMap, !Ref Env, DeletionPolicy]
+    DeletionPolicy:
+      !FindInMap [
+        myOpensearchLongerEnvironmentConfigMap,
+        !Ref Env,
+        DeletionPolicy
+      ]
     UpdateReplacePolicy: Retain
     Properties:
       GroupDescription: 'The Security Group for my-opensearch-longer to access OpenSearch.'
@@ -87,7 +116,12 @@ Resources:
     Metadata:
       'aws:copilot:description': 'Allow ingress from containers in my application to the OpenSearch cluster'
     Type: AWS::EC2::SecurityGroupIngress
-    DeletionPolicy: !FindInMap [myOpensearchLongerEnvironmentConfigMap, !Ref Env, DeletionPolicy]
+    DeletionPolicy:
+      !FindInMap [
+        myOpensearchLongerEnvironmentConfigMap,
+        !Ref Env,
+        DeletionPolicy
+      ]
     UpdateReplacePolicy: Retain
     Properties:
       Description: Ingress Security Group from Fargate containers
@@ -99,32 +133,55 @@ Resources:
 
   myOpensearchLongerOpenSearchDomain:
     Type: 'AWS::OpenSearchService::Domain'
-    DeletionPolicy: !FindInMap [myOpensearchLongerEnvironmentConfigMap, !Ref Env, DeletionPolicy]
+    DeletionPolicy:
+      !FindInMap [
+        myOpensearchLongerEnvironmentConfigMap,
+        !Ref Env,
+        DeletionPolicy
+      ]
     UpdateReplacePolicy: Retain
     Properties:
       AccessPolicies:
         Version: '2012-10-17'
         Statement:
-        - Effect: Allow
-          Principal:
-            AWS: '*'
-          Action:
-          - 'es:ESHttp*'
-          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/myopensearchlon*'
+          - Effect: Allow
+            Principal:
+              AWS: '*'
+            Action:
+              - 'es:ESHttp*'
+            Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/myopensearchlon*'
       AdvancedSecurityOptions:
         Enabled: true
         InternalUserDatabaseEnabled: true
         MasterUserOptions:
           MasterUserName:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:username}}" ]]
+            !Join [
+              '',
+              [
+                '{{resolve:secretsmanager:',
+                !Ref myOpensearchLongerOpenSearchSecret,
+                ':SecretString:username}}'
+              ]
+            ]
           MasterUserPassword:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:password}}" ]]
+            !Join [
+              '',
+              [
+                '{{resolve:secretsmanager:',
+                !Ref myOpensearchLongerOpenSearchSecret,
+                ':SecretString:password}}'
+              ]
+            ]
       DomainEndpointOptions:
         EnforceHTTPS: true
         TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07'
       EngineVersion: !FindInMap
         - myOpensearchLongerEngineVersionMap
-        - !FindInMap [myOpensearchLongerEnvironmentConfigMap, !Ref Env, EngineVersion]
+        - !FindInMap [
+            myOpensearchLongerEnvironmentConfigMap,
+            !Ref Env,
+            EngineVersion
+          ]
         - EngineVersion
       NodeToNodeEncryptionOptions:
         Enabled: true
@@ -132,24 +189,48 @@ Resources:
         Enabled: true
       EBSOptions:
         EBSEnabled: true
-        VolumeSize: !FindInMap [myOpensearchLongerEnvironmentConfigMap, !Ref Env, VolumeSize]
+        VolumeSize:
+          !FindInMap [
+            myOpensearchLongerEnvironmentConfigMap,
+            !Ref Env,
+            VolumeSize
+          ]
         VolumeType: gp2
       ClusterConfig:
-        DedicatedMasterEnabled: !If [myOpensearchLongerEnableHA, !FindInMap [myOpensearchLongerEnvironmentConfigMap, !Ref Env, DedicatedMaster], false]
-        InstanceCount: !FindInMap [myOpensearchLongerEnvironmentConfigMap, !Ref Env, InstanceCount]
-        InstanceType: !FindInMap [myOpensearchLongerEnvironmentConfigMap, !Ref Env, InstanceType]
+        DedicatedMasterEnabled:
+          !If [
+            myOpensearchLongerEnableHA,
+            !FindInMap [
+              myOpensearchLongerEnvironmentConfigMap,
+              !Ref Env,
+              DedicatedMaster
+            ],
+            false
+          ]
+        InstanceCount:
+          !FindInMap [
+            myOpensearchLongerEnvironmentConfigMap,
+            !Ref Env,
+            InstanceCount
+          ]
+        InstanceType:
+          !FindInMap [
+            myOpensearchLongerEnvironmentConfigMap,
+            !Ref Env,
+            InstanceType
+          ]
         ZoneAwarenessEnabled: !If [myOpensearchLongerEnableHA, true, false]
         ZoneAwarenessConfig: !If
           - myOpensearchLongerEnableHA
           - AvailabilityZoneCount: 2 #Fn::length always resolves to 1 despite there being subnets.
-          - !Ref "AWS::NoValue"
+          - !Ref 'AWS::NoValue'
       VPCOptions:
         SecurityGroupIds:
           - !Ref myOpensearchLongerOpenSearchSecurityGroup
         SubnetIds: !If
           - myOpensearchLongerEnableHA
-          - !Split [ ",", !Ref PrivateSubnets ]
-          - - !Select [ 0, !Split [ ',', !Ref PrivateSubnets ] ]
+          - !Split [',', !Ref PrivateSubnets]
+          - - !Select [0, !Split [',', !Ref PrivateSubnets]]
       SoftwareUpdateOptions:
         AutoSoftwareUpdateEnabled: true
       LogPublishingOptions:
@@ -175,16 +256,32 @@ Resources:
 
   myOpensearchLongerOpenSearchEndpointConfigParam:
     Type: AWS::SSM::Parameter
-    DependsOn: 
+    DependsOn:
       - myOpensearchLongerOpenSearchDomain
     Properties:
-      Name: !Sub "/copilot/${App}/${Env}/secrets/MY_OPENSEARCH_LONGER"
+      Name: !Sub '/copilot/${App}/${Env}/secrets/MY_OPENSEARCH_LONGER'
       Type: String
       Value: !Sub
-        - "https://${username}:${password}@${url}"
+        - 'https://${username}:${password}@${url}'
         - url: !GetAtt myOpensearchLongerOpenSearchDomain.DomainEndpoint
-          username: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:username}}" ]]
-          password: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:password}}" ]]
+          username:
+            !Join [
+              '',
+              [
+                '{{resolve:secretsmanager:',
+                !Ref myOpensearchLongerOpenSearchSecret,
+                ':SecretString:username}}'
+              ]
+            ]
+          password:
+            !Join [
+              '',
+              [
+                '{{resolve:secretsmanager:',
+                !Ref myOpensearchLongerOpenSearchSecret,
+                ':SecretString:password}}'
+              ]
+            ]
 
   myOpensearchLongerOpenSearchAuditLogGroup:
     Type: AWS::Logs::LogGroup

--- a/tests/platform_helper/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
+++ b/tests/platform_helper/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
@@ -45,10 +45,30 @@ Mappings:
       EngineVersion: 'OpenSearch_1.3'
     '2.3':
       EngineVersion: 'OpenSearch_2.3'
+    '2.5':
+      EngineVersion: 'OpenSearch_2.5'
+    '2.7':
+      EngineVersion: 'OpenSearch_2.7'
+    '2.9':
+      EngineVersion: 'OpenSearch_2.9'
+    '2.11':
+      EngineVersion: 'OpenSearch_2.11'
 
 Conditions:
-  myOpensearchEnableHA: !Not [!Equals [!FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, InstanceCount], 1]]
-  myOpensearchCreateProdSubFilter: !Or [!Equals [!Ref Env, prod], !Equals [!Ref Env, production], !Equals [!Ref Env, PROD], !Equals [!Ref Env, PRODUCTION]]
+  myOpensearchEnableHA:
+    !Not [
+      !Equals [
+        !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, InstanceCount],
+        1
+      ]
+    ]
+  myOpensearchCreateProdSubFilter:
+    !Or [
+      !Equals [!Ref Env, prod],
+      !Equals [!Ref Env, production],
+      !Equals [!Ref Env, PROD],
+      !Equals [!Ref Env, PRODUCTION]
+    ]
 
 Resources:
   myOpensearchOpenSearchSecret:
@@ -60,7 +80,7 @@ Resources:
       Description: !Sub OpenSearch main user secret for ${AWS::StackName}
       GenerateSecretString:
         SecretStringTemplate: '{"username": "opensearch"}'
-        GenerateStringKey: "password"
+        GenerateStringKey: 'password'
         ExcludePunctuation: false
         RequireEachIncludedType: true
         IncludeSpace: false
@@ -73,7 +93,8 @@ Resources:
     Metadata:
       'aws:copilot:description': 'A security group to access OS'
     Type: AWS::EC2::SecurityGroup
-    DeletionPolicy: !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, DeletionPolicy]
+    DeletionPolicy:
+      !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, DeletionPolicy]
     UpdateReplacePolicy: Retain
     Properties:
       GroupDescription: 'The Security Group for my-opensearch to access OpenSearch.'
@@ -87,7 +108,8 @@ Resources:
     Metadata:
       'aws:copilot:description': 'Allow ingress from containers in my application to the OpenSearch cluster'
     Type: AWS::EC2::SecurityGroupIngress
-    DeletionPolicy: !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, DeletionPolicy]
+    DeletionPolicy:
+      !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, DeletionPolicy]
     UpdateReplacePolicy: Retain
     Properties:
       Description: Ingress Security Group from Fargate containers
@@ -99,26 +121,41 @@ Resources:
 
   myOpensearchOpenSearchDomain:
     Type: 'AWS::OpenSearchService::Domain'
-    DeletionPolicy: !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, DeletionPolicy]
+    DeletionPolicy:
+      !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, DeletionPolicy]
     UpdateReplacePolicy: Retain
     Properties:
       AccessPolicies:
         Version: '2012-10-17'
         Statement:
-        - Effect: Allow
-          Principal:
-            AWS: '*'
-          Action:
-          - 'es:ESHttp*'
-          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/myopensearch*'
+          - Effect: Allow
+            Principal:
+              AWS: '*'
+            Action:
+              - 'es:ESHttp*'
+            Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/myopensearch*'
       AdvancedSecurityOptions:
         Enabled: true
         InternalUserDatabaseEnabled: true
         MasterUserOptions:
           MasterUserName:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchOpenSearchSecret, ":SecretString:username}}" ]]
+            !Join [
+              '',
+              [
+                '{{resolve:secretsmanager:',
+                !Ref myOpensearchOpenSearchSecret,
+                ':SecretString:username}}'
+              ]
+            ]
           MasterUserPassword:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchOpenSearchSecret, ":SecretString:password}}" ]]
+            !Join [
+              '',
+              [
+                '{{resolve:secretsmanager:',
+                !Ref myOpensearchOpenSearchSecret,
+                ':SecretString:password}}'
+              ]
+            ]
       DomainEndpointOptions:
         EnforceHTTPS: true
         TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07'
@@ -132,24 +169,36 @@ Resources:
         Enabled: true
       EBSOptions:
         EBSEnabled: true
-        VolumeSize: !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, VolumeSize]
+        VolumeSize:
+          !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, VolumeSize]
         VolumeType: gp2
       ClusterConfig:
-        DedicatedMasterEnabled: !If [myOpensearchEnableHA, !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, DedicatedMaster], false]
-        InstanceCount: !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, InstanceCount]
-        InstanceType: !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, InstanceType]
+        DedicatedMasterEnabled:
+          !If [
+            myOpensearchEnableHA,
+            !FindInMap [
+              myOpensearchEnvironmentConfigMap,
+              !Ref Env,
+              DedicatedMaster
+            ],
+            false
+          ]
+        InstanceCount:
+          !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, InstanceCount]
+        InstanceType:
+          !FindInMap [myOpensearchEnvironmentConfigMap, !Ref Env, InstanceType]
         ZoneAwarenessEnabled: !If [myOpensearchEnableHA, true, false]
         ZoneAwarenessConfig: !If
           - myOpensearchEnableHA
           - AvailabilityZoneCount: 2 #Fn::length always resolves to 1 despite there being subnets.
-          - !Ref "AWS::NoValue"
+          - !Ref 'AWS::NoValue'
       VPCOptions:
         SecurityGroupIds:
           - !Ref myOpensearchOpenSearchSecurityGroup
         SubnetIds: !If
           - myOpensearchEnableHA
-          - !Split [ ",", !Ref PrivateSubnets ]
-          - - !Select [ 0, !Split [ ',', !Ref PrivateSubnets ] ]
+          - !Split [',', !Ref PrivateSubnets]
+          - - !Select [0, !Split [',', !Ref PrivateSubnets]]
       SoftwareUpdateOptions:
         AutoSoftwareUpdateEnabled: true
       LogPublishingOptions:
@@ -175,16 +224,32 @@ Resources:
 
   myOpensearchOpenSearchEndpointConfigParam:
     Type: AWS::SSM::Parameter
-    DependsOn: 
+    DependsOn:
       - myOpensearchOpenSearchDomain
     Properties:
-      Name: !Sub "/copilot/${App}/${Env}/secrets/MY_OPENSEARCH"
+      Name: !Sub '/copilot/${App}/${Env}/secrets/MY_OPENSEARCH'
       Type: String
       Value: !Sub
-        - "https://${username}:${password}@${url}"
+        - 'https://${username}:${password}@${url}'
         - url: !GetAtt myOpensearchOpenSearchDomain.DomainEndpoint
-          username: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchOpenSearchSecret, ":SecretString:username}}" ]]
-          password: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchOpenSearchSecret, ":SecretString:password}}" ]]
+          username:
+            !Join [
+              '',
+              [
+                '{{resolve:secretsmanager:',
+                !Ref myOpensearchOpenSearchSecret,
+                ':SecretString:username}}'
+              ]
+            ]
+          password:
+            !Join [
+              '',
+              [
+                '{{resolve:secretsmanager:',
+                !Ref myOpensearchOpenSearchSecret,
+                ':SecretString:password}}'
+              ]
+            ]
 
   myOpensearchOpenSearchAuditLogGroup:
     Type: AWS::Logs::LogGroup

--- a/tests/platform_helper/fixtures/make_addons/expected/environments/addons/my-redis.yml
+++ b/tests/platform_helper/fixtures/make_addons/expected/environments/addons/my-redis.yml
@@ -31,6 +31,10 @@ Mappings:
       DeletionPolicy: Delete
 
   myRedisEngineVersionMap:
+    '7.1':
+      CacheParameterGroupFamily: 'redis7.x'
+    '7.0':
+      CacheParameterGroupFamily: 'redis7.x'
     '6.2':
       CacheParameterGroupFamily: 'redis6.x'
     '6.0':
@@ -49,14 +53,26 @@ Mappings:
       CacheParameterGroupFamily: 'redis3.2'
 
 Conditions:
-  myRedisHasAutomaticFailoverEnabled: !Not [!Equals [!FindInMap [myRedisEnvironmentConfigMap, !Ref Env, NumReplicas], 0]]
-  myRedisCreateProdSubFilter: !Or [!Equals [!Ref Env, prod], !Equals [!Ref Env, production], !Equals [!Ref Env, PROD], !Equals [!Ref Env, PRODUCTION]]
+  myRedisHasAutomaticFailoverEnabled:
+    !Not [
+      !Equals [
+        !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, NumReplicas],
+        0
+      ]
+    ]
+  myRedisCreateProdSubFilter:
+    !Or [
+      !Equals [!Ref Env, prod],
+      !Equals [!Ref Env, production],
+      !Equals [!Ref Env, PROD],
+      !Equals [!Ref Env, PRODUCTION]
+    ]
 
 Resources:
-
   myRedisCacheParameterGroup:
     Type: 'AWS::ElastiCache::ParameterGroup'
-    DeletionPolicy: !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, DeletionPolicy]
+    DeletionPolicy:
+      !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, DeletionPolicy]
     UpdateReplacePolicy: Retain
     Properties:
       CacheParameterGroupFamily: !FindInMap
@@ -68,44 +84,51 @@ Resources:
 
   myRedisCacheSubnetGroupName:
     Type: 'AWS::ElastiCache::SubnetGroup'
-    DeletionPolicy: !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, DeletionPolicy]
+    DeletionPolicy:
+      !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, DeletionPolicy]
     UpdateReplacePolicy: Retain
     Properties:
       Description: !Ref 'AWS::StackName'
-      SubnetIds: !Split [ ",", !Ref PrivateSubnets ]
+      SubnetIds: !Split [',', !Ref PrivateSubnets]
 
   myRedisSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
-    DeletionPolicy: !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, DeletionPolicy]
+    DeletionPolicy:
+      !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, DeletionPolicy]
     UpdateReplacePolicy: Retain
     Properties:
       GroupDescription: !Ref 'AWS::StackName'
       VpcId: !Ref VpcId
       SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: 6379
-        ToPort: 6379
-        SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 6379
+          ToPort: 6379
+          SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
       Tags:
         - Key: Name
           Value: !Sub 'copilot-${App}-${Env}-my-redis-Redis-SecurityGroup'
 
   myRedisReplicationGroup:
     Type: 'AWS::ElastiCache::ReplicationGroup'
-    DeletionPolicy: !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, DeletionPolicy]
+    DeletionPolicy:
+      !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, DeletionPolicy]
     UpdateReplacePolicy: Retain
     Properties:
       ReplicationGroupDescription: !Ref 'AWS::StackName'
       AtRestEncryptionEnabled: true
-      AutomaticFailoverEnabled: !If [myRedisHasAutomaticFailoverEnabled, true, false]
+      AutomaticFailoverEnabled:
+        !If [myRedisHasAutomaticFailoverEnabled, true, false]
       MultiAZEnabled: !If [myRedisHasAutomaticFailoverEnabled, true, false]
-      CacheNodeType: !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, CacheNodeType]
+      CacheNodeType:
+        !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, CacheNodeType]
       CacheParameterGroupName: !Ref myRedisCacheParameterGroup
       CacheSubnetGroupName: !Ref myRedisCacheSubnetGroupName
       Engine: redis
-      EngineVersion: !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, EngineVersion]
-      NumNodeGroups: 1   # run in non clustered mode with 1 master and 0-5 replicas
-      ReplicasPerNodeGroup: !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, NumReplicas]
+      EngineVersion:
+        !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, EngineVersion]
+      NumNodeGroups: 1 # run in non clustered mode with 1 master and 0-5 replicas
+      ReplicasPerNodeGroup:
+        !FindInMap [myRedisEnvironmentConfigMap, !Ref Env, NumReplicas]
       PreferredMaintenanceWindow: 'sat:07:00-sat:08:00'
       LogDeliveryConfigurations:
         - DestinationDetails:
@@ -121,7 +144,7 @@ Resources:
           LogFormat: json
           LogType: engine-log
       SecurityGroupIds:
-      - !Ref myRedisSecurityGroup
+        - !Ref myRedisSecurityGroup
 
       TransitEncryptionEnabled: true
       # UpdatePolicy:
@@ -153,7 +176,7 @@ Resources:
   myRedisEndpointAddressParam:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub '/copilot/${App}/${Env}/secrets/MY_REDIS'   # Other services can retrieve the endpoint from this path.
+      Name: !Sub '/copilot/${App}/${Env}/secrets/MY_REDIS' # Other services can retrieve the endpoint from this path.
       Type: String
       Value: !Sub
         - 'rediss://${url}:${port}'

--- a/tests/platform_helper/fixtures/make_addons/opensearch_addons.yml
+++ b/tests/platform_helper/fixtures/make_addons/opensearch_addons.yml
@@ -6,11 +6,11 @@ my-opensearch:
   environments:
     default:
       plan: tiny
-      # supported engine versions as of 06/2023: 2.5, 2.3, 1.3, 1.2, 1.1, 1.0
-      engine: "2.3"
+      # supported engine versions as of 03/2024: 2.11, 2.9, 2.7, 2.5, 2.3, 1.3, 1.2, 1.1, 1.0
+      engine: '2.3'
     production:
       plan: large-ha
-      engine: "2.3"
+      engine: '2.3'
 
 # This name is meant to be 18 characters without hyphens,
 # this tests access policy generation.
@@ -21,5 +21,5 @@ my-opensearch-longer:
     default:
       plan: small
 
-      # supported engine versions as of 06/2023: 2.5, 2.3, 1.3, 1.2, 1.1, 1.0
-      engine: "2.3"
+      # supported engine versions as of  03/2024: 2.11, 2.9, 2.7, 2.5, 2.3, 1.3, 1.2, 1.1, 1.0
+      engine: '2.3'

--- a/tests/platform_helper/test-application-deploy/addons.yml
+++ b/tests/platform_helper/test-application-deploy/addons.yml
@@ -3,13 +3,13 @@
 my-s3-bucket:
   # currently no other features are supported such as bucket versioning, etc.  If you need additional features, you can use the s3-policy type to give a service access to an existing bucket.
 
-  type: s3   # creates an s3 bucket in each environment and gives the listed services permissions to access the bucket
+  type: s3 # creates an s3 bucket in each environment and gives the listed services permissions to access the bucket
 
-  readonly: true  # services are granted read only access to the bucket
+  readonly: true # services are granted read only access to the bucket
 
-  services:  # services that require access to the bucket.
-    - "web"
-    - "celery"
+  services: # services that require access to the bucket.
+    - 'web'
+    - 'celery'
 
   environments:
     # NOTE: [bucket names must be unique across all AWS accounts in the AWS (Standard Regions) Partition](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) and need to be defined for each environment
@@ -23,20 +23,18 @@ my-s3-bucket:
     development:
       bucket_name: my-bucket-dev
 
-
 ##### s3-policy example:
 
 my-s3-bucket-bucket-access:
-  type: s3-policy  # gives the listed services permissions to access an existing bucket
+  type: s3-policy # gives the listed services permissions to access an existing bucket
 
-  services:  # services that require access to the bucket.
-    - "web"
-    - "celery"
+  services: # services that require access to the bucket.
+    - 'web'
+    - 'celery'
 
   environments:
     default:
       bucket_name: my-bucket
-
 
 ##### Redis example:
 
@@ -48,11 +46,10 @@ my-redis:
       engine: '6.2'
       # availble engine versions: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html
 
-      plan: small  # The redis plan defines the instance type and number of replicas. HA instances require 1 or more replicas. See addon-plans.yaml.
+      plan: small # The redis plan defines the instance type and number of replicas. HA instances require 1 or more replicas. See addon-plans.yaml.
 
     production:
       plan: medium-ha
-
 
 ##### RDS postgres example:
 
@@ -64,7 +61,6 @@ my-rds-db:
     default:
       plan: small-ha
 
-
 ##### Aurora serverless v2 example:
 
 my-aurora-db:
@@ -74,8 +70,7 @@ my-aurora-db:
   environments:
     default:
       min_capacity: 0.5 # AllowedValues: from 0.5 through 128
-      max_capacity: 8   # AllowedValues: from 0.5 through 128
-
+      max_capacity: 8 # AllowedValues: from 0.5 through 128
 
 ##### Opensearch example:
 
@@ -86,8 +81,8 @@ my-opensearch:
     default:
       plan: small
 
-      # supported engine versions as of 06/2023: 2.5, 2.3, 1.3, 1.2, 1.1, 1.0
-      engine: "2.3"
+      # supported engine versions as of 03/2024: 2.11, 2.9, 2.7, 2.5, 2.3, 1.3, 1.2, 1.1, 1.0
+      engine: '2.3'
 
     production:
       plan: large-ha


### PR DESCRIPTION
Update code with latest supported versions of Redis and opensearch engines as per [DBT-829](https://uktrade.atlassian.net/browse/DBTP-829)

Updated references to these engines also.

Wondering if we should remove all references to now unsupported versions of engines form the code?
Will this break anything?