### PR TITLE
fix: DBTP-1504 - Fix unauthorised error in OpenSearch conduit CLI

### DIFF
--- a/images/conduit/opensearch/Dockerfile
+++ b/images/conduit/opensearch/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/debian:12-slim
-ARG OPENSEARCH_CLI_VERSION=1.1.0
+ARG OPENSEARCH_CLI_VERSION=1.2.0
 RUN apt-get update && apt-get install -y jq gawk procps unzip bash curl && apt-get clean
 
 # Shell and entrypoint

--- a/images/conduit/opensearch/entrypoint.sh
+++ b/images/conduit/opensearch/entrypoint.sh
@@ -3,7 +3,9 @@
 ## SETUP Connection Profile
 mkdir -p /root/.opensearch-cli/
 
-echo $CONNECTION_SECRET | gawk '{
+function decode_url() { : "${*//+/ }"; echo "${_//%/\\x}"; }
+
+echo $(decode_url "$CONNECTION_SECRET") | gawk '{
   match($0, /^https:\/\/([A-Za-z0-9_]+):([^@]+)@(.+)$/, arr);
   print "profiles:"
   print "    - name: connection"


### PR DESCRIPTION
When terraforming OpenSearch we set the master password and encode it when saving it to the parameter store. This fix decodes the connection string in the conduit session before it's written to the opensearch-cli config file.

https://uktrade.atlassian.net/browse/DBTP-1054

Also updating the opensearch-cli to the latest version, which is backwards compatible
https://github.com/opensearch-project/opensearch-cli/releases/tag/v1.2.0

Related docs change
https://github.com/uktrade/platform-documentation/pull/322

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [x] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
