### PR TITLE
fix: DBTP-1053 - Fix opensearch conduit parameter path

### DIFF
--- a/dbt_platform_helper/commands/conduit.py
+++ b/dbt_platform_helper/commands/conduit.py
@@ -219,6 +219,8 @@ def create_addon_client_task(
         elif access == "admin" and is_terraform_project():
             create_postgres_admin_task(app, env, secret_name, task_name, addon_type, addon_name)
             return
+    elif addon_type == "redis" or addon_type == "opensearch":
+        secret_name += "_ENDPOINT"
 
     subprocess.call(
         f"copilot task run --app {app.name} --env {env} "

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -294,6 +294,8 @@ def mock_connection_secret_name(mock_application, addon_type, addon_name, access
             return f"{secret_name}_READ_ONLY_USER"
         elif access == "write":
             return f"{secret_name}_APPLICATION_USER"
+    elif addon_type == "redis" or addon_type == "opensearch":
+        secret_name += "_ENDPOINT"
 
     return secret_name
 


### PR DESCRIPTION
Fix additional reference to parameter path for opensearch and redis conduit sessions