### PR TITLE
test: Remove tests from publish pipeline

### DIFF
--- a/buildspec.pypi.yml
+++ b/buildspec.pypi.yml
@@ -21,10 +21,5 @@ phases:
 
   build:
     commands:
-      - echo -e "\nRunning unit tests"
-      - poetry run tox
-      - echo -e "\nRunning regression tests"
-      # Todo: Swap this out for the full regression tests when we have them
-      - ./regression_tests/pull_request_tests.sh
       - echo -e "\nBuild and publish to PyPi"
       - ./publish_to_pypi.sh ${PYPI_TOKEN} ${SLACK_TOKEN} ${SLACK_CHANNEL_ID}


### PR DESCRIPTION
The unit tests are automatically run before and after merge to `main`.

The regression tests should be manually triggered before merging to `main` and are automatically run after merging to `main`.

All we achieve by running them in the publish pipeline is to make it take half an hour to publish a release.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
- [ ] Manually run the commented out sections of the [pull request regression tests](https://github.com/uktrade/platform-tools/blob/main/regression_tests/pull_request_tests.sh) (unless it's not a code change)
