### PR TITLE
test: fix pytest warnings

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -147,6 +147,17 @@ files = [
 ]
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.13.1"
+description = "ANTLR 4.13.1 runtime for Python 3"
+optional = false
+python-versions = "*"
+files = [
+    {file = "antlr4-python3-runtime-4.13.1.tar.gz", hash = "sha256:3cd282f5ea7cfb841537fe01f143350fdb1c0b1ce7981443a2fa8513fddb6d1a"},
+    {file = "antlr4_python3_runtime-4.13.1-py3-none-any.whl", hash = "sha256:78ec57aad12c97ac039ca27403ad61cb98aaec8a3f9bb8144f889aa0fa28b943"},
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.2.1"
 description = "Bash tab completion for argparse"
@@ -211,13 +222,13 @@ dev = ["black (==23.10.1)", "boto3 (>=1.23,<2)", "boto3-stubs[appconfig,serverle
 
 [[package]]
 name = "aws-xray-sdk"
-version = "2.12.1"
+version = "2.13.0"
 description = "The AWS X-Ray SDK for Python (the SDK) enables Python developers to record and emit information from within their applications to the AWS X-Ray service."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "aws-xray-sdk-2.12.1.tar.gz", hash = "sha256:0bbfdbc773cfef4061062ac940b85e408297a2242f120bcdfee2593209b1e432"},
-    {file = "aws_xray_sdk-2.12.1-py2.py3-none-any.whl", hash = "sha256:f6803832dc08d18cc265e2327a69bfa9ee41c121fac195edc9745d04b7a566c3"},
+    {file = "aws-xray-sdk-2.13.0.tar.gz", hash = "sha256:816186126917bc35ae4e6e2f304702a43d494ecef34a39e6330f5018bdecc9f5"},
+    {file = "aws_xray_sdk-2.13.0-py2.py3-none-any.whl", hash = "sha256:d18604a8688b4bed03ce4a858cc9acd72b71400e085bf7512fc31cf657ca85f9"},
 ]
 
 [package.dependencies]
@@ -325,19 +336,19 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.28.82"
+version = "1.34.85"
 description = "The AWS SDK for Python"
 optional = false
-python-versions = ">= 3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.28.82-py3-none-any.whl", hash = "sha256:bb8ecd6f86289ceaed566eefc0ce8ac66a85e5954aef115ed4ac602cbe61f101"},
-    {file = "boto3-1.28.82.tar.gz", hash = "sha256:ae1352d0193aaf90c47d6e57ab054b0b1fabf0fbbe9f51eefec431bf2c3e18f4"},
+    {file = "boto3-1.34.85-py3-none-any.whl", hash = "sha256:135f1358fbc7d7dc89ad1a4346cb8da621fdc2aea69deb7b20c71ffec7cde111"},
+    {file = "boto3-1.34.85.tar.gz", hash = "sha256:de73d0f2dec1819074caf3f0888e18f6e13a9fb75ef5f17b1bdd9d1acc127b33"},
 ]
 
 [package.dependencies]
-botocore = ">=1.31.82,<1.32.0"
+botocore = ">=1.34.85,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.7.0,<0.8.0"
+s3transfer = ">=0.10.0,<0.11.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
@@ -723,13 +734,13 @@ xray = ["mypy-boto3-xray (>=1.28.0,<1.29.0)"]
 
 [[package]]
 name = "botocore"
-version = "1.31.82"
+version = "1.34.85"
 description = "Low-level, data-driven core of boto 3."
 optional = false
-python-versions = ">= 3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.31.82-py3-none-any.whl", hash = "sha256:5f213229348433d0b7b6aac2d9ae2fdd15c4ff9f38c30ea072f5b300bf6c1dcb"},
-    {file = "botocore-1.31.82.tar.gz", hash = "sha256:9d7d8de1789b1ed37b86a2b0a4fcff9fac91deef0548461d411e1626f68ca70c"},
+    {file = "botocore-1.34.85-py3-none-any.whl", hash = "sha256:9abae3f7925a8cc2b91b6ff3f09e631476c74826d45dc44fb30d1d15960639db"},
+    {file = "botocore-1.34.85.tar.gz", hash = "sha256:18548525d4975bbe982f393f6470ba45249919a93f5dc6a69e37e435dd2cf579"},
 ]
 
 [package.dependencies]
@@ -737,11 +748,11 @@ jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
 urllib3 = [
     {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
-    {version = ">=1.25.4,<2.1", markers = "python_version >= \"3.10\""},
+    {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
 ]
 
 [package.extras]
-crt = ["awscrt (==0.16.26)"]
+crt = ["awscrt (==0.20.9)"]
 
 [[package]]
 name = "botocore-stubs"
@@ -1342,24 +1353,6 @@ files = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.18.0"
-description = "ECDSA cryptographic signature library (pure python)"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-files = [
-    {file = "ecdsa-0.18.0-py2.py3-none-any.whl", hash = "sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd"},
-    {file = "ecdsa-0.18.0.tar.gz", hash = "sha256:190348041559e21b22a1d65cee485282ca11a6f81d503fddb84d5017e9ed1e49"},
-]
-
-[package.dependencies]
-six = ">=1.9.0"
-
-[package.extras]
-gmpy = ["gmpy"]
-gmpy2 = ["gmpy2"]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.1.3"
 description = "Backport of PEP 654 (exception groups)"
@@ -1712,6 +1705,23 @@ files = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "0.9.0"
+description = "The ultimate Python library for JOSE RFCs, including JWS, JWE, JWK, JWA, JWT"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "joserfc-0.9.0-py3-none-any.whl", hash = "sha256:4026bdbe2c196cd40574e916fa1e28874d99649412edaab0e373dec3077153fb"},
+    {file = "joserfc-0.9.0.tar.gz", hash = "sha256:eebca7f587b1761ce43a98ffd5327f2b600b9aa5bb0a77b947687f503ad43bc0"},
+]
+
+[package.dependencies]
+cryptography = "*"
+
+[package.extras]
+drafts = ["pycryptodome"]
+
+[[package]]
 name = "jschema-to-python"
 version = "1.2.3"
 description = "Generate source code for Python classes from a JSON schema."
@@ -1750,6 +1760,20 @@ files = [
 
 [package.dependencies]
 jsonpointer = ">=1.9"
+
+[[package]]
+name = "jsonpath-ng"
+version = "1.6.1"
+description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
+optional = false
+python-versions = "*"
+files = [
+    {file = "jsonpath-ng-1.6.1.tar.gz", hash = "sha256:086c37ba4917304850bd837aeab806670224d3f038fe2833ff593a672ef0a5fa"},
+    {file = "jsonpath_ng-1.6.1-py3-none-any.whl", hash = "sha256:8f22cd8273d7772eea9aaa84d922e0841aa36fdb8a2c6b7f6c3791a16a9bc0be"},
+]
+
+[package.dependencies]
+ply = "*"
 
 [[package]]
 name = "jsonpickle"
@@ -1846,47 +1870,48 @@ regex = ["regex"]
 
 [[package]]
 name = "lazy-object-proxy"
-version = "1.9.0"
+version = "1.10.0"
 description = "A fast and thorough lazy object proxy."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "lazy-object-proxy-1.9.0.tar.gz", hash = "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-win32.whl", hash = "sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-win32.whl", hash = "sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-win32.whl", hash = "sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-win32.whl", hash = "sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-win32.whl", hash = "sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f"},
