### PR TITLE
fix: DBTP-909 - Remove CloudWatch log resource policy

### DIFF
--- a/dbt_platform_helper/templates/env/terraform-overrides/cfn.patches.yml
+++ b/dbt_platform_helper/templates/env/terraform-overrides/cfn.patches.yml
@@ -2,3 +2,6 @@
 - op: add
   path: /Resources/Cluster/Properties/ClusterName
   value: !Sub '${AppName}-${EnvironmentName}'
+
+- op: remove
+  path: /Resources/LogResourcePolicy


### PR DESCRIPTION
Add cfn patch to remove CloudWatch LogResourcePolicy from copilot CloudFormation stack (this is now provisioned with Terraform)