### PR TITLE
test: Add GH action job to tests for test failures

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -61,5 +61,33 @@ jobs:
 
       - name: docs
         run: poetry run pre-commit run docs --all-files
+        
+  notify_slack:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    needs: [tests, lint]
+    if: needs.tests.result == 'failure' || needs.lint.result == 'failure'
+    steps:
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+      - name: Get Slack credentials
+        run: |
+          SLACK_TOKEN=$(aws ssm get-parameter --name /codebuild/slack_oauth_token --with-decryption --query "Parameter.Value" --output text)
+          SLACK_CHANNEL_ID=$(aws ssm get-parameter --name /codebuild/slack_channel_id_test_command_output --query "Parameter.Value" --output text)
+          # easier to just store the values as secrets in GH actions than fiddle with AWS?
+      
+      - name: Send Slack notification
+        run: |
+          if [ "${{ needs.tests.result }}" != "success" ]; then
+            MESSAGE=":alert: @here Tests have failed in <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub Actions> :sob:"
+          elif [ "${{ needs.lint.result }}" != "success" ]; then
+            MESSAGE=":alert: @here Lint checks have failed in <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub Actions> :sob:"
+          fi
+          # How do we install and get access to platform-helper???
+          platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "" "${MESSAGE}"
 
 


### PR DESCRIPTION
Addresses [DBTP-1077 Slack alerts for failing GitHub Actions on main branches](https://uktrade.atlassian.net/browse/DBTP-1077)

Please add any relevant context for you pull request here, or delete this if none needed.

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
- [ ] Manually run the commented out sections of the [pull request regression tests](https://github.com/uktrade/platform-tools/blob/main/regression_tests/pull_request_tests.sh) (unless it's not a code change)