+    {file = "lazy-object-proxy-1.10.0.tar.gz", hash = "sha256:78247b6d45f43a52ef35c25b5581459e85117225408a4128a3daf8bf9648ac69"},
+    {file = "lazy_object_proxy-1.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:855e068b0358ab916454464a884779c7ffa312b8925c6f7401e952dcf3b89977"},
+    {file = "lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab7004cf2e59f7c2e4345604a3e6ea0d92ac44e1c2375527d56492014e690c3"},
+    {file = "lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc0d2fc424e54c70c4bc06787e4072c4f3b1aa2f897dfdc34ce1013cf3ceef05"},
+    {file = "lazy_object_proxy-1.10.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e2adb09778797da09d2b5ebdbceebf7dd32e2c96f79da9052b2e87b6ea495895"},
+    {file = "lazy_object_proxy-1.10.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b1f711e2c6dcd4edd372cf5dec5c5a30d23bba06ee012093267b3376c079ec83"},
+    {file = "lazy_object_proxy-1.10.0-cp310-cp310-win32.whl", hash = "sha256:76a095cfe6045c7d0ca77db9934e8f7b71b14645f0094ffcd842349ada5c5fb9"},
+    {file = "lazy_object_proxy-1.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:b4f87d4ed9064b2628da63830986c3d2dca7501e6018347798313fcf028e2fd4"},
+    {file = "lazy_object_proxy-1.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fec03caabbc6b59ea4a638bee5fce7117be8e99a4103d9d5ad77f15d6f81020c"},
+    {file = "lazy_object_proxy-1.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02c83f957782cbbe8136bee26416686a6ae998c7b6191711a04da776dc9e47d4"},
+    {file = "lazy_object_proxy-1.10.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:009e6bb1f1935a62889ddc8541514b6a9e1fcf302667dcb049a0be5c8f613e56"},
+    {file = "lazy_object_proxy-1.10.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:75fc59fc450050b1b3c203c35020bc41bd2695ed692a392924c6ce180c6f1dc9"},
+    {file = "lazy_object_proxy-1.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:782e2c9b2aab1708ffb07d4bf377d12901d7a1d99e5e410d648d892f8967ab1f"},
+    {file = "lazy_object_proxy-1.10.0-cp311-cp311-win32.whl", hash = "sha256:edb45bb8278574710e68a6b021599a10ce730d156e5b254941754a9cc0b17d03"},
+    {file = "lazy_object_proxy-1.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:e271058822765ad5e3bca7f05f2ace0de58a3f4e62045a8c90a0dfd2f8ad8cc6"},
+    {file = "lazy_object_proxy-1.10.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e98c8af98d5707dcdecc9ab0863c0ea6e88545d42ca7c3feffb6b4d1e370c7ba"},
+    {file = "lazy_object_proxy-1.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:952c81d415b9b80ea261d2372d2a4a2332a3890c2b83e0535f263ddfe43f0d43"},
+    {file = "lazy_object_proxy-1.10.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80b39d3a151309efc8cc48675918891b865bdf742a8616a337cb0090791a0de9"},
+    {file = "lazy_object_proxy-1.10.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e221060b701e2aa2ea991542900dd13907a5c90fa80e199dbf5a03359019e7a3"},
+    {file = "lazy_object_proxy-1.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:92f09ff65ecff3108e56526f9e2481b8116c0b9e1425325e13245abfd79bdb1b"},
+    {file = "lazy_object_proxy-1.10.0-cp312-cp312-win32.whl", hash = "sha256:3ad54b9ddbe20ae9f7c1b29e52f123120772b06dbb18ec6be9101369d63a4074"},
+    {file = "lazy_object_proxy-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:127a789c75151db6af398b8972178afe6bda7d6f68730c057fbbc2e96b08d282"},
+    {file = "lazy_object_proxy-1.10.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9e4ed0518a14dd26092614412936920ad081a424bdcb54cc13349a8e2c6d106a"},
+    {file = "lazy_object_proxy-1.10.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ad9e6ed739285919aa9661a5bbed0aaf410aa60231373c5579c6b4801bd883c"},
+    {file = "lazy_object_proxy-1.10.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fc0a92c02fa1ca1e84fc60fa258458e5bf89d90a1ddaeb8ed9cc3147f417255"},
+    {file = "lazy_object_proxy-1.10.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:0aefc7591920bbd360d57ea03c995cebc204b424524a5bd78406f6e1b8b2a5d8"},
+    {file = "lazy_object_proxy-1.10.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5faf03a7d8942bb4476e3b62fd0f4cf94eaf4618e304a19865abf89a35c0bbee"},
+    {file = "lazy_object_proxy-1.10.0-cp38-cp38-win32.whl", hash = "sha256:e333e2324307a7b5d86adfa835bb500ee70bfcd1447384a822e96495796b0ca4"},
+    {file = "lazy_object_proxy-1.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:cb73507defd385b7705c599a94474b1d5222a508e502553ef94114a143ec6696"},
+    {file = "lazy_object_proxy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:366c32fe5355ef5fc8a232c5436f4cc66e9d3e8967c01fb2e6302fd6627e3d94"},
+    {file = "lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2297f08f08a2bb0d32a4265e98a006643cd7233fb7983032bd61ac7a02956b3b"},
+    {file = "lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18dd842b49456aaa9a7cf535b04ca4571a302ff72ed8740d06b5adcd41fe0757"},
+    {file = "lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:217138197c170a2a74ca0e05bddcd5f1796c735c37d0eee33e43259b192aa424"},
+    {file = "lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9a3a87cf1e133e5b1994144c12ca4aa3d9698517fe1e2ca82977781b16955658"},
+    {file = "lazy_object_proxy-1.10.0-cp39-cp39-win32.whl", hash = "sha256:30b339b2a743c5288405aa79a69e706a06e02958eab31859f7f3c04980853b70"},
+    {file = "lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:a899b10e17743683b293a729d3a11f2f399e8a90c73b089e29f5d0fe3509f0dd"},
+    {file = "lazy_object_proxy-1.10.0-pp310.pp311.pp312.pp38.pp39-none-any.whl", hash = "sha256:80fa48bd89c8f2f456fc0765c11c23bf5af827febacd2f523ca5bc1893fcc09d"},
 ]
 
 [[package]]
@@ -1986,65 +2011,60 @@ files = [
 
 [[package]]
 name = "moto"
-version = "4.2.7"
+version = "5.0.5"
 description = ""
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "moto-4.2.7-py2.py3-none-any.whl", hash = "sha256:3e0ef388900448485cd6eff18e9f7fcaa6cf4560b6fb536ba2e2e1278a5ecc59"},
-    {file = "moto-4.2.7.tar.gz", hash = "sha256:1298006aaa6996b886658eb194cac0e3a5679c9fcce6cb13e741ccc5a7247abb"},
+    {file = "moto-5.0.5-py2.py3-none-any.whl", hash = "sha256:4ecdd4084491a2f25f7a7925416dcf07eee0031ce724957439a32ef764b22874"},
+    {file = "moto-5.0.5.tar.gz", hash = "sha256:2eaca2df7758f6868df420bf0725cd0b93d98709606f1fb8b2343b5bdc822d91"},
 ]
 
 [package.dependencies]
