### PR TITLE
feat: Add slack notification commands

### DIFF
--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -35,6 +35,9 @@
 - [platform-helper secrets](#platform-helper-secrets)
 - [platform-helper secrets copy](#platform-helper-secrets-copy)
 - [platform-helper secrets list](#platform-helper-secrets-list)
+- [platform-helper notify](#platform-helper-notify)
+- [platform-helper notify environment-progress](#platform-helper-notify-environment-progress)
+- [platform-helper notify add-comment](#platform-helper-notify-add-comment)
 
 # platform-helper
 
@@ -63,6 +66,7 @@ platform-helper <command> [--version]
 - [`domain` ↪](#platform-helper-domain)
 - [`environment` ↪](#platform-helper-environment)
 - [`generate` ↪](#platform-helper-generate)
+- [`notify` ↪](#platform-helper-notify)
 - [`pipeline` ↪](#platform-helper-pipeline)
 - [`secrets` ↪](#platform-helper-secrets)
 
@@ -826,5 +830,93 @@ platform-helper secrets list <application> <environment>
 
 ## Options
 
+- `--help <boolean>` _Defaults to False._
+  - Show this message and exit.
+
+# platform-helper notify
+
+[↩ Parent](#platform-helper)
+
+    Send Slack notifications
+
+## Usage
+
+```
+platform-helper notify (environment-progress|add-comment) 
+```
+
+## Options
+
+- `--help <boolean>` _Defaults to False._
+  - Show this message and exit.
+
+## Commands
+
+- [`add-comment` ↪](#platform-helper-notify-add-comment)
+- [`environment-progress` ↪](#platform-helper-notify-environment-progress)
+
+# platform-helper notify environment-progress
+
+[↩ Parent](#platform-helper-notify)
+
+    Send environment progress notifications
+
+## Usage
+
+```
+platform-helper notify environment-progress <slack_channel_id> <slack_token> 
+                                            <message> 
+                                            [--build-arn <build_arn>] 
+                                            [--repository <repository>] 
+                                            [--commit-sha <commit_sha>] 
+                                            [--slack-ref <slack_ref>] 
+```
+
+## Arguments
+
+- `slack-channel-id <text>`
+- `slack-token <text>`
+- `message <text>`
+
+## Options
+
+- `--build-arn <text>`
+
+- `--repository <text>`
+
+- `--commit-sha <text>`
+
+- `--slack-ref <text>`
+  - Slack message reference
+- `--help <boolean>` _Defaults to False._
+  - Show this message and exit.
+
+# platform-helper notify add-comment
+
+[↩ Parent](#platform-helper-notify)
+
+    Add comment to a notification
+
+## Usage
+
+```
+platform-helper notify add-comment <slack_channel_id> <slack_token> 
+                                   <slack_ref> <message> 
+                                   [--title <title>] [--send-to-main-channel <send_to_main_channel>] 
+```
+
+## Arguments
+
+- `slack-channel-id <text>`
+- `slack-token <text>`
+- `slack-ref <text>`
+- `message <text>`
+
+## Options
+
+- `--title <text>`
+  - Message title
+- `--send-to-main-channel <boolean>` _Defaults to False._
+  - Send to main channel
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.

--- a/dbt_platform_helper/commands/notify.py
+++ b/dbt_platform_helper/commands/notify.py
@@ -1,0 +1,128 @@
+import click
+from slack_sdk import WebClient
+from slack_sdk.models import blocks
+
+from dbt_platform_helper.utils.arn_parser import ARN
+from dbt_platform_helper.utils.click import ClickDocOptGroup
+from dbt_platform_helper.utils.versioning import (
+    check_platform_helper_version_needs_update,
+)
+
+
+@click.group(cls=ClickDocOptGroup, help="Send Slack notifications")
+def notify():
+    check_platform_helper_version_needs_update()
+
+
+@notify.command(help="Send environment progress notifications")
+@click.argument("slack-channel-id")
+@click.argument("slack-token")
+@click.argument("message")
+@click.option("--build-arn")
+@click.option("--repository")
+@click.option("--commit-sha")
+@click.option(
+    "--slack-ref",
+    default=None,
+    help="Slack message reference",
+)
+def environment_progress(
+    slack_channel_id, slack_token, message, build_arn, repository, commit_sha, slack_ref: str | None
+):
+    slack = get_slack_client(slack_token)
+    # os.environ["SLACK_TOKEN"]
+    # channel = os.environ["SLACK_CHANNEL_ID"]
+    # application = os.environ["APPLICATION"]
+    # build_arn = os.environ["CODEBUILD_BUILD_ARN"]
+    # repository = os.environ["REPOSITORY"]
+    # commit_sha = os.environ["CODEBUILD_RESOLVED_SOURCE_VERSION"][:7]
+
+    context_elements = []
+    if repository:
+        context_elements.append(f"*Repository*: <https://github.com/{repository}|{repository}>")
+        if commit_sha:
+            context_elements.append(
+                f"*Revision*: <https://github.com/{repository}/commit/{commit_sha}|{commit_sha}>"
+            )
+
+    if build_arn:
+        context_elements.append(f"<{get_build_url(build_arn)}|Build Logs>")
+
+    message_blocks = [
+        blocks.SectionBlock(
+            text=blocks.TextObject(type="mrkdwn", text=message),
+        ),
+        blocks.ContextBlock(
+            elements=[
+                blocks.TextObject(type="mrkdwn", text=element) for element in context_elements
+            ]
+        ),
+    ]
+
+    args = {
+        "channel": slack_channel_id,
+        "blocks": message_blocks,
+        "text": message,
+        "unfurl_links": False,
+        "unfurl_media": False,
+    }
+
+    # breakpoint()
+    if slack_ref:
+        args["ts"] = slack_ref
+        response = slack.chat_update(**args)
+    else:
+        response = slack.chat_postMessage(**args)
+
+    print(response["ts"])
+
+
+def get_slack_client(token):
+    return WebClient(token=token)
+
+
+@notify.command(help="Add comment to a notification")
+@click.argument("slack-channel-id")
+@click.argument("slack-token")
+@click.argument("slack-ref")
+@click.argument("message")
+@click.option("--title", default=None, help="Message title")
+@click.option("--send-to-main-channel", default=False, help="Send to main channel")
+def add_comment(
+    slack_channel_id: str,
+    slack_token: str,
+    slack_ref: str,
+    message: str,
+    title: str,
+    send_to_main_channel: bool,
+):
+    # token = os.environ["SLACK_TOKEN"]
+    slack = get_slack_client(slack_token)
+    # channel = os.environ["SLACK_CHANNEL_ID"]
+
+    slack.chat_postMessage(
+        channel=slack_channel_id,
+        blocks=[blocks.SectionBlock(text=blocks.TextObject(type="mrkdwn", text=message))],
+        text=title if title else message,
+        reply_broadcast=send_to_main_channel,
+        unfurl_links=False,
+        unfurl_media=False,
+        thread_ts=slack_ref,
+    )
+
+
+def get_build_url(build_arn):
+    try:
+        arn = ARN(build_arn)
+        url = (
+            "https://{region}.console.aws.amazon.com/codesuite/codebuild/{account}/projects/{"
+            "project}/build/{project}%3A{build_id}"
+        )
+        return url.format(
+            region=arn.region,
+            account=arn.account_id,
+            project=arn.project.replace("build/", ""),
+            build_id=arn.build_id,
+        )
+    except ValueError:
+        return ""

--- a/dbt_platform_helper/commands/notify.py
+++ b/dbt_platform_helper/commands/notify.py
@@ -42,7 +42,9 @@ def environment_progress(
     print(response["ts"])
 
 
-def _get_slack_args(build_arn, commit_sha, message, repository, slack_channel_id):
+def _get_slack_args(
+    build_arn: str, commit_sha: str, message: str, repository: str, slack_channel_id: str
+):
     context_elements = []
     if repository:
         context_elements.append(f"*Repository*: <https://github.com/{repository}|{repository}>")
@@ -77,7 +79,7 @@ def _get_slack_args(build_arn, commit_sha, message, repository, slack_channel_id
     return args
 
 
-def _get_slack_client(token):
+def _get_slack_client(token: str):
     return WebClient(token=token)
 
 
@@ -109,7 +111,7 @@ def add_comment(
     )
 
 
-def get_build_url(build_arn):
+def get_build_url(build_arn: str):
     try:
         arn = ARN(build_arn)
         url = (

--- a/dbt_platform_helper/commands/notify.py
+++ b/dbt_platform_helper/commands/notify.py
@@ -21,21 +21,17 @@ def notify():
 @click.option("--build-arn")
 @click.option("--repository")
 @click.option("--commit-sha")
-@click.option(
-    "--slack-ref",
-    default=None,
-    help="Slack message reference",
-)
+@click.option("--slack-ref", help="Slack message reference")
 def environment_progress(
-    slack_channel_id, slack_token, message, build_arn, repository, commit_sha, slack_ref: str | None
+    slack_channel_id: str,
+    slack_token: str,
+    message: str,
+    build_arn: str,
+    repository: str,
+    commit_sha: str,
+    slack_ref: str,
 ):
     slack = get_slack_client(slack_token)
-    # os.environ["SLACK_TOKEN"]
-    # channel = os.environ["SLACK_CHANNEL_ID"]
-    # application = os.environ["APPLICATION"]
-    # build_arn = os.environ["CODEBUILD_BUILD_ARN"]
-    # repository = os.environ["REPOSITORY"]
-    # commit_sha = os.environ["CODEBUILD_RESOLVED_SOURCE_VERSION"][:7]
 
     context_elements = []
     if repository:
@@ -67,7 +63,6 @@ def environment_progress(
         "unfurl_media": False,
     }
 
-    # breakpoint()
     if slack_ref:
         args["ts"] = slack_ref
         response = slack.chat_update(**args)
@@ -96,9 +91,7 @@ def add_comment(
     title: str,
     send_to_main_channel: bool,
 ):
-    # token = os.environ["SLACK_TOKEN"]
     slack = get_slack_client(slack_token)
-    # channel = os.environ["SLACK_CHANNEL_ID"]
 
     slack.chat_postMessage(
         channel=slack_channel_id,

--- a/dbt_platform_helper/utils/arn_parser.py
+++ b/dbt_platform_helper/utils/arn_parser.py
@@ -1,5 +1,4 @@
-class ValidationError(Exception):
-    pass
+from dbt_platform_helper.exceptions import ValidationException
 
 
 class ARN:
@@ -10,7 +9,7 @@ class ARN:
         arn_parts = arn.split(":", 7)
 
         if len(arn_parts) != 7:
-            raise ValidationError(f"Invalid ARN: {arn}")
+            raise ValidationException(f"Invalid ARN: {arn}")
 
         # parse and store ARN parts
         # arn:partition:service:region:account-id:resource-type:resource-id

--- a/dbt_platform_helper/utils/arn_parser.py
+++ b/dbt_platform_helper/utils/arn_parser.py
@@ -1,0 +1,60 @@
+class ValidationError(Exception):
+    pass
+
+
+class ARN:
+    def __init__(self, arn, *args, **kwargs):
+        # store the original ARN
+        self.__source = arn
+
+        arn_parts = arn.split(":", 7)
+
+        if len(arn_parts) != 7:
+            raise ValidationError(f"Invalid ARN: {arn}")
+
+        # parse and store ARN parts
+        # arn:partition:service:region:account-id:resource-type:resource-id
+        (
+            _,
+            partition,
+            service,
+            region,
+            account,
+            project,
+            build_id,
+        ) = arn_parts
+
+        self.__partition = partition
+        self.__service = service
+        self.__region = region
+        self.__account_id = account
+        self.__project = project
+        self.__build_id = build_id
+
+    @property
+    def source(self):
+        return self.__source
+
+    @property
+    def partition(self):
+        return self.__partition
+
+    @property
+    def service(self):
+        return self.__service
+
+    @property
+    def region(self):
+        return self.__region
+
+    @property
+    def account_id(self):
+        return self.__account_id
+
+    @property
+    def project(self):
+        return self.__project
+
+    @property
+    def build_id(self):
+        return self.__build_id

--- a/platform_helper.py
+++ b/platform_helper.py
@@ -16,6 +16,7 @@ from dbt_platform_helper.commands.dns import cdn as cdn_commands
 from dbt_platform_helper.commands.dns import domain as domain_commands
 from dbt_platform_helper.commands.environment import environment as environment_commands
 from dbt_platform_helper.commands.generate import generate as generate_commands
+from dbt_platform_helper.commands.notify import notify as notify_commands
 from dbt_platform_helper.commands.pipeline import pipeline as pipeline_commands
 from dbt_platform_helper.commands.secrets import secrets as secrets_commands
 from dbt_platform_helper.utils.click import ClickDocOptGroup
@@ -42,6 +43,7 @@ platform_helper.add_command(environment_commands)
 platform_helper.add_command(generate_commands)
 platform_helper.add_command(pipeline_commands)
 platform_helper.add_command(secrets_commands)
+platform_helper.add_command(notify_commands)
 
 if __name__ == "__main__":
     platform_helper()

--- a/tests/doubles/slack.py
+++ b/tests/doubles/slack.py
@@ -1,0 +1,8 @@
+from unittest.mock import Mock
+
+
+class WebClient:
+    def __init__(self, token: str):
+        self.token = token
+        self.chat_update = Mock(return_value={"ts": "updated-message"})
+        self.chat_postMessage = Mock(return_value={"ts": "first-message"})

--- a/tests/platform_helper/test_command_notify.py
+++ b/tests/platform_helper/test_command_notify.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import patch
 
 import pytest
@@ -9,187 +8,191 @@ from dbt_platform_helper.commands.notify import environment_progress
 from dbt_platform_helper.commands.notify import get_build_url
 
 
+def test_getting_build_url():
+    actual_url = get_build_url(
+        "arn:aws:codebuild:region:000000000000:build/project:example-build-id"
+    )
+    exp_url = "https://region.console.aws.amazon.com/codesuite/codebuild/000000000000/projects/project/build/project%3Aexample-build-id"
+    assert actual_url == exp_url
+
+
 @patch("dbt_platform_helper.commands.notify._get_slack_client")
-class TestNotify(unittest.TestCase):
-    def test_getting_build_url(self, webclient):
-        self.assertEqual(
-            get_build_url("arn:aws:codebuild:region:000000000000:build/project:example-build-id"),
-            "https://region.console.aws.amazon.com/codesuite/codebuild/000000000000"
-            "/projects/project/build/project%3Aexample-build-id",
-        )
+def test_sending_progress_updates_with_no_optional_elements(webclient):
+    CliRunner().invoke(
+        environment_progress,
+        [
+            "my-slack-channel-id",
+            "my-slack-token",
+            "The very important thing everyone should know",
+        ],
+    )
 
-    def test_sending_progress_updates_with_no_optional_elements(self, webclient):
-        CliRunner().invoke(
-            environment_progress,
-            [
-                "my-slack-channel-id",
-                "my-slack-token",
-                "The very important thing everyone should know",
-            ],
-        )
+    calls = webclient().chat_postMessage.call_args_list
+    assert len(calls) == 1
+    call_args = calls[0].kwargs
+    assert call_args["channel"] == "my-slack-channel-id"
+    assert call_args["text"] == "The very important thing everyone should know"
+    assert call_args["unfurl_links"] == False
+    assert call_args["unfurl_media"] == False
+    assert call_args["blocks"][0].text.text == "The very important thing everyone should know"
 
-        calls = webclient().chat_postMessage.call_args_list
-        assert len(calls) == 1
-        call_args = calls[0].kwargs
-        assert call_args["channel"] == "my-slack-channel-id"
-        assert call_args["text"] == "The very important thing everyone should know"
-        assert call_args["unfurl_links"] == False
-        assert call_args["unfurl_media"] == False
-        self.assertEqual(
-            call_args["blocks"][0].text.text, "The very important thing everyone should know"
-        )
 
-    def test_sending_progress_updates_with_all_optional_elements(self, webclient):
-        build_arn = "arn:aws:codebuild:us-west-1:123456:project:my-app"
-        repository = "my-repo"
-        commit = "abc1234"
-        CliRunner().invoke(
-            environment_progress,
-            [
-                "my-slack-channel-id",
-                "my-slack-token",
-                "The very important thing everyone should know",
-                "--build-arn",
-                build_arn,
-                "--repository",
-                repository,
-                "--commit-sha",
-                commit,
-            ],
-        )
-        calls = webclient().chat_postMessage.call_args_list
-        assert len(calls) == 1
-        call_args = calls[0].kwargs
-        assert call_args["channel"] == "my-slack-channel-id"
-        assert call_args["text"] == "The very important thing everyone should know"
-        assert call_args["unfurl_links"] == False
-        assert call_args["unfurl_media"] == False
-        self.assertEqual(
-            call_args["blocks"][0].text.text, "The very important thing everyone should know"
-        )
-        actual_elements = call_args["blocks"][1].elements
-        assert len(actual_elements) == 3
-        self.assertEqual(
-            actual_elements[0].text, f"*Repository*: <https://github.com/{repository}|{repository}>"
-        )
-        self.assertEqual(
-            actual_elements[1].text,
-            f"*Revision*: <https://github.com/{repository}/commit/{commit}|{commit}>",
-        )
-        assert actual_elements[2].text == f"<{get_build_url(build_arn)}|Build Logs>"
+@patch("dbt_platform_helper.commands.notify._get_slack_client")
+def test_sending_progress_updates_with_all_optional_elements(webclient):
+    build_arn = "arn:aws:codebuild:us-west-1:123456:project:my-app"
+    repository = "my-repo"
+    commit = "abc1234"
+    CliRunner().invoke(
+        environment_progress,
+        [
+            "my-slack-channel-id",
+            "my-slack-token",
+            "The very important thing everyone should know",
+            "--build-arn",
+            build_arn,
+            "--repository",
+            repository,
+            "--commit-sha",
+            commit,
+        ],
+    )
+    calls = webclient().chat_postMessage.call_args_list
+    assert len(calls) == 1
+    call_args = calls[0].kwargs
+    assert call_args["channel"] == "my-slack-channel-id"
+    assert call_args["text"] == "The very important thing everyone should know"
+    assert call_args["unfurl_links"] == False
+    assert call_args["unfurl_media"] == False
+    assert call_args["blocks"][0].text.text == "The very important thing everyone should know"
+    actual_elements = call_args["blocks"][1].elements
+    assert len(actual_elements) == 3
+    assert (
+        actual_elements[0].text == f"*Repository*: <https://github.com/{repository}|{repository}>"
+    )
+    assert (
+        actual_elements[1].text
+        == f"*Revision*: <https://github.com/{repository}/commit/{commit}|{commit}>"
+    )
+    assert actual_elements[2].text == f"<{get_build_url(build_arn)}|Build Logs>"
 
-    def test_sending_progress_updates_with_optional_build_arn(self, webclient):
-        build_arn = "arn:aws:codebuild:us-west-1:123456:project:my-app"
-        CliRunner().invoke(
-            environment_progress,
-            [
-                "my-slack-channel-id",
-                "my-slack-token",
-                "The very important thing everyone should know",
-                "--build-arn",
-                build_arn,
-            ],
-        )
-        calls = webclient().chat_postMessage.call_args_list
-        assert len(calls) == 1
-        call_args = calls[0].kwargs
-        actual_elements = call_args["blocks"][1].elements
-        assert len(actual_elements) == 1
-        assert actual_elements[0].text == f"<{get_build_url(build_arn)}|Build Logs>"
 
-    def test_sending_progress_updates_with_optional_repository(self, webclient):
-        repository = "my-repo"
-        CliRunner().invoke(
-            environment_progress,
-            [
-                "my-slack-channel-id",
-                "my-slack-token",
-                "The very important thing everyone should know",
-                "--repository",
-                repository,
-            ],
-        )
-        calls = webclient().chat_postMessage.call_args_list
-        assert len(calls) == 1
-        call_args = calls[0].kwargs
-        actual_elements = call_args["blocks"][1].elements
-        assert len(actual_elements) == 1
-        self.assertEqual(
-            actual_elements[0].text, f"*Repository*: <https://github.com/{repository}|{repository}>"
-        )
+@patch("dbt_platform_helper.commands.notify._get_slack_client")
+def test_sending_progress_updates_with_optional_build_arn(webclient):
+    build_arn = "arn:aws:codebuild:us-west-1:123456:project:my-app"
+    CliRunner().invoke(
+        environment_progress,
+        [
+            "my-slack-channel-id",
+            "my-slack-token",
+            "The very important thing everyone should know",
+            "--build-arn",
+            build_arn,
+        ],
+    )
+    calls = webclient().chat_postMessage.call_args_list
+    assert len(calls) == 1
+    call_args = calls[0].kwargs
+    actual_elements = call_args["blocks"][1].elements
+    assert len(actual_elements) == 1
+    assert actual_elements[0].text == f"<{get_build_url(build_arn)}|Build Logs>"
 
-    def test_sending_progress_updates_with_optional_repository_and_commit(self, webclient):
-        repository = "my-repo"
-        commit = "abc1234"
-        CliRunner().invoke(
-            environment_progress,
-            [
-                "my-slack-channel-id",
-                "my-slack-token",
-                "The very important thing everyone should know",
-                "--repository",
-                repository,
-                "--commit-sha",
-                commit,
-            ],
-        )
-        calls = webclient().chat_postMessage.call_args_list
-        assert len(calls) == 1
-        call_args = calls[0].kwargs
-        actual_elements = call_args["blocks"][1].elements
-        assert len(actual_elements) == 2
-        self.assertEqual(
-            actual_elements[0].text, f"*Repository*: <https://github.com/{repository}|{repository}>"
-        )
-        self.assertEqual(
-            actual_elements[1].text,
-            f"*Revision*: <https://github.com/{repository}/commit/{commit}|{commit}>",
-        )
 
-    def test_sending_progress_updates_with_optional_slack_ref(self, webclient):
-        build_arn = "arn:aws:codebuild:us-west-1:123456:project:my-app"
-        repository = "my-repo"
-        commit = "abc1234"
-        CliRunner().invoke(
-            environment_progress,
-            [
-                "my-slack-channel-id",
-                "my-slack-token",
-                "The very important thing everyone should know",
-                "--build-arn",
-                build_arn,
-                "--repository",
-                repository,
-                "--commit-sha",
-                commit,
-                "--slack-ref",
-                "10000.10",
-            ],
-        )
-        post_calls = webclient().chat_postMessage.call_args_list
-        update_calls = webclient().chat_update.call_args_list
-        assert len(post_calls) == 0
-        assert len(update_calls) == 1
+@patch("dbt_platform_helper.commands.notify._get_slack_client")
+def test_sending_progress_updates_with_optional_repository(webclient):
+    repository = "my-repo"
+    CliRunner().invoke(
+        environment_progress,
+        [
+            "my-slack-channel-id",
+            "my-slack-token",
+            "The very important thing everyone should know",
+            "--repository",
+            repository,
+        ],
+    )
+    calls = webclient().chat_postMessage.call_args_list
+    assert len(calls) == 1
+    call_args = calls[0].kwargs
+    actual_elements = call_args["blocks"][1].elements
+    assert len(actual_elements) == 1
+    assert (
+        actual_elements[0].text == f"*Repository*: <https://github.com/{repository}|{repository}>"
+    )
 
-        call_args = update_calls[0].kwargs
-        assert call_args["channel"] == "my-slack-channel-id"
-        assert call_args["text"] == "The very important thing everyone should know"
-        assert call_args["unfurl_links"] == False
-        assert call_args["unfurl_media"] == False
-        assert call_args["ts"] == "10000.10"
-        self.assertEqual(
-            call_args["blocks"][0].text.text, "The very important thing everyone should know"
-        )
-        actual_elements = call_args["blocks"][1].elements
-        assert len(actual_elements) == 3
-        self.assertEqual(
-            actual_elements[0].text, f"*Repository*: <https://github.com/{repository}|{repository}>"
-        )
-        self.assertEqual(
-            actual_elements[1].text,
-            f"*Revision*: <https://github.com/{repository}/commit/{commit}|{commit}>",
-        )
-        assert actual_elements[2].text == f"<{get_build_url(build_arn)}|Build Logs>"
+
+@patch("dbt_platform_helper.commands.notify._get_slack_client")
+def test_sending_progress_updates_with_optional_repository_and_commit(webclient):
+    repository = "my-repo"
+    commit = "abc1234"
+    CliRunner().invoke(
+        environment_progress,
+        [
+            "my-slack-channel-id",
+            "my-slack-token",
+            "The very important thing everyone should know",
+            "--repository",
+            repository,
+            "--commit-sha",
+            commit,
+        ],
+    )
+    calls = webclient().chat_postMessage.call_args_list
+    assert len(calls) == 1
+    call_args = calls[0].kwargs
+    actual_elements = call_args["blocks"][1].elements
+    assert len(actual_elements) == 2
+    assert (
+        actual_elements[0].text == f"*Repository*: <https://github.com/{repository}|{repository}>"
+    )
+    assert (
+        actual_elements[1].text
+        == f"*Revision*: <https://github.com/{repository}/commit/{commit}|{commit}>"
+    )
+
+
+@patch("dbt_platform_helper.commands.notify._get_slack_client")
+def test_sending_progress_updates_with_optional_slack_ref(webclient):
+    build_arn = "arn:aws:codebuild:us-west-1:123456:project:my-app"
+    repository = "my-repo"
+    commit = "abc1234"
+    CliRunner().invoke(
+        environment_progress,
+        [
+            "my-slack-channel-id",
+            "my-slack-token",
+            "The very important thing everyone should know",
+            "--build-arn",
+            build_arn,
+            "--repository",
+            repository,
+            "--commit-sha",
+            commit,
+            "--slack-ref",
+            "10000.10",
+        ],
+    )
+    post_calls = webclient().chat_postMessage.call_args_list
+    update_calls = webclient().chat_update.call_args_list
+    assert len(post_calls) == 0
+    assert len(update_calls) == 1
+
+    call_args = update_calls[0].kwargs
+    assert call_args["channel"] == "my-slack-channel-id"
+    assert call_args["text"] == "The very important thing everyone should know"
+    assert call_args["unfurl_links"] == False
+    assert call_args["unfurl_media"] == False
+    assert call_args["ts"] == "10000.10"
+    assert call_args["blocks"][0].text.text == "The very important thing everyone should know"
+    actual_elements = call_args["blocks"][1].elements
+    assert len(actual_elements) == 3
+    assert (
+        actual_elements[0].text == f"*Repository*: <https://github.com/{repository}|{repository}>"
+    )
+    assert (
+        actual_elements[1].text
+        == f"*Revision*: <https://github.com/{repository}/commit/{commit}|{commit}>"
+    )
+    assert actual_elements[2].text == f"<{get_build_url(build_arn)}|Build Logs>"
 
 
 @pytest.mark.parametrize(

--- a/tests/platform_helper/test_command_notify.py
+++ b/tests/platform_helper/test_command_notify.py
@@ -1,0 +1,147 @@
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from dbt_platform_helper.commands.notify import environment_progress
+from dbt_platform_helper.commands.notify import get_build_url
+
+
+@patch("dbt_platform_helper.commands.notify.get_slack_client")
+class TestNotify(unittest.TestCase):
+    def test_getting_build_url(self, webclient):
+        self.assertEqual(
+            get_build_url("arn:aws:codebuild:region:000000000000:build/project:example-build-id"),
+            "https://region.console.aws.amazon.com/codesuite/codebuild/000000000000"
+            "/projects/project/build/project%3Aexample-build-id",
+        )
+
+    def test_sending_progress_updates_with_no_optional_elements(self, webclient):
+        CliRunner().invoke(
+            environment_progress,
+            [
+                "my-slack-channel-id",
+                "my-slack-token",
+                "The very important thing everyone should know",
+            ],
+        )
+
+        calls = webclient().chat_postMessage.call_args_list
+        self.assertEqual(len(calls), 1)
+        call_args = calls[0].kwargs
+        self.assertEqual(call_args["channel"], "my-slack-channel-id")
+        self.assertEqual(call_args["text"], "The very important thing everyone should know")
+        self.assertEqual(call_args["unfurl_links"], False)
+        self.assertEqual(call_args["unfurl_media"], False)
+        self.assertEqual(
+            call_args["blocks"][0].text.text, "The very important thing everyone should know"
+        )
+
+    def test_sending_progress_updates_with_all_optional_elements(self, webclient):
+        build_arn = "arn:aws:codebuild:us-west-1:123456:project:my-app"
+        repository = "my-repo"
+        commit = "abc1234"
+        CliRunner().invoke(
+            environment_progress,
+            [
+                "my-slack-channel-id",
+                "my-slack-token",
+                "The very important thing everyone should know",
+                "--build-arn",
+                build_arn,
+                "--repository",
+                repository,
+                "--commit-sha",
+                commit,
+            ],
+        )
+        calls = webclient().chat_postMessage.call_args_list
+        self.assertEqual(len(calls), 1)
+        call_args = calls[0].kwargs
+        self.assertEqual(call_args["channel"], "my-slack-channel-id")
+        self.assertEqual(call_args["text"], "The very important thing everyone should know")
+        self.assertEqual(call_args["unfurl_links"], False)
+        self.assertEqual(call_args["unfurl_media"], False)
+        self.assertEqual(
+            call_args["blocks"][0].text.text, "The very important thing everyone should know"
+        )
+        actual_elements = call_args["blocks"][1].elements
+        self.assertEqual(len(actual_elements), 3)
+        self.assertEqual(
+            actual_elements[0].text, f"*Repository*: <https://github.com/{repository}|{repository}>"
+        )
+        self.assertEqual(
+            actual_elements[1].text,
+            f"*Revision*: <https://github.com/{repository}/commit/{commit}|{commit}>",
+        )
+        self.assertEqual(actual_elements[2].text, f"<{get_build_url(build_arn)}|Build Logs>")
+
+    def test_sending_progress_updates_with_optional_build_arn(self, webclient):  # , time):
+        build_arn = "arn:aws:codebuild:us-west-1:123456:project:my-app"
+        CliRunner().invoke(
+            environment_progress,
+            [
+                "my-slack-channel-id",
+                "my-slack-token",
+                "The very important thing everyone should know",
+                "--build-arn",
+                build_arn,
+            ],
+        )
+        calls = webclient().chat_postMessage.call_args_list
+        self.assertEqual(len(calls), 1)
+        call_args = calls[0].kwargs
+        actual_elements = call_args["blocks"][1].elements
+        self.assertEqual(len(actual_elements), 1)
+        self.assertEqual(actual_elements[0].text, f"<{get_build_url(build_arn)}|Build Logs>")
+
+    def test_sending_progress_updates_with_optional_repository(self, webclient):  # , time):
+        repository = "my-repo"
+        CliRunner().invoke(
+            environment_progress,
+            [
+                "my-slack-channel-id",
+                "my-slack-token",
+                "The very important thing everyone should know",
+                "--repository",
+                repository,
+            ],
+        )
+        calls = webclient().chat_postMessage.call_args_list
+        self.assertEqual(len(calls), 1)
+        call_args = calls[0].kwargs
+        actual_elements = call_args["blocks"][1].elements
+        self.assertEqual(len(actual_elements), 1)
+        self.assertEqual(
+            actual_elements[0].text, f"*Repository*: <https://github.com/{repository}|{repository}>"
+        )
+
+    def test_sending_progress_updates_with_optional_repository_and_commit(
+        self, webclient
+    ):  # , time):
+        repository = "my-repo"
+        commit = "abc1234"
+        CliRunner().invoke(
+            environment_progress,
+            [
+                "my-slack-channel-id",
+                "my-slack-token",
+                "The very important thing everyone should know",
+                "--repository",
+                repository,
+                "--commit-sha",
+                commit,
+            ],
+        )
+        calls = webclient().chat_postMessage.call_args_list
+        self.assertEqual(len(calls), 1)
+        call_args = calls[0].kwargs
+        actual_elements = call_args["blocks"][1].elements
+        self.assertEqual(len(actual_elements), 2)
+        self.assertEqual(
+            actual_elements[0].text, f"*Repository*: <https://github.com/{repository}|{repository}>"
+        )
+        self.assertEqual(
+            actual_elements[1].text,
+            f"*Revision*: <https://github.com/{repository}/commit/{commit}|{commit}>",
+        )

--- a/tests/platform_helper/test_command_notify.py
+++ b/tests/platform_helper/test_command_notify.py
@@ -124,7 +124,7 @@ def test_environment_progress(
     ),
 )
 @patch("dbt_platform_helper.commands.notify._get_slack_client")
-def test_add_comment(webclient, title, broadcast, expected_text):
+def test_add_comment(webclient, title: str, broadcast: bool, expected_text: str):
     cli_args = [
         "my-slack-channel-id",
         "my-slack-token",

--- a/tests/platform_helper/test_command_notify.py
+++ b/tests/platform_helper/test_command_notify.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
+from dbt_platform_helper.commands.notify import add_comment
 from dbt_platform_helper.commands.notify import environment_progress
 from dbt_platform_helper.commands.notify import get_build_url
 
@@ -188,3 +189,73 @@ class TestNotify(unittest.TestCase):
             f"*Revision*: <https://github.com/{repository}/commit/{commit}|{commit}>",
         )
         self.assertEqual(actual_elements[2].text, f"<{get_build_url(build_arn)}|Build Logs>")
+
+    def test_adding_comments_no_options_set(self, webclient):
+        CliRunner().invoke(
+            add_comment,
+            [
+                "my-slack-channel-id",
+                "my-slack-token",
+                "1234.56",
+                "The comment",
+            ],
+        )
+
+        calls = webclient().chat_postMessage.call_args_list
+        self.assertEqual(len(calls), 1)
+        call_args = calls[0].kwargs
+        self.assertEqual(call_args["channel"], "my-slack-channel-id")
+        self.assertEqual(call_args["text"], "The comment")
+        self.assertFalse(call_args["reply_broadcast"])
+        self.assertEqual(call_args["unfurl_links"], False)
+        self.assertEqual(call_args["unfurl_media"], False)
+        self.assertEqual(call_args["thread_ts"], "1234.56")
+        self.assertEqual(call_args["blocks"][0].text.text, "The comment")
+
+    def test_adding_comments_title_overrides_message_text(self, webclient):
+        CliRunner().invoke(
+            add_comment,
+            [
+                "my-slack-channel-id",
+                "my-slack-token",
+                "1234.56",
+                "The comment",
+                "--title",
+                "The Title",
+            ],
+        )
+
+        calls = webclient().chat_postMessage.call_args_list
+        self.assertEqual(len(calls), 1)
+        call_args = calls[0].kwargs
+        self.assertEqual(call_args["channel"], "my-slack-channel-id")
+        self.assertEqual(call_args["text"], "The Title")
+        self.assertFalse(call_args["reply_broadcast"])
+        self.assertEqual(call_args["unfurl_links"], False)
+        self.assertEqual(call_args["unfurl_media"], False)
+        self.assertEqual(call_args["thread_ts"], "1234.56")
+        self.assertEqual(call_args["blocks"][0].text.text, "The comment")
+
+    def test_adding_comments_send_to_main_channel(self, webclient):
+        CliRunner().invoke(
+            add_comment,
+            [
+                "my-slack-channel-id",
+                "my-slack-token",
+                "1234.56",
+                "The comment",
+                "--send-to-main-channel",
+                "true",
+            ],
+        )
+
+        calls = webclient().chat_postMessage.call_args_list
+        self.assertEqual(len(calls), 1)
+        call_args = calls[0].kwargs
+        self.assertEqual(call_args["channel"], "my-slack-channel-id")
+        self.assertEqual(call_args["text"], "The comment")
+        self.assertTrue(call_args["reply_broadcast"])
+        self.assertEqual(call_args["unfurl_links"], False)
+        self.assertEqual(call_args["unfurl_media"], False)
+        self.assertEqual(call_args["thread_ts"], "1234.56")
+        self.assertEqual(call_args["blocks"][0].text.text, "The comment")

--- a/tests/platform_helper/test_command_notify.py
+++ b/tests/platform_helper/test_command_notify.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from dbt_platform_helper.commands.notify import add_comment
@@ -28,12 +29,12 @@ class TestNotify(unittest.TestCase):
         )
 
         calls = webclient().chat_postMessage.call_args_list
-        self.assertEqual(len(calls), 1)
+        assert len(calls) == 1
         call_args = calls[0].kwargs
-        self.assertEqual(call_args["channel"], "my-slack-channel-id")
-        self.assertEqual(call_args["text"], "The very important thing everyone should know")
-        self.assertEqual(call_args["unfurl_links"], False)
-        self.assertEqual(call_args["unfurl_media"], False)
+        assert call_args["channel"] == "my-slack-channel-id"
+        assert call_args["text"] == "The very important thing everyone should know"
+        assert call_args["unfurl_links"] == False
+        assert call_args["unfurl_media"] == False
         self.assertEqual(
             call_args["blocks"][0].text.text, "The very important thing everyone should know"
         )
@@ -57,17 +58,17 @@ class TestNotify(unittest.TestCase):
             ],
         )
         calls = webclient().chat_postMessage.call_args_list
-        self.assertEqual(len(calls), 1)
+        assert len(calls) == 1
         call_args = calls[0].kwargs
-        self.assertEqual(call_args["channel"], "my-slack-channel-id")
-        self.assertEqual(call_args["text"], "The very important thing everyone should know")
-        self.assertEqual(call_args["unfurl_links"], False)
-        self.assertEqual(call_args["unfurl_media"], False)
+        assert call_args["channel"] == "my-slack-channel-id"
+        assert call_args["text"] == "The very important thing everyone should know"
+        assert call_args["unfurl_links"] == False
+        assert call_args["unfurl_media"] == False
         self.assertEqual(
             call_args["blocks"][0].text.text, "The very important thing everyone should know"
         )
         actual_elements = call_args["blocks"][1].elements
-        self.assertEqual(len(actual_elements), 3)
+        assert len(actual_elements) == 3
         self.assertEqual(
             actual_elements[0].text, f"*Repository*: <https://github.com/{repository}|{repository}>"
         )
@@ -75,7 +76,7 @@ class TestNotify(unittest.TestCase):
             actual_elements[1].text,
             f"*Revision*: <https://github.com/{repository}/commit/{commit}|{commit}>",
         )
-        self.assertEqual(actual_elements[2].text, f"<{get_build_url(build_arn)}|Build Logs>")
+        assert actual_elements[2].text == f"<{get_build_url(build_arn)}|Build Logs>"
 
     def test_sending_progress_updates_with_optional_build_arn(self, webclient):
         build_arn = "arn:aws:codebuild:us-west-1:123456:project:my-app"
@@ -90,11 +91,11 @@ class TestNotify(unittest.TestCase):
             ],
         )
         calls = webclient().chat_postMessage.call_args_list
-        self.assertEqual(len(calls), 1)
+        assert len(calls) == 1
         call_args = calls[0].kwargs
         actual_elements = call_args["blocks"][1].elements
-        self.assertEqual(len(actual_elements), 1)
-        self.assertEqual(actual_elements[0].text, f"<{get_build_url(build_arn)}|Build Logs>")
+        assert len(actual_elements) == 1
+        assert actual_elements[0].text == f"<{get_build_url(build_arn)}|Build Logs>"
 
     def test_sending_progress_updates_with_optional_repository(self, webclient):
         repository = "my-repo"
@@ -109,10 +110,10 @@ class TestNotify(unittest.TestCase):
             ],
         )
         calls = webclient().chat_postMessage.call_args_list
-        self.assertEqual(len(calls), 1)
+        assert len(calls) == 1
         call_args = calls[0].kwargs
         actual_elements = call_args["blocks"][1].elements
-        self.assertEqual(len(actual_elements), 1)
+        assert len(actual_elements) == 1
         self.assertEqual(
             actual_elements[0].text, f"*Repository*: <https://github.com/{repository}|{repository}>"
         )
@@ -133,10 +134,10 @@ class TestNotify(unittest.TestCase):
             ],
         )
         calls = webclient().chat_postMessage.call_args_list
-        self.assertEqual(len(calls), 1)
+        assert len(calls) == 1
         call_args = calls[0].kwargs
         actual_elements = call_args["blocks"][1].elements
-        self.assertEqual(len(actual_elements), 2)
+        assert len(actual_elements) == 2
         self.assertEqual(
             actual_elements[0].text, f"*Repository*: <https://github.com/{repository}|{repository}>"
         )
@@ -167,20 +168,20 @@ class TestNotify(unittest.TestCase):
         )
         post_calls = webclient().chat_postMessage.call_args_list
         update_calls = webclient().chat_update.call_args_list
-        self.assertEqual(len(post_calls), 0)
-        self.assertEqual(len(update_calls), 1)
+        assert len(post_calls) == 0
+        assert len(update_calls) == 1
 
         call_args = update_calls[0].kwargs
-        self.assertEqual(call_args["channel"], "my-slack-channel-id")
-        self.assertEqual(call_args["text"], "The very important thing everyone should know")
-        self.assertEqual(call_args["unfurl_links"], False)
-        self.assertEqual(call_args["unfurl_media"], False)
-        self.assertEqual(call_args["ts"], "10000.10")
+        assert call_args["channel"] == "my-slack-channel-id"
+        assert call_args["text"] == "The very important thing everyone should know"
+        assert call_args["unfurl_links"] == False
+        assert call_args["unfurl_media"] == False
+        assert call_args["ts"] == "10000.10"
         self.assertEqual(
             call_args["blocks"][0].text.text, "The very important thing everyone should know"
         )
         actual_elements = call_args["blocks"][1].elements
-        self.assertEqual(len(actual_elements), 3)
+        assert len(actual_elements) == 3
         self.assertEqual(
             actual_elements[0].text, f"*Repository*: <https://github.com/{repository}|{repository}>"
         )
@@ -188,74 +189,41 @@ class TestNotify(unittest.TestCase):
             actual_elements[1].text,
             f"*Revision*: <https://github.com/{repository}/commit/{commit}|{commit}>",
         )
-        self.assertEqual(actual_elements[2].text, f"<{get_build_url(build_arn)}|Build Logs>")
+        assert actual_elements[2].text == f"<{get_build_url(build_arn)}|Build Logs>"
 
-    def test_adding_comments_no_options_set(self, webclient):
-        CliRunner().invoke(
-            add_comment,
-            [
-                "my-slack-channel-id",
-                "my-slack-token",
-                "1234.56",
-                "The comment",
-            ],
-        )
 
-        calls = webclient().chat_postMessage.call_args_list
-        self.assertEqual(len(calls), 1)
-        call_args = calls[0].kwargs
-        self.assertEqual(call_args["channel"], "my-slack-channel-id")
-        self.assertEqual(call_args["text"], "The comment")
-        self.assertFalse(call_args["reply_broadcast"])
-        self.assertEqual(call_args["unfurl_links"], False)
-        self.assertEqual(call_args["unfurl_media"], False)
-        self.assertEqual(call_args["thread_ts"], "1234.56")
-        self.assertEqual(call_args["blocks"][0].text.text, "The comment")
+@pytest.mark.parametrize(
+    "title, broadcast, expected_text",
+    (
+        (None, False, "The comment"),
+        (None, True, "The comment"),
+        ("My title", False, "My title"),
+        ("My title", True, "My title"),
+    ),
+)
+@patch("dbt_platform_helper.commands.notify._get_slack_client")
+def test_adding_comments_no_options_set(webclient, title, broadcast, expected_text):
+    cli_args = [
+        "my-slack-channel-id",
+        "my-slack-token",
+        "1234.56",
+        "The comment",
+    ]
 
-    def test_adding_comments_title_overrides_message_text(self, webclient):
-        CliRunner().invoke(
-            add_comment,
-            [
-                "my-slack-channel-id",
-                "my-slack-token",
-                "1234.56",
-                "The comment",
-                "--title",
-                "The Title",
-            ],
-        )
+    if broadcast:
+        cli_args.extend(["--send-to-main-channel", "true"])
+    if title:
+        cli_args.extend(["--title", title])
 
-        calls = webclient().chat_postMessage.call_args_list
-        self.assertEqual(len(calls), 1)
-        call_args = calls[0].kwargs
-        self.assertEqual(call_args["channel"], "my-slack-channel-id")
-        self.assertEqual(call_args["text"], "The Title")
-        self.assertFalse(call_args["reply_broadcast"])
-        self.assertEqual(call_args["unfurl_links"], False)
-        self.assertEqual(call_args["unfurl_media"], False)
-        self.assertEqual(call_args["thread_ts"], "1234.56")
-        self.assertEqual(call_args["blocks"][0].text.text, "The comment")
+    CliRunner().invoke(add_comment, cli_args)
 
-    def test_adding_comments_send_to_main_channel(self, webclient):
-        CliRunner().invoke(
-            add_comment,
-            [
-                "my-slack-channel-id",
-                "my-slack-token",
-                "1234.56",
-                "The comment",
-                "--send-to-main-channel",
-                "true",
-            ],
-        )
-
-        calls = webclient().chat_postMessage.call_args_list
-        self.assertEqual(len(calls), 1)
-        call_args = calls[0].kwargs
-        self.assertEqual(call_args["channel"], "my-slack-channel-id")
-        self.assertEqual(call_args["text"], "The comment")
-        self.assertTrue(call_args["reply_broadcast"])
-        self.assertEqual(call_args["unfurl_links"], False)
-        self.assertEqual(call_args["unfurl_media"], False)
-        self.assertEqual(call_args["thread_ts"], "1234.56")
-        self.assertEqual(call_args["blocks"][0].text.text, "The comment")
+    calls = webclient().chat_postMessage.call_args_list
+    assert len(calls) == 1
+    call_args = calls[0].kwargs
+    assert call_args["channel"] == "my-slack-channel-id"
+    assert call_args["text"] == expected_text
+    assert call_args["reply_broadcast"] == broadcast
+    assert call_args["unfurl_links"] == False
+    assert call_args["unfurl_media"] == False
+    assert call_args["thread_ts"] == "1234.56"
+    assert call_args["blocks"][0].text.text == "The comment"

--- a/tests/platform_helper/test_command_notify.py
+++ b/tests/platform_helper/test_command_notify.py
@@ -8,7 +8,7 @@ from dbt_platform_helper.commands.notify import environment_progress
 from dbt_platform_helper.commands.notify import get_build_url
 
 
-@patch("dbt_platform_helper.commands.notify.get_slack_client")
+@patch("dbt_platform_helper.commands.notify._get_slack_client")
 class TestNotify(unittest.TestCase):
     def test_getting_build_url(self, webclient):
         self.assertEqual(

--- a/tests/platform_helper/test_platform_helper.py
+++ b/tests/platform_helper/test_platform_helper.py
@@ -31,4 +31,5 @@ class TestCopilotHelperCli:
             "generate",
             "pipeline",
             "secrets",
+            "notify",
         ]

--- a/tests/platform_helper/utils/test_arn_parser.py
+++ b/tests/platform_helper/utils/test_arn_parser.py
@@ -1,0 +1,33 @@
+import unittest
+
+import pytest
+from parameterized import parameterized
+
+from dbt_platform_helper.utils.arn_parser import ARN
+from dbt_platform_helper.utils.arn_parser import ValidationError
+
+
+class TestArnParser(unittest.TestCase):
+    def setUp(self, *args, **kwargs):
+        self.source_arn = "arn:partition:service:region:account-id:resource-type:resource-id"
+
+    def test_arn_parser_properties(self):
+        arn = ARN(self.source_arn)
+
+        self.assertEqual(arn.source, self.source_arn)
+        self.assertEqual(arn.partition, "partition")
+        self.assertEqual(arn.service, "service")
+        self.assertEqual(arn.region, "region")
+        self.assertEqual(arn.account_id, "account-id")
+        self.assertEqual(arn.project, "resource-type")
+        self.assertEqual(arn.build_id, "resource-id")
+
+    @parameterized.expand(
+        [
+            "",
+            "arn:partition:service:region:account-id",
+        ]
+    )
+    def test_arn_parser_raises_error_if_arn_not_valid(self, arn):
+        with pytest.raises(ValidationError, match=f"Invalid ARN: {arn}"):
+            ARN(arn)

--- a/tests/platform_helper/utils/test_arn_parser.py
+++ b/tests/platform_helper/utils/test_arn_parser.py
@@ -1,5 +1,3 @@
-import unittest
-
 import pytest
 from parameterized import parameterized
 
@@ -7,27 +5,25 @@ from dbt_platform_helper.exceptions import ValidationException
 from dbt_platform_helper.utils.arn_parser import ARN
 
 
-class TestArnParser(unittest.TestCase):
-    def setUp(self, *args, **kwargs):
-        self.source_arn = "arn:partition:service:region:account-id:resource-type:resource-id"
+def test_arn_parser_properties():
+    source_arn = "arn:partition:service:region:account-id:resource-type:resource-id"
+    arn = ARN(source_arn)
 
-    def test_arn_parser_properties(self):
-        arn = ARN(self.source_arn)
+    assert arn.source == source_arn
+    assert arn.partition == "partition"
+    assert arn.service == "service"
+    assert arn.region == "region"
+    assert arn.account_id == "account-id"
+    assert arn.project == "resource-type"
+    assert arn.build_id == "resource-id"
 
-        self.assertEqual(arn.source, self.source_arn)
-        self.assertEqual(arn.partition, "partition")
-        self.assertEqual(arn.service, "service")
-        self.assertEqual(arn.region, "region")
-        self.assertEqual(arn.account_id, "account-id")
-        self.assertEqual(arn.project, "resource-type")
-        self.assertEqual(arn.build_id, "resource-id")
 
-    @parameterized.expand(
-        [
-            "",
-            "arn:partition:service:region:account-id",
-        ]
-    )
-    def test_arn_parser_raises_error_if_arn_not_valid(self, arn):
-        with pytest.raises(ValidationException, match=f"Invalid ARN: {arn}"):
-            ARN(arn)
+@parameterized.expand(
+    [
+        "",
+        "arn:partition:service:region:account-id",
+    ]
+)
+def test_arn_parser_raises_error_if_arn_not_valid(arn):
+    with pytest.raises(ValidationException, match=f"Invalid ARN: {arn}"):
+        ARN(arn)

--- a/tests/platform_helper/utils/test_arn_parser.py
+++ b/tests/platform_helper/utils/test_arn_parser.py
@@ -3,8 +3,8 @@ import unittest
 import pytest
 from parameterized import parameterized
 
+from dbt_platform_helper.exceptions import ValidationException
 from dbt_platform_helper.utils.arn_parser import ARN
-from dbt_platform_helper.utils.arn_parser import ValidationError
 
 
 class TestArnParser(unittest.TestCase):
@@ -29,5 +29,5 @@ class TestArnParser(unittest.TestCase):
         ]
     )
     def test_arn_parser_raises_error_if_arn_not_valid(self, arn):
-        with pytest.raises(ValidationError, match=f"Invalid ARN: {arn}"):
+        with pytest.raises(ValidationException, match=f"Invalid ARN: {arn}"):
             ARN(arn)


### PR DESCRIPTION
Ported from ci-imagebuilder. Modified to be commands, but core code is broadly the same.

The main differences are that the command explicitly has all arguments and options supplied on the cli, rather than having variables coming in via env vars.