### PR TITLE
fix: redis and opensearch parameters missing ENDPOINT suffix

### DIFF
--- a/dbt_platform_helper/commands/conduit.py
+++ b/dbt_platform_helper/commands/conduit.py
@@ -97,6 +97,8 @@ def get_parameter_name(
 ) -> str:
     if addon_type == "postgres":
         return f"/copilot/{app.name}/{env}/conduits/{normalise_secret_name(addon_name)}_{access.upper()}"
+    elif addon_type == "redis" or addon_type == "opensearch":
+        return f"/copilot/{app.name}/{env}/conduits/{normalise_secret_name(addon_name)}_ENDPOINT"
     else:
         return f"/copilot/{app.name}/{env}/conduits/{normalise_secret_name(addon_name)}"
 

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -281,6 +281,8 @@ def mock_parameter_name(app, addon_type, addon_name, access: str = "read"):
     addon_name = addon_name.replace("-", "_").upper()
     if addon_type == "postgres":
         return f"/copilot/{app.name}/development/conduits/{addon_name}_{access.upper()}"
+    elif addon_type == "redis" or addon_type == "opensearch":
+        return f"/copilot/{app.name}/development/conduits/{addon_name}_ENDPOINT"
     else:
         return f"/copilot/{app.name}/development/conduits/{addon_name}"
 


### PR DESCRIPTION
Redis and Opensearch parameters have ENDPOINT suffix now but conduit hasn't been updated.

This PR resolves issues connecting to Redis and Opensearch resources.