### PR TITLE
fix: add dmas-migration to available environment template options

### DIFF
--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -652,7 +652,7 @@ platform-helper environment (offline|online|generate)
 ## Usage
 
 ```
-platform-helper environment offline --app <application> --env <environment> [--template (default|migration)] 
+platform-helper environment offline --app <application> --env <environment> [--template (default|migration|dmas-migration)] 
 ```
 
 ## Options

--- a/dbt_platform_helper/commands/environment.py
+++ b/dbt_platform_helper/commands/environment.py
@@ -15,7 +15,7 @@ from dbt_platform_helper.utils.versioning import (
     check_platform_helper_version_needs_update,
 )
 
-AVAILABLE_TEMPLATES = ["default", "migration"]
+AVAILABLE_TEMPLATES = ["default", "migration", "dmas-migration"]
 
 
 @click.group(cls=ClickDocOptGroup)


### PR DESCRIPTION
Addresses a direct request in slack.

The dmas-migration template option is missing and needs to be added to enable DMAS cutover tomorrow.

I'm not sure if tests are needed, or whether this option will be removed or made a bit more generic post migration. 

It is an additional fix that allows the changes in this PR to work correctly: https://github.com/uktrade/platform-tools/commit/8b271c9f6bfd04974c3d8794b2f646dafc4fa9ac\

Post DMAS go live we should probably look at a more general solution - maybe allowing a template to be supplied, or a parameter for a date that the service will unavailable. 

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
- [ ] Manually run the commented out sections of the [pull request regression tests](https://github.com/uktrade/platform-tools/blob/main/regression_tests/pull_request_tests.sh) (unless it's not a code change)
