### PR TITLE
feat: Add prometheus-policy extension type

### DIFF
--- a/dbt_platform_helper/addon-plans.yml
+++ b/dbt_platform_helper/addon-plans.yml
@@ -220,3 +220,5 @@ s3-policy: {}
 monitoring: {}
 
 alb: {}
+
+prometheus-policy: {}

--- a/dbt_platform_helper/addons-template-map.yml
+++ b/dbt_platform_helper/addons-template-map.yml
@@ -49,3 +49,7 @@ vpc:
     - template: addons/env/vpc.yml
 alb:
   requires_addons_parameters: false
+prometheus-policy:
+  requires_addons_parameters: false
+  svc:
+    - template: addons/svc/prometheus-policy.yml

--- a/dbt_platform_helper/templates/addons/svc/prometheus-policy.yml
+++ b/dbt_platform_helper/templates/addons/svc/prometheus-policy.yml
@@ -1,0 +1,34 @@
+Parameters:
+  App:
+    Type: String
+    Description: Your application's name.
+  Env:
+    Type: String
+    Description: The environment name your service, job, or workflow is being deployed to.
+  Name:
+    Type: String
+    Description: The name of the service, job, or workflow being deployed.
+
+Mappings:
+  {{ addon_config.prefix }}EnvironmentConfigMap:
+    # Create an entry for each environment
+{% for env_name, config in addon_config.environments.items() %}
+    {{ env_name }}:
+      RoleArn: '{{ config.role_arn }}'
+{% endfor %}
+
+Resources:
+  PromCrossAccountPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sts:AssumeRole
+            Resource: !FindInMap [{{ addon_config.prefix }}EnvironmentConfigMap, !Ref Env, RoleArn]
+Outputs:
+  AMPAccessPolicyArn:
+    Description: "Allow the task to assume the prometheus writer role in the central account"
+    Value: !Ref PromCrossAccountPolicy

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -458,6 +458,18 @@ ALB_SCHEMA = Schema(
     }
 )
 
+PROMETHEUS_POLICY_SCHEMA = Schema(
+    {
+        "type": "prometheus-policy",
+        Optional("services"): Or("__all__", [str]),
+        Optional("environments"): {
+            ENV_NAME: {
+                "role_arn": str,
+            }
+        },
+    }
+)
+
 
 def no_param_schema(schema_type):
     return Schema({"type": schema_type, Optional("services"): Or("__all__", [str])})
@@ -476,4 +488,5 @@ SCHEMA_MAP = {
     "vpc": no_param_schema("vpc"),
     "xray": no_param_schema("xray"),
     "alb": ALB_SCHEMA,
+    "prometheus-policy": PROMETHEUS_POLICY_SCHEMA,
 }

--- a/tests/platform_helper/fixtures/make_addons/expected/web/addons/prometheus.yml
+++ b/tests/platform_helper/fixtures/make_addons/expected/web/addons/prometheus.yml
@@ -1,0 +1,36 @@
+Parameters:
+  App:
+    Type: String
+    Description: Your application's name.
+  Env:
+    Type: String
+    Description: The environment name your service, job, or workflow is being deployed to.
+  Name:
+    Type: String
+    Description: The name of the service, job, or workflow being deployed.
+
+Mappings:
+  prometheusEnvironmentConfigMap:
+    # Create an entry for each environment
+
+    development:
+      RoleArn: 'dev-prometheus-role-arn'
+
+    production:
+      RoleArn: 'prod-prometheus-role-arn'
+
+Resources:
+  PromCrossAccountPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sts:AssumeRole
+            Resource: !FindInMap [prometheusEnvironmentConfigMap, !Ref Env, RoleArn]
+Outputs:
+  AMPAccessPolicyArn:
+    Description: "Allow the task to assume the prometheus writer role in the central account"
+    Value: !Ref PromCrossAccountPolicy

--- a/tests/platform_helper/fixtures/make_addons/prometheus_policy_addons.yml
+++ b/tests/platform_helper/fixtures/make_addons/prometheus_policy_addons.yml
@@ -1,0 +1,11 @@
+prometheus:
+  type: prometheus-policy
+
+  services:
+    - "web"
+
+  environments:
+    '*':
+      role_arn: "dev-prometheus-role-arn"
+    production:
+      role_arn: "prod-prometheus-role-arn"

--- a/tests/platform_helper/test_command_copilot.py
+++ b/tests/platform_helper/test_command_copilot.py
@@ -74,6 +74,17 @@ name: web
 type: Load Balanced Web Service
 """
 
+PROMETHEUS_WRITE_POLICY_CONTENTS = """
+prometheus:
+  type: prometheus-write-policy
+  services:
+    - "web"
+  role_arn: arn:nonprod:fake:fake:fake:fake
+  environments:
+    production:
+      role_arn: role_arn: arn:prod:fake:fake:fake:fake
+"""
+
 EXTENSION_CONFIG_FILENAME = "extensions.yml"
 
 
@@ -175,6 +186,10 @@ class TestTerraformEnabledMakeAddonCommand:
             (
                 "monitoring_addons.yml",
                 ["appconfig-ipfilter.yml", "subscription-filter.yml"],
+            ),
+            (
+                "prometheus_policy_addons.yml",
+                ["appconfig-ipfilter.yml", "subscription-filter.yml", "prometheus.yml"],
             ),
         ],
     )
@@ -1075,7 +1090,7 @@ alb:
   type: alb
   environments:
     default:
-      cdn_domains_list: 
+      cdn_domains_list:
         test.domain.uktrade.digital: "domain.uktrade.digital"
       additional_address_list: ["another.domain"]
     development:

--- a/tests/platform_helper/utils/fixtures/addons_files/prometheus_policy_addons_bad_data.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/prometheus_policy_addons_bad_data.yml
@@ -1,0 +1,20 @@
+my-prometheus-policy-wrong-key:
+  type: prometheus-policy
+
+  services:
+    - "web"
+
+  environments:
+    dev:
+      wrong-key: donkey
+
+my-prometheus-policy-wrong-type:
+  type: prometheus-policy
+
+  services:
+    - "web"
+
+  environments:
+    dev:
+      role_arn:
+        - notalist: true

--- a/tests/platform_helper/utils/test_validation.py
+++ b/tests/platform_helper/utils/test_validation.py
@@ -193,6 +193,13 @@ def test_validate_addons_success(mock_name_is_available, addons_file):
                 "my-alb": r"Wrong key 'alb_param' in",
             },
         ),
+        (
+            "prometheus_policy_addons_bad_data.yml",
+            {
+                "my-prometheus-policy-wrong-key": r"Missing key: 'role_arn'",
+                "my-prometheus-policy-wrong-type": r"Key 'role_arn' error.*should be instance of 'str'",
+            },
+        ),
     ],
 )
 @patch("dbt_platform_helper.utils.validation.warn_on_s3_bucket_name_availability")


### PR DESCRIPTION
This PR adds a service level extension type called `prometheus-policy` that allows allows the ECS task to assume a cross account role that enables the ADOT AWS Distro for Open Telemetry sidecar container to write metrics into Prometheus.

Additional configuration is required to use Prometheus and will be added to the platform documentation soon.

Some changes may be made to this logic in the future as we explore using Prometheus/Grafana for container insights metrics.  This initial PR will unblock datahub and allow them to set up their RQ dashboard in Grafana.