### PR TITLE
fix: DPTP-923 Mock function that causes problems in generate tests

### DIFF
--- a/tests/platform_helper/test_command_generate.py
+++ b/tests/platform_helper/test_command_generate.py
@@ -7,32 +7,41 @@ from dbt_platform_helper.commands.generate import generate as platform_helper_ge
 from dbt_platform_helper.utils.versioning import generate_platform_helper_version_file
 
 
+@patch(
+    "dbt_platform_helper.commands.generate.generate_platform_helper_version_file",
+    new=Mock(return_value=None),
+)
 @patch("dbt_platform_helper.commands.generate.make_addons", return_value=None)
 @patch("dbt_platform_helper.commands.generate.pipeline_generate", return_value=None)
 def test_platform_helper_generate_creates_the_pipeline_configuration_and_addons(
-    mock_generate, mock_make_addons
+    mock_pipeline_generate, mock_make_addons, tmp_path
 ):
     CliRunner().invoke(platform_helper_generate)
 
-    assert mock_generate.called
+    assert mock_pipeline_generate.called
     assert mock_make_addons.called
 
 
 @patch("click.secho")
-@patch("dbt_platform_helper.utils.versioning.get_file_app_versions")
+@patch(
+    "dbt_platform_helper.utils.versioning.get_file_app_versions",
+    new=Mock(return_value=[(1, 0, 1), (1, 0, 0)]),
+)
 @patch(
     "dbt_platform_helper.utils.versioning.running_as_installed_package", new=Mock(return_value=True)
 )
-@patch("dbt_platform_helper.commands.generate.make_addons", new=Mock(return_value=None))
-@patch("dbt_platform_helper.commands.generate.pipeline_generate", new=Mock(return_value=None))
+@patch("dbt_platform_helper.commands.generate.make_addons", new=Mock(return_value=True))
+@patch("dbt_platform_helper.commands.generate.pipeline_generate", new=Mock(return_value=True))
+@patch(
+    "dbt_platform_helper.commands.generate.generate_platform_helper_version_file",
+    new=Mock(return_value=None),
+)
 def test_platform_helper_generate_shows_a_warning_when_version_is_different_than_on_file(
-    get_file_app_versions, secho
+    mock_secho, tmp_path
 ):
-    get_file_app_versions.return_value = (1, 0, 1), (1, 0, 0)
-
     CliRunner().invoke(platform_helper_generate)
 
-    secho.assert_called_once_with(
+    mock_secho.assert_called_once_with(
         f"WARNING: You are running platform-helper v1.0.1 against v1.0.0 specified by .platform-helper-version.",
         fg="red",
     )


### PR DESCRIPTION
The problem was that `generate_platform_helper_version_file` wasn't being mocked and `tmp_path` / `fakefs`'s fixture were not passed in. This was causing all sorts of weird behaviours with the `.platform-helper-version` file being created in random places and remaining there as the filesystem wasn't a temporary throw away one. On top of this, `dbt-platform-helper` was not being found by tests. 
These errors were not easy to find due to pytest's stderr capture masking the real problem