### PR TITLE
fix: DBTP-1148 platform-helper environment generate should exit it not logged in

### DIFF
--- a/dbt_platform_helper/commands/environment.py
+++ b/dbt_platform_helper/commands/environment.py
@@ -377,7 +377,7 @@ def generate_terraform(name):
     _generate_terraform_environment_manifests(conf["application"], name, env_config)
 
 
-def _generate_copilot_environment_manifests(name, env_config):
+def _generate_copilot_environment_manifests(name, env_config, session):
     env_template = setup_templates().get_template("env/manifest.yml")
     vpc_name = env_config.get("vpc", None)
     vpc_id = get_vpc_id(session, name, vpc_name)

--- a/dbt_platform_helper/commands/environment.py
+++ b/dbt_platform_helper/commands/environment.py
@@ -342,6 +342,7 @@ def generate(name, vpc_name):
         )
         raise click.Abort
 
+    session = get_aws_session_or_abort()
     config_file_check()
     conf = yaml.safe_load(Path(PLATFORM_CONFIG_FILE).read_text())
 
@@ -353,7 +354,7 @@ def generate(name, vpc_name):
 
     env_config = apply_environment_defaults(conf)["environments"][name]
 
-    _generate_copilot_environment_manifests(name, env_config)
+    _generate_copilot_environment_manifests(name, env_config, session)
 
 
 @environment.command()
@@ -377,7 +378,6 @@ def generate_terraform(name):
 
 
 def _generate_copilot_environment_manifests(name, env_config):
-    session = get_aws_session_or_abort()
     env_template = setup_templates().get_template("env/manifest.yml")
     vpc_name = env_config.get("vpc", None)
     vpc_id = get_vpc_id(session, name, vpc_name)


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1148

Moved check into generate function

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