+antlr4-python3-runtime = {version = "*", optional = true, markers = "extra == \"all\""}
 aws-xray-sdk = {version = ">=0.93,<0.96 || >0.96", optional = true, markers = "extra == \"all\""}
 boto3 = ">=1.9.201"
-botocore = ">=1.12.201"
+botocore = ">=1.14.0"
 cfn-lint = {version = ">=0.40.0", optional = true, markers = "extra == \"all\""}
 cryptography = ">=3.3.1"
 docker = {version = ">=3.0.0", optional = true, markers = "extra == \"all\""}
-ecdsa = {version = "!=0.15", optional = true, markers = "extra == \"all\""}
 graphql-core = {version = "*", optional = true, markers = "extra == \"all\""}
 Jinja2 = ">=2.10.1"
+joserfc = {version = ">=0.9.0", optional = true, markers = "extra == \"all\""}
 jsondiff = {version = ">=1.1.2", optional = true, markers = "extra == \"all\""}
+jsonpath-ng = {version = "*", optional = true, markers = "extra == \"all\""}
 multipart = {version = "*", optional = true, markers = "extra == \"all\""}
 openapi-spec-validator = {version = ">=0.5.0", optional = true, markers = "extra == \"all\""}
-py-partiql-parser = {version = "0.4.1", optional = true, markers = "extra == \"all\""}
+py-partiql-parser = {version = "0.5.4", optional = true, markers = "extra == \"all\""}
 pyparsing = {version = ">=3.0.7", optional = true, markers = "extra == \"all\""}
 python-dateutil = ">=2.1,<3.0.0"
-python-jose = {version = ">=3.1.0,<4.0.0", extras = ["cryptography"], optional = true, markers = "extra == \"all\""}
 PyYAML = {version = ">=5.1", optional = true, markers = "extra == \"all\""}
 requests = ">=2.5"
-responses = ">=0.13.0"
+responses = ">=0.15.0"
 setuptools = {version = "*", optional = true, markers = "extra == \"all\""}
-sshpubkeys = {version = ">=3.1.0", optional = true, markers = "extra == \"all\""}
 werkzeug = ">=0.5,<2.2.0 || >2.2.0,<2.2.1 || >2.2.1"
 xmltodict = "*"
 
 [package.extras]
-all = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "multipart", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.4.1)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
-apigateway = ["PyYAML (>=5.1)", "ecdsa (!=0.15)", "openapi-spec-validator (>=0.5.0)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
-apigatewayv2 = ["PyYAML (>=5.1)"]
+all = ["PyYAML (>=5.1)", "antlr4-python3-runtime", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "graphql-core", "joserfc (>=0.9.0)", "jsondiff (>=1.1.2)", "jsonpath-ng", "multipart", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.5.4)", "pyparsing (>=3.0.7)", "setuptools"]
+apigateway = ["PyYAML (>=5.1)", "joserfc (>=0.9.0)", "openapi-spec-validator (>=0.5.0)"]
+apigatewayv2 = ["PyYAML (>=5.1)", "openapi-spec-validator (>=0.5.0)"]
 appsync = ["graphql-core"]
 awslambda = ["docker (>=3.0.0)"]
 batch = ["docker (>=3.0.0)"]
-cloudformation = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.4.1)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
-cognitoidp = ["ecdsa (!=0.15)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
-ds = ["sshpubkeys (>=3.1.0)"]
-dynamodb = ["docker (>=3.0.0)", "py-partiql-parser (==0.4.1)"]
-dynamodbstreams = ["docker (>=3.0.0)", "py-partiql-parser (==0.4.1)"]
-ebs = ["sshpubkeys (>=3.1.0)"]
-ec2 = ["sshpubkeys (>=3.1.0)"]
-efs = ["sshpubkeys (>=3.1.0)"]
-eks = ["sshpubkeys (>=3.1.0)"]
+cloudformation = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "graphql-core", "joserfc (>=0.9.0)", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.5.4)", "pyparsing (>=3.0.7)", "setuptools"]
+cognitoidp = ["joserfc (>=0.9.0)"]
+dynamodb = ["docker (>=3.0.0)", "py-partiql-parser (==0.5.4)"]
+dynamodbstreams = ["docker (>=3.0.0)", "py-partiql-parser (==0.5.4)"]
 glue = ["pyparsing (>=3.0.7)"]
 iotdata = ["jsondiff (>=1.1.2)"]
-proxy = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=2.5.1)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "multipart", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.4.1)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
-resourcegroupstaggingapi = ["PyYAML (>=5.1)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.4.1)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "sshpubkeys (>=3.1.0)"]
-route53resolver = ["sshpubkeys (>=3.1.0)"]
-s3 = ["PyYAML (>=5.1)", "py-partiql-parser (==0.4.1)"]
-s3crc32c = ["PyYAML (>=5.1)", "crc32c", "py-partiql-parser (==0.4.1)"]
-server = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "flask (!=2.2.0,!=2.2.1)", "flask-cors", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.4.1)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+proxy = ["PyYAML (>=5.1)", "antlr4-python3-runtime", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=2.5.1)", "graphql-core", "joserfc (>=0.9.0)", "jsondiff (>=1.1.2)", "jsonpath-ng", "multipart", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.5.4)", "pyparsing (>=3.0.7)", "setuptools"]
+resourcegroupstaggingapi = ["PyYAML (>=5.1)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "graphql-core", "joserfc (>=0.9.0)", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.5.4)", "pyparsing (>=3.0.7)"]
+s3 = ["PyYAML (>=5.1)", "py-partiql-parser (==0.5.4)"]
+s3crc32c = ["PyYAML (>=5.1)", "crc32c", "py-partiql-parser (==0.5.4)"]
+server = ["PyYAML (>=5.1)", "antlr4-python3-runtime", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "flask (!=2.2.0,!=2.2.1)", "flask-cors", "graphql-core", "joserfc (>=0.9.0)", "jsondiff (>=1.1.2)", "jsonpath-ng", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.5.4)", "pyparsing (>=3.0.7)", "setuptools"]
 ssm = ["PyYAML (>=5.1)"]
+stepfunctions = ["antlr4-python3-runtime", "jsonpath-ng"]
 xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
 
 [[package]]
@@ -2511,17 +2531,17 @@ files = [
 
 [[package]]
 name = "py-partiql-parser"
-version = "0.4.1"
+version = "0.5.4"
 description = "Pure Python PartiQL Parser"
 optional = false
 python-versions = "*"
 files = [
-    {file = "py-partiql-parser-0.4.1.tar.gz", hash = "sha256:e0640ee913812bbf5cd126accc0b09eebd0e68df769a9bfbaef9a5e74a0c6d55"},
-    {file = "py_partiql_parser-0.4.1-py3-none-any.whl", hash = "sha256:6357ec3215f4ceabe4aa1926e4a0f808b9ebc9f7fd438e7f22dbdc3d6efb2eae"},
+    {file = "py_partiql_parser-0.5.4-py2.py3-none-any.whl", hash = "sha256:3dc4295a47da9587681a96b35c6e151886fdbd0a4acbe0d97c4c68e5f689d315"},
+    {file = "py_partiql_parser-0.5.4.tar.gz", hash = "sha256:72e043919538fa63edae72fb59afc7e3fd93adbde656718a7d2b4666f23dd114"},
 ]
 
 [package.extras]
-dev = ["black (==22.6.0)", "flake8", "mypy (==0.971)", "pytest"]
+dev = ["black (==22.6.0)", "flake8", "mypy", "pytest"]
 
 [[package]]
 name = "py-serializable"
@@ -2536,17 +2556,6 @@ files = [
 
 [package.dependencies]
 defusedxml = ">=0.7.1,<0.8.0"
-
-[[package]]
-name = "pyasn1"
-version = "0.5.0"
-description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-files = [
-    {file = "pyasn1-0.5.0-py2.py3-none-any.whl", hash = "sha256:87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57"},
-    {file = "pyasn1-0.5.0.tar.gz", hash = "sha256:97b7290ca68e62a832558ec3976f15cbf911bf5d7c7039d8b861c2a0ece69fde"},
-]
 
 [[package]]
 name = "pycares"
@@ -2988,28 +2997,6 @@ files = [
 six = ">=1.5"
 
 [[package]]
-name = "python-jose"
-version = "3.3.0"
-description = "JOSE implementation in Python"
-optional = false
-python-versions = "*"
-files = [
-    {file = "python-jose-3.3.0.tar.gz", hash = "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a"},
-    {file = "python_jose-3.3.0-py2.py3-none-any.whl", hash = "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"},
-]
-
-[package.dependencies]
-cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"cryptography\""}
-ecdsa = "!=0.15"
-pyasn1 = "*"
-rsa = "*"
-
-[package.extras]
-cryptography = ["cryptography (>=3.4.0)"]
-pycrypto = ["pyasn1", "pycrypto (>=2.6.0,<2.7.0)"]
-pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
-
-[[package]]
 name = "pywin32"
 version = "306"
 description = "Python for Window Extensions"
@@ -3222,13 +3209,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "responses"
-version = "0.24.0"
+version = "0.25.0"
 description = "A utility library for mocking out the `requests` Python library."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "responses-0.24.0-py3-none-any.whl", hash = "sha256:060be153c270c06fa4d22c1ef8865fdef43902eb595204deeef736cddb62d353"},
-    {file = "responses-0.24.0.tar.gz", hash = "sha256:3df82f7d4dcd3e5f61498181aadb4381f291da25c7506c47fe8cb68ce29203e7"},
+    {file = "responses-0.25.0-py3-none-any.whl", hash = "sha256:2f0b9c2b6437db4b528619a77e5d565e4ec2a9532162ac1a131a83529db7be1a"},
+    {file = "responses-0.25.0.tar.gz", hash = "sha256:01ae6a02b4f34e39bffceb0fc6786b67a25eae919c6368d05eabc8d9576c2a66"},
 ]
 
 [package.dependencies]
@@ -3252,20 +3239,6 @@ files = [
 
 [package.dependencies]
 six = "*"
-
-[[package]]
-name = "rsa"
-version = "4.9"
-description = "Pure-Python RSA implementation"
-optional = false
-python-versions = ">=3.6,<4"
-files = [
-    {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
-    {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
-]
-
-[package.dependencies]
-pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "rustworkx"
@@ -3348,20 +3321,20 @@ mpl = ["matplotlib (>=3.0)"]
 
 [[package]]
 name = "s3transfer"
-version = "0.7.0"
+version = "0.10.1"
 description = "An Amazon S3 Transfer Manager"
 optional = false
-python-versions = ">= 3.7"
+python-versions = ">= 3.8"
 files = [
-    {file = "s3transfer-0.7.0-py3-none-any.whl", hash = "sha256:10d6923c6359175f264811ef4bf6161a3156ce8e350e705396a7557d6293c33a"},
-    {file = "s3transfer-0.7.0.tar.gz", hash = "sha256:fd3889a66f5fe17299fe75b82eae6cf722554edca744ca5d5fe308b104883d2e"},
+    {file = "s3transfer-0.10.1-py3-none-any.whl", hash = "sha256:ceb252b11bcf87080fb7850a224fb6e05c8a776bab8f2b64b7f25b969464839d"},
+    {file = "s3transfer-0.10.1.tar.gz", hash = "sha256:5683916b4c724f799e600f41dd9e10a9ff19871bf87623cc8f491cb4f5fa0a19"},
 ]
 
 [package.dependencies]
-botocore = ">=1.12.36,<2.0a.0"
+botocore = ">=1.33.2,<2.0a.0"
 
 [package.extras]
-crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
+crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
 
 [[package]]
 name = "sarif-om"
@@ -3519,24 +3492,6 @@ code-style = ["black", "flake8", "isort"]
 development = ["black", "flake8", "isort", "networkx", "pytest"]
 graph-generation = ["networkx", "pygraphviz"]
 test = ["pyshacl", "pytest", "tzdata"]
-
-[[package]]
-name = "sshpubkeys"
-version = "3.3.1"
-description = "SSH public key parser"
-optional = false
-python-versions = ">=3"
-files = [
-    {file = "sshpubkeys-3.3.1-py2.py3-none-any.whl", hash = "sha256:946f76b8fe86704b0e7c56a00d80294e39bc2305999844f079a217885060b1ac"},
-    {file = "sshpubkeys-3.3.1.tar.gz", hash = "sha256:3020ed4f8c846849299370fbe98ff4157b0ccc1accec105e07cfa9ae4bb55064"},
-]
-
-[package.dependencies]
-cryptography = ">=2.1.4"
-ecdsa = ">=0.13"
-
-[package.extras]
-dev = ["twine", "wheel", "yapf"]
 
 [[package]]
 name = "sympy"
@@ -3797,13 +3752,13 @@ test = ["websockets"]
 
 [[package]]
 name = "werkzeug"
-version = "3.0.1"
+version = "3.0.2"
 description = "The comprehensive WSGI web application library."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "werkzeug-3.0.1-py3-none-any.whl", hash = "sha256:90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10"},
-    {file = "werkzeug-3.0.1.tar.gz", hash = "sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc"},
+    {file = "werkzeug-3.0.2-py3-none-any.whl", hash = "sha256:3aac3f5da756f93030740bc235d3e09449efcf65f2f55e3602e1d851b8f48795"},
+    {file = "werkzeug-3.0.2.tar.gz", hash = "sha256:e39b645a6ac92822588e7b39a692e7828724ceae0b0d702ef96701f90e70128d"},
 ]
 
 [package.dependencies]
@@ -4007,4 +3962,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "76440282e649d6b18af4314b2d7803b3ade2dff5d145d33e05331ae8f899ae91"
+content-hash = "9a983ec16c4ac3b43ad0f327acaf6d7bd7842892ded23e494bb7cebae0ac9cdb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ Jinja2 = "^3.1.3"
 PyYAML = "6.0.1"
 boto3 = "^1.28.24"
 boto3-stubs = "^1.26.148"
-botocore = "^1.29.31"
+botocore = "^1.34.85"
 click = "^8.1.3"
 cloudfoundry-client = "1.35.2"
 mypy-boto3-codebuild = "^1.26.0.post1"
@@ -41,7 +41,7 @@ checkov = "^3.1.67"
 slack-sdk = "^3.27.1"
 
 [tool.poetry.group.dev.dependencies]
-moto = {extras = ["all"], version = "^4.1.12"}
+moto = {extras = ["all"], version = "^5.0.5"}
 pyfakefs = "^5.2.2"
 pytest = "^7.3.1"
 pytest-env = "^0.8.1"

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,13 @@ env =
 addopts = --tb=short --numprocesses auto --dist loadgroup
 ; You may need to use the addopts setting below to unbreak debugging in your IDE
 ; addopts = --tb=short
+
+filterwarnings =
+    ignore::UserWarning:moto.cloudformation.parsing.*
+    ; Tried to parse AWS::Logs::SubscriptionFilter but it's not supported by moto's CloudFormation implementation
+    ignore::DeprecationWarning:botocore.auth.* 
+    ; datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC)
+    ignore::DeprecationWarning:dateutil.tz.* 
+    ; datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC)
+    ignore::DeprecationWarning:importlib._bootstrap.* 
+    ; Type google._upb._message.MessageMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -9,13 +9,7 @@ import botocore
 import certifi
 import pytest
 import yaml
