### PR TITLE
fix: env generate vpc name not found bug

### DIFF
--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -668,10 +668,12 @@ platform-helper environment online --app <application> --env <environment>
 ## Usage
 
 ```
-platform-helper environment generate [--name <name>] 
+platform-helper environment generate --name <name> [--vpc-name <vpc_name>] 
 ```
 
 ## Options
+
+- `--vpc-name <text>`
 
 - `--name
 -n <text>`

--- a/dbt_platform_helper/commands/environment.py
+++ b/dbt_platform_helper/commands/environment.py
@@ -138,8 +138,10 @@ def online(app, env):
         raise click.Abort
 
 
-def get_vpc_id(session, env_name):
-    vpc_name = f"{session.profile_name}-{env_name}"
+def get_vpc_id(session, env_name, vpc_name=None):
+    if not vpc_name:
+        vpc_name = f"{session.profile_name}-{env_name}"
+
     filters = [{"Name": "tag:Name", "Values": [vpc_name]}]
     vpcs = session.client("ec2").describe_vpcs(Filters=filters)["Vpcs"]
 
@@ -185,14 +187,15 @@ def get_cert_arn(session, env_name):
 
 
 @environment.command()
-@click.option("--name", "-n", multiple=True)
-def generate(name):
+@click.option("--vpc-name")
+@click.option("--name", "-n", multiple=True, required=True)
+def generate(name, vpc_name):
     ensure_cwd_is_repo_root()
     session = get_aws_session_or_abort()
     env_template = setup_templates().get_template("env/manifest.yml")
 
     for env_name in name:
-        vpc_id = get_vpc_id(session, env_name)
+        vpc_id = get_vpc_id(session, env_name, vpc_name)
         pub_subnet_ids, priv_subnet_ids = get_subnet_ids(session, vpc_id)
         cert_arn = get_cert_arn(session, env_name)
         contents = env_template.render(

--- a/dbt_platform_helper/commands/environment.py
+++ b/dbt_platform_helper/commands/environment.py
@@ -144,6 +144,10 @@ def get_vpc_id(session, env_name):
     vpcs = session.client("ec2").describe_vpcs(Filters=filters)["Vpcs"]
 
     if not vpcs:
+        filters[0]["Values"] = [session.profile_name]
+        vpcs = session.client("ec2").describe_vpcs(Filters=filters)["Vpcs"]
+
+    if not vpcs:
         click.secho(
             f"No VPC found with name {vpc_name} in AWS account {session.profile_name}.", fg="red"
         )

--- a/tests/platform_helper/test_command_environment.py
+++ b/tests/platform_helper/test_command_environment.py
@@ -346,7 +346,7 @@ class TestGenerate:
             Path("copilot/fixtures/test_environment_manifest.yml").read_text()
         )
 
-        mock_get_vpc_id.assert_called_once_with(mocked_session, "test")
+        mock_get_vpc_id.assert_called_once_with(mocked_session, "test", None)
         mock_get_subnet_ids.assert_called_once_with(mocked_session, "vpc-abc123")
         mock_get_cert_arn.assert_called_once_with(mocked_session, "test")
         assert actual == expected
@@ -374,6 +374,10 @@ class TestGenerate:
         actual_vpc_id = get_vpc_id(session, "prod")
 
         assert expected_vpc_id == actual_vpc_id
+
+        vpc_id_from_name = get_vpc_id(session, "not-an-env", vpc_name=vpc_name)
+
+        assert expected_vpc_id == vpc_id_from_name
 
     @mock_aws
     def test_get_vpc_id_failure(self, capsys):

--- a/tests/platform_helper/test_command_environment.py
+++ b/tests/platform_helper/test_command_environment.py
@@ -352,7 +352,7 @@ class TestGenerate:
         assert actual == expected
         assert "File copilot/environments/test/manifest.yml created" in result.output
 
-    @pytest.mark.parametrize("vpc_name", ["default", "default-development"])
+    @pytest.mark.parametrize("vpc_name", ["default", "default-prod"])
     @mock_aws
     def test_get_vpc_id(self, vpc_name):
         from dbt_platform_helper.commands.environment import get_vpc_id
@@ -371,7 +371,7 @@ class TestGenerate:
         )["Vpc"]
         expected_vpc_id = vpc["VpcId"]
 
-        actual_vpc_id = get_vpc_id(session, "development")
+        actual_vpc_id = get_vpc_id(session, "prod")
 
         assert expected_vpc_id == actual_vpc_id
 


### PR DESCRIPTION
Non-prod envs all use the same vpc and expect the vpc name to match AWS account name e.g. `intranet`, whereas prod env expects format `intranet-prod`

Also removes commented out crap from previous PR