-from moto import mock_acm
-from moto import mock_cloudformation
-from moto import mock_ec2
-from moto import mock_ecs
-from moto import mock_iam
-from moto import mock_route53
-from moto import mock_secretsmanager
+from moto import mock_aws
 from moto.ec2 import utils as ec2_utils
 
 from dbt_platform_helper.utils.aws import AWS_SESSION_CACHE
@@ -119,21 +113,21 @@ def aws_credentials(monkeypatch):
 
 @pytest.fixture(scope="function")
 def acm_session(aws_credentials):
-    with mock_acm():
+    with mock_aws():
         session = boto3.session.Session(profile_name="foo", region_name="eu-west-2")
         yield session.client("acm")
 
 
 @pytest.fixture(scope="function")
 def route53_session(aws_credentials):
-    with mock_route53():
+    with mock_aws():
         session = boto3.session.Session(profile_name="foo", region_name="eu-west-2")
         yield session.client("route53")
 
 
 @pytest.fixture
 def alias_session(aws_credentials):
-    with mock_iam():
+    with mock_aws():
         session = boto3.session.Session(region_name="eu-west-2")
         session.client("iam").create_account_alias(AccountAlias="foo")
 
@@ -142,7 +136,7 @@ def alias_session(aws_credentials):
 
 @pytest.fixture(scope="function")
 def mocked_cluster():
-    with mock_ecs():
+    with mock_aws():
         yield boto3.client("ecs").create_cluster(
             tags=[
                 {"key": "copilot-application", "value": "test-application"},
@@ -155,7 +149,7 @@ def mocked_cluster():
 @pytest.fixture(scope="function")
 def mock_cluster_client_task(mocked_cluster):
     def _setup(addon_type, agent_last_status="RUNNING", task_running=True):
-        with mock_ec2():
+        with mock_aws():
             mocked_ecs_client = boto3.client("ecs")
             mocked_cluster_arn = mocked_cluster["cluster"]["clusterArn"]
 
@@ -267,7 +261,7 @@ def mock_tool_versions():
 @pytest.fixture(scope="function")
 def mock_stack():
     def _create_stack(addon_name):
-        with mock_cloudformation():
+        with mock_aws():
             with open(FIXTURES_DIR / "test_cloudformation_template.yml") as f:
                 template = yaml.safe_load(f)
             cf = boto3.client("cloudformation")

--- a/tests/platform_helper/custom_resources/test_s3_object.py
+++ b/tests/platform_helper/custom_resources/test_s3_object.py
@@ -10,7 +10,7 @@ from urllib.error import HTTPError
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from moto import mock_s3
+from moto import mock_aws
 from parameterized import parameterized
 
 from dbt_platform_helper.custom_resources import s3_object
@@ -115,7 +115,7 @@ class TestS3ObjectCustomResource(unittest.TestCase):
 
     @parameterized.expand([("Create",), ("Update",)])
     @patch("urllib.request.urlopen", return_value=None)
-    @mock_s3
+    @mock_aws
     def test_resource_creation_puts_an_object_in_s3_and_reports_success(
         self, request_type, urlopen
     ):
@@ -142,7 +142,7 @@ class TestS3ObjectCustomResource(unittest.TestCase):
         self.assertEqual(f"s3://bucket-name/object-with-contents", sent_body["PhysicalResourceId"])
 
     @patch("urllib.request.urlopen", return_value=None)
-    @mock_s3
+    @mock_aws
     def test_resource_delete_removes_an_object_from_s3_and_reports_success(self, urlopen):
         s3_client = boto3.client("s3", "eu-west-2")
         bucket = self._resource_properties["S3Bucket"]
@@ -174,7 +174,7 @@ class TestS3ObjectCustomResource(unittest.TestCase):
 
     @parameterized.expand([("Create", "Put"), ("Update", "Put"), ("Delete", "Delete")])
     @patch("urllib.request.urlopen", return_value=None)
-    @mock_s3
+    @mock_aws
     def test_resource_action_failure_reports_failure(self, request_type, request_action, urlopen):
         event = self._event.copy()
         event["RequestType"] = request_type

--- a/tests/platform_helper/test_command_application.py
+++ b/tests/platform_helper/test_command_application.py
@@ -1,9 +1,7 @@
 from unittest.mock import patch
 
 from click.testing import CliRunner
-from moto import mock_ecs
-from moto import mock_logs
-from moto import mock_sts
+from moto import mock_aws
 
 from dbt_platform_helper.commands.application import container_stats
 from dbt_platform_helper.commands.application import task_stats
@@ -155,9 +153,7 @@ results = {
 #     assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
 
 
-@mock_logs
-@mock_ecs
-@mock_sts
+@mock_aws
 @patch("dbt_platform_helper.commands.application.get_query_results", return_value=results)
 def test_stats(alias_session):
     runner = CliRunner()
@@ -177,9 +173,7 @@ def test_stats(alias_session):
     )
 
 
-@mock_logs
-@mock_ecs
-@mock_sts
+@mock_aws
 @patch("dbt_platform_helper.commands.application.get_query_results", return_value=results)
 def test_stats_all_options(alias_session):
     runner = CliRunner()
@@ -206,9 +200,7 @@ def test_stats_all_options(alias_session):
     )
 
 
-@mock_logs
-@mock_ecs
-@mock_sts
+@mock_aws
 @patch("dbt_platform_helper.commands.application.get_query_results", return_value=results)
 def test_container_stats(alias_session):
     runner = CliRunner()
@@ -232,9 +224,7 @@ def test_container_stats(alias_session):
     )
 
 
-@mock_logs
-@mock_ecs
-@mock_sts
+@mock_aws
 @patch("dbt_platform_helper.commands.application.get_query_results", return_value=results)
 def test_container_stats_all_options(alias_session):
     runner = CliRunner()

--- a/tests/platform_helper/test_command_conduit.py
+++ b/tests/platform_helper/test_command_conduit.py
@@ -6,12 +6,7 @@ import boto3
 import pytest
 from cfn_tools import load_yaml
 from click.testing import CliRunner
-from moto import mock_cloudformation
-from moto import mock_ecs
-from moto import mock_iam
-from moto import mock_resourcegroupstaggingapi
-from moto import mock_secretsmanager
-from moto import mock_ssm
+from moto import mock_aws
 
 from tests.platform_helper.conftest import add_addon_config_parameter
 from tests.platform_helper.conftest import mock_connection_secret_name
@@ -35,7 +30,7 @@ def test_normalise_secret_name(test_string):
     assert normalise_secret_name(test_string[0]) == test_string[1]
 
 
-@mock_resourcegroupstaggingapi
+@mock_aws
 def test_get_cluster_arn(mocked_cluster, mock_application):
     """Test that, given app and environment strings, get_cluster_arn returns the
     arn of a cluster tagged with these strings."""
@@ -46,7 +41,7 @@ def test_get_cluster_arn(mocked_cluster, mock_application):
     )
 
 
-@mock_ecs
+@mock_aws
 def test_get_cluster_arn_when_there_is_no_cluster(mock_application):
     """Test that, given app and environment strings, get_cluster_arn raises an
     exception when no cluster tagged with these strings exists."""
@@ -57,8 +52,7 @@ def test_get_cluster_arn_when_there_is_no_cluster(mock_application):
         get_cluster_arn(mock_application, "staging")
 
 
-@mock_secretsmanager
-@mock_ssm
+@mock_aws
 def test_get_connection_secret_arn_from_secrets_manager(mock_application):
     """Test that, given app, environment and secret name strings,
     get_connection_secret_arn returns an ARN from secrets manager."""
@@ -79,7 +73,7 @@ def test_get_connection_secret_arn_from_secrets_manager(mock_application):
     )
 
 
-@mock_ssm
+@mock_aws
 def test_get_connection_secret_arn_from_parameter_store(mock_application):
     """Test that, given app, environment and secret name strings,
     get_connection_secret_arn returns an ARN from parameter store."""
@@ -101,8 +95,7 @@ def test_get_connection_secret_arn_from_parameter_store(mock_application):
     )
 
 
-@mock_secretsmanager
-@mock_ssm
+@mock_aws
 def test_get_connection_secret_arn_when_secret_does_not_exist(mock_application):
     """Test that, given app, environment and secret name strings,
     get_connection_secret_arn raises an exception when no matching secret exists
@@ -297,8 +290,7 @@ def test_addon_client_is_running_when_no_client_agent_running(
         )
 
 
-@mock_iam
-@mock_cloudformation
+@mock_aws
 @pytest.mark.parametrize(
     "addon_name",
     ["postgres", "redis", "opensearch", "rds-postgres"],
@@ -347,9 +339,7 @@ def test_add_stack_delete_policy_to_task_role(sleep, mock_stack, addon_name, moc
     assert policy_document == mock_policy
 
 
-@mock_iam
-@mock_ssm
-@mock_cloudformation
+@mock_aws
 @pytest.mark.parametrize(
     "addon_type, addon_name, parameter_suffix",
     [
@@ -409,7 +399,7 @@ def test_update_conduit_stack_resources(
     )
 
 
-@mock_ssm
+@mock_aws
 def test_get_or_create_task_name(mock_application):
     """Test that get_or_create_task_name retrieves the task name from the
     parameter store when it has been stored."""
@@ -429,7 +419,7 @@ def test_get_or_create_task_name(mock_application):
     assert task_name == mock_task_name(addon_name)
 
 
-@mock_ssm
+@mock_aws
 def test_get_or_create_task_name_when_name_does_not_exist(mock_application):
     """Test that get_or_create_task_name creates the task name and appends it
     with a 12 digit lowercase alphanumeric string when it does not exist in the
@@ -445,7 +435,7 @@ def test_get_or_create_task_name_when_name_does_not_exist(mock_application):
     assert random_id.isalnum() and random_id.islower() and len(random_id) == 12
 
 
-@mock_ssm
+@mock_aws
 @pytest.mark.parametrize(
     "access",
     [
@@ -896,7 +886,7 @@ def test_start_conduit_with_access_permissions(
     )
 
 
-@mock_ssm
+@mock_aws
 @pytest.mark.parametrize(
     "addon_type, addon_name",
     [
@@ -934,7 +924,7 @@ def test_conduit_command(start_conduit, addon_type, addon_name, validate_version
     )
 
 
-@mock_ssm
+@mock_aws
 @pytest.mark.parametrize(
     "addon_name",
     [
@@ -978,7 +968,7 @@ def test_conduit_command_when_no_cluster_exists(start_conduit, secho, addon_name
     )
 
 
-@mock_ssm
+@mock_aws
 @pytest.mark.parametrize(
     "addon_name",
     [
@@ -1025,7 +1015,7 @@ def test_conduit_command_when_no_connection_secret_exists(
     )
 
 
-@mock_ssm
+@mock_aws
 @pytest.mark.parametrize(
     "addon_name",
     [
@@ -1072,7 +1062,7 @@ def test_conduit_command_when_client_task_fails_to_start(
     )
 
 
-@mock_ssm
+@mock_aws
 @patch("click.secho")
 @patch(
     "dbt_platform_helper.utils.versioning.running_as_installed_package", new=Mock(return_value=True)
@@ -1105,7 +1095,7 @@ def test_conduit_command_when_addon_type_is_invalid(start_conduit, secho, valida
     )
 
 
-@mock_ssm
+@mock_aws
 @patch("click.secho")
 @patch(
     "dbt_platform_helper.utils.versioning.running_as_installed_package", new=Mock(return_value=True)
@@ -1138,7 +1128,7 @@ def test_conduit_command_when_addon_does_not_exist(start_conduit, secho, validat
     )
 
 
-@mock_ssm
+@mock_aws
 @pytest.mark.parametrize(
     "addon_name",
     [
@@ -1177,7 +1167,7 @@ def test_conduit_command_when_no_addon_config_parameter_exists(secho, addon_name
     )
 
 
-@mock_ssm
+@mock_aws
 @pytest.mark.parametrize(
     "addon_type, addon_name, access",
     [
@@ -1216,7 +1206,7 @@ def test_conduit_command_flags(
     )
 
 
-@mock_ssm
+@mock_aws
 @pytest.mark.parametrize(
     "addon_name, expected_type",
     [
@@ -1236,7 +1226,7 @@ def test_get_addon_type(addon_name, expected_type, mock_application):
     assert addon_type == expected_type
 
 
-@mock_ssm
+@mock_aws
 def test_get_addon_type_when_addon_not_found(mock_application):
     """Test that get_addon_type raises the expected error when the addon is not
     found in the config file."""
@@ -1249,7 +1239,7 @@ def test_get_addon_type_when_addon_not_found(mock_application):
         get_addon_type(mock_application, "development", "custom-name-postgres")
 
 
-@mock_ssm
+@mock_aws
 def test_get_addon_type_when_parameter_not_found(mock_application):
     """Test that get_addon_type raises the expected error when the addon config
     parameter is not found."""

--- a/tests/platform_helper/test_command_copilot.py
+++ b/tests/platform_helper/test_command_copilot.py
@@ -12,11 +12,7 @@ import yaml
 from botocore.exceptions import ClientError
 from click.testing import CliRunner
 from freezegun import freeze_time
-from moto import mock_iam
-from moto import mock_kms
-from moto import mock_s3
-from moto import mock_ssm
-from moto import mock_sts
+from moto import mock_aws
 from yaml import dump
 
 from dbt_platform_helper.commands.copilot import copilot
@@ -108,10 +104,7 @@ class TestTerraformEnabledMakeAddonCommand:
     )
     @patch("dbt_platform_helper.utils.application.get_aws_session_or_abort")
     @patch("dbt_platform_helper.commands.copilot.get_aws_session_or_abort")
-    @mock_sts
-    @mock_s3
-    @mock_iam
-    @mock_kms
+    @mock_aws
     def test_s3_kms_arn_is_rendered_in_template(
         self, mock_get_session, mock_get_session2, fakefs, kms_key_exists, kms_key_arn
     ):
@@ -199,9 +192,7 @@ class TestTerraformEnabledMakeAddonCommand:
         ),
     )
     @patch("dbt_platform_helper.commands.copilot.get_aws_session_or_abort")
-    @mock_s3
-    @mock_sts
-    @mock_iam
+    @mock_aws
     def test_terraform_compatible_make_addons_success(
         self,
         mock_get_session,
@@ -369,9 +360,7 @@ class TestMakeAddonCommand:
         ),
     )
     @patch("dbt_platform_helper.commands.copilot.get_aws_session_or_abort")
-    @mock_s3
-    @mock_sts
-    @mock_iam
+    @mock_aws
     def test_make_addons_success(
         self,
         mock_get_session,
@@ -481,9 +470,7 @@ class TestMakeAddonCommand:
             return_value='{"prod": "arn:cwl_log_destination_prod", "dev": "arn:dev_cwl_log_destination"}'
         ),
     )
-    @mock_iam
-    @mock_sts
-    @mock_s3
+    @mock_aws
     @patch("dbt_platform_helper.utils.validation.get_aws_session_or_abort")
     def test_make_addons_success_but_warns_when_bucket_name_in_use(self, mock_get_session, fakefs):
         client = mock_aws_client(mock_get_session)
@@ -617,9 +604,7 @@ class TestMakeAddonCommand:
         ),
     )
     @patch("dbt_platform_helper.utils.aws.get_aws_session_or_abort", new=Mock())
-    @mock_s3
-    @mock_sts
-    @mock_iam
+    @mock_aws
     def test_make_addons_deletion_policy(
         self,
         fakefs,
@@ -691,9 +676,7 @@ class TestMakeAddonCommand:
         "dbt_platform_helper.utils.versioning.running_as_installed_package",
         new=Mock(return_value=False),
     )
-    @mock_s3
-    @mock_sts
-    @mock_iam
+    @mock_aws
     def test_exit_with_error_if_invalid_services(self, fakefs):
         fakefs.create_file(
             ADDON_CONFIG_FILENAME,
@@ -727,9 +710,7 @@ invalid-entry:
         "dbt_platform_helper.utils.versioning.running_as_installed_package",
         new=Mock(return_value=False),
     )
-    @mock_s3
-    @mock_sts
-    @mock_iam
+    @mock_aws
     def test_exit_with_error_if_addons_yml_validation_fails(self, fakefs):
         fakefs.create_file(
             ADDON_CONFIG_FILENAME,
@@ -761,9 +742,7 @@ example-invalid-file:
         "dbt_platform_helper.utils.versioning.running_as_installed_package",
         new=Mock(return_value=False),
     )
-    @mock_s3
-    @mock_sts
-    @mock_iam
+    @mock_aws
     def test_exit_with_error_if_invalid_environments(self, fakefs):
         fakefs.create_file(
             ADDON_CONFIG_FILENAME,
@@ -795,9 +774,7 @@ invalid-environment:
         "dbt_platform_helper.utils.versioning.running_as_installed_package",
         new=Mock(return_value=False),
     )
-    @mock_s3
-    @mock_sts
-    @mock_iam
+    @mock_aws
     def test_exit_with_multiple_errors(self, fakefs):
         fakefs.create_file(
             ADDON_CONFIG_FILENAME,
@@ -924,9 +901,7 @@ invalid-entry:
         ),
     )
     @patch("dbt_platform_helper.utils.aws.get_aws_session_or_abort", new=Mock())
-    @mock_s3
-    @mock_sts
-    @mock_iam
+    @mock_aws
     def test_addons_parameters_file_included_with_required_parameters_for_the_addon_types(
         self, fakefs, addon_file_contents, has_postgres_addon
     ):
@@ -1056,9 +1031,7 @@ invalid-entry:
         assert result.exit_code == 0
 
 
-@mock_ssm
-@mock_sts
-@mock_iam
+@mock_aws
 @patch(
     "dbt_platform_helper.utils.versioning.running_as_installed_package",
     new=Mock(return_value=False),

--- a/tests/platform_helper/test_command_dns.py
+++ b/tests/platform_helper/test_command_dns.py
@@ -6,11 +6,7 @@ import pytest
 from botocore import stub
 from botocore.stub import Stubber
 from click.testing import CliRunner
-from moto import mock_acm
-from moto import mock_ec2
-from moto import mock_ecs
-from moto import mock_elbv2
-from moto import mock_sts
+from moto import mock_aws
 
 from dbt_platform_helper.commands.dns import InvalidDomainException
 from dbt_platform_helper.commands.dns import _get_paginated_zones
@@ -852,11 +848,7 @@ def setup_alb_listener(conditions, multiple):
     )
 
 
-@mock_sts
-@mock_elbv2
-@mock_ec2
-@mock_ecs
-@mock_acm
+@mock_aws
 def test_cdn_add_if_domain_already_exists(alias_session, aws_credentials):
     conditions = [{"Field": "host-header", "Values": ["test.com"]}]
 
@@ -882,11 +874,7 @@ def test_cdn_add_if_domain_already_exists(alias_session, aws_credentials):
     assert "test.com already exists, exiting" in result.output
 
 
-@mock_sts
-@mock_elbv2
-@mock_ec2
-@mock_ecs
-@mock_acm
+@mock_aws
 @patch("dbt_platform_helper.commands.dns.get_aws_session_or_abort", return_value=boto3.Session())
 @patch("dbt_platform_helper.commands.dns.create_required_zones_and_certs", return_value="arn:12345")
 def test_cdn_add(alias_session, aws_credentials):
@@ -919,11 +907,7 @@ def test_cdn_add(alias_session, aws_credentials):
     assert "Domains now configured: ['test.com', 'web.dev.uktrade.digital']" in result.output
 
 
-@mock_sts
-@mock_elbv2
-@mock_ec2
-@mock_ecs
-@mock_acm
+@mock_aws
 @patch("dbt_platform_helper.commands.dns.get_aws_session_or_abort", return_value=boto3.Session())
 @patch("dbt_platform_helper.commands.dns.create_required_zones_and_certs", return_value="arn:12345")
 def test_cdn_delete(alias_session, aws_credentials):
@@ -955,11 +939,7 @@ def test_cdn_delete(alias_session, aws_credentials):
     assert "deleting web.dev.uktrade.digital\nDomains now configured: ['test.com']" in result.output
 
 
-@mock_sts
-@mock_elbv2
-@mock_ec2
-@mock_ecs
-@mock_acm
+@mock_aws
 def test_cdn_list(alias_session, aws_credentials):
     conditions = [
         {
@@ -988,11 +968,7 @@ def test_cdn_list(alias_session, aws_credentials):
     assert "Domains currently configured: ['test.com', 'web.dev.uktrade.digital']" in result.output
 
 
-@mock_sts
-@mock_elbv2
-@mock_ec2
-@mock_ecs
-@mock_acm
+@mock_aws
 @patch("dbt_platform_helper.commands.dns.get_aws_session_or_abort", return_value=boto3.Session())
 @patch("dbt_platform_helper.commands.dns.create_required_zones_and_certs", return_value="arn:12345")
 def test_cdn_add_multiple_domains(alias_session, aws_credentials):

--- a/tests/platform_helper/utils/test_application.py
+++ b/tests/platform_helper/utils/test_application.py
@@ -5,8 +5,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import boto3
-from moto import mock_ssm
-from moto import mock_sts
+from moto import mock_aws
 
 from dbt_platform_helper.utils.application import Application
 from dbt_platform_helper.utils.application import ApplicationNotFoundError
@@ -81,8 +80,7 @@ class ApplicationTest(TestCase):
             str(application), "Application test with environments one:111111111, two:222222222"
         )
 
-    @mock_ssm
-    @mock_sts
+    @mock_aws
     @patch("dbt_platform_helper.utils.application.get_application_name", return_value="test")
     def test_loading_an_application_with_environments(
         self, get_application_name, get_aws_session_or_abort, get_profile_name_from_account_id
@@ -169,8 +167,7 @@ class ApplicationTest(TestCase):
         self.assertEqual(application.name, "test")
         self.assertEqual(str(application), "Application test with environments one:111111111")
 
-    @mock_ssm
-    @mock_sts
+    @mock_aws
     @patch("dbt_platform_helper.utils.application.get_application_name", return_value="test")
     def test_loading_an_empty_application(
         self, get_application_name, get_aws_session_or_abort, get_profile_name_from_account_id
@@ -192,8 +189,7 @@ class ApplicationTest(TestCase):
         self.assertEqual(application.name, "test")
         self.assertEqual(str(application), "Application test with no environments")
 
-    @mock_ssm
-    @mock_sts
+    @mock_aws
     def test_loading_an_empty_application_passing_in_the_name_and_session(
         self, get_aws_session_or_abort, get_profile_name_from_account_id
     ):
@@ -218,7 +214,7 @@ class ApplicationTest(TestCase):
         self.assertEqual(application.environments["my_env"].name, "my_env")
         self.assertEqual(application.environments["my_env"].session, session)
 
-    @mock_ssm
+    @mock_aws
     @patch("dbt_platform_helper.utils.application.get_application_name", return_value="test")
     def test_loading_an_application_in_a_different_account(
         self, get_application_name, get_aws_session_or_abort, get_profile_name_from_account_id

--- a/tests/platform_helper/utils/test_aws.py
+++ b/tests/platform_helper/utils/test_aws.py
@@ -6,10 +6,7 @@ from unittest.mock import patch
 
 import boto3
 import pytest
-from moto import mock_ec2
-from moto import mock_ecs
-from moto import mock_elbv2
-from moto import mock_ssm
+from moto import mock_aws
 
 from dbt_platform_helper.exceptions import ValidationException
 from dbt_platform_helper.utils.aws import NoProfileForAccountIdError
@@ -90,7 +87,7 @@ def test_get_ssm_secrets(mock_get_aws_session_or_abort):
     "overwrite, exists",
     [(False, False), (False, True)],
 )
-@mock_ssm
+@mock_aws
 @patch("dbt_platform_helper.utils.aws.get_aws_session_or_abort")
 def test_set_ssm_param(mock_get_aws_session_or_abort, overwrite, exists):
     mocked_ssm = boto3.client("ssm")
@@ -126,7 +123,7 @@ def test_set_ssm_param(mock_get_aws_session_or_abort, overwrite, exists):
     assert result.items() >= expected_response.items()
 
 
-@mock_ssm
+@mock_aws
 @patch("dbt_platform_helper.utils.aws.get_aws_session_or_abort")
 def test_set_ssm_param_with_existing_secret(mock_get_aws_session_or_abort):
     mocked_ssm = boto3.client("ssm")
@@ -164,7 +161,7 @@ def test_set_ssm_param_with_existing_secret(mock_get_aws_session_or_abort):
     assert result == "overwritten value"
 
 
-@mock_ssm
+@mock_aws
 @patch("dbt_platform_helper.utils.aws.get_aws_session_or_abort")
 def test_set_ssm_param_with_overwrite_but_not_exists(mock_get_aws_session_or_abort):
     mocked_ssm = boto3.client("ssm")
@@ -203,7 +200,7 @@ def test_set_ssm_param_with_overwrite_but_not_exists(mock_get_aws_session_or_abo
     )
 
 
-@mock_ssm
+@mock_aws
 @patch("dbt_platform_helper.utils.aws.get_aws_session_or_abort")
 def test_set_ssm_param_tags(mock_get_aws_session_or_abort):
     mocked_ssm = boto3.client("ssm")
@@ -237,7 +234,7 @@ def test_set_ssm_param_tags(mock_get_aws_session_or_abort):
     }
 
 
-@mock_ssm
+@mock_aws
 @patch("dbt_platform_helper.utils.aws.get_aws_session_or_abort")
 def test_set_ssm_param_tags_with_existing_secret(mock_get_aws_session_or_abort):
     mocked_ssm = boto3.client("ssm")
@@ -371,7 +368,7 @@ def test_get_profile_name_from_account_id_with_no_matching_account(fakefs):
     assert str(error.value) == "No profile found for account 999999999"
 
 
-@mock_ecs
+@mock_aws
 def test_get_load_balancer_domain_and_configuration_no_clusters(capfd):
     with pytest.raises(SystemExit):
         get_load_balancer_domain_and_configuration(
@@ -389,7 +386,7 @@ def test_get_load_balancer_domain_and_configuration_no_clusters(capfd):
     )
 
 
-@mock_ecs
+@mock_aws
 def test_get_load_balancer_domain_and_configuration_no_services(capfd):
     boto3.Session().client("ecs").create_cluster(
         clusterName=f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{CLUSTER_NAME_SUFFIX}"
@@ -411,9 +408,7 @@ def test_get_load_balancer_domain_and_configuration_no_services(capfd):
     )
 
 
-@mock_elbv2
-@mock_ec2
-@mock_ecs
+@mock_aws
 @pytest.mark.parametrize(
     "svc_name",
     [

--- a/tests/platform_helper/utils/test_validation.py
+++ b/tests/platform_helper/utils/test_validation.py
@@ -6,9 +6,7 @@ import boto3
 import pytest
 import yaml
 from botocore.exceptions import ClientError
-from moto import mock_iam
-from moto import mock_s3
-from moto import mock_sts
+from moto import mock_aws
 from schema import SchemaError
 
 from dbt_platform_helper.utils.validation import AVAILABILITY_UNCERTAIN_TEMPLATE
@@ -333,9 +331,7 @@ def test_warn_on_s3_bucket_name_availability_fails_40x(mock_get_session, http_co
     assert BUCKET_NAME_IN_USE_TEMPLATE.format(f"bucket-name-{http_code}") in capfd.readouterr().out
 
 
-@mock_s3
-@mock_sts
-@mock_iam
+@mock_aws
 def test_warn_on_s3_bucket_name_availability_success_200(capfd):
     client = boto3.client("s3")
     client.create_bucket(
@@ -346,9 +342,7 @@ def test_warn_on_s3_bucket_name_availability_success_200(capfd):
     assert "Warning:" not in capfd.readouterr().out
 
 
-@mock_s3
-@mock_sts
-@mock_iam
+@mock_aws
 def test_warn_on_s3_bucket_name_availability(clear_session_cache, capfd):
     warn_on_s3_bucket_name_availability("brand-new-bucket")
     assert "Warning:" not in capfd.readouterr().out


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/DBTP-906

Bumping moto silences CryptographyDeprecationWarning - requires replacing decorators with all-purpose `mock_aws`

Running tests with 3.12 gives hundreds of warnings - silenced a few of these in `pytest.ini`