### PR TITLE
fix: DBPT-1128 Connection Error when connecting to Redis via Conduit

### DIFF
--- a/dbt_platform_helper/commands/conduit.py
+++ b/dbt_platform_helper/commands/conduit.py
@@ -17,6 +17,7 @@ from dbt_platform_helper.utils.versioning import (
     check_platform_helper_version_needs_update,
 )
 
+
 class ConduitError(Exception):
     pass
 
@@ -210,7 +211,7 @@ def create_addon_client_task(
 ):
     secret_name = f"/copilot/{app.name}/{env}/secrets/{normalise_secret_name(addon_name)}"
     session = app.environments[env].session
- 
+
     if addon_type == "postgres":
         if access == "read":
             secret_name += "_READ_ONLY_USER"

--- a/dbt_platform_helper/commands/conduit.py
+++ b/dbt_platform_helper/commands/conduit.py
@@ -225,6 +225,7 @@ def create_addon_client_task(
     subprocess.call(
         f"copilot task run --app {app.name} --env {env} "
         f"--task-group-name {task_name} "
+        f"--execution-role {app.name}-{addon_type}-{app.name}-{env}-ecsTask "
         f"--image {CONDUIT_DOCKER_IMAGE_LOCATION}:{addon_type} "
         f"--secrets CONNECTION_SECRET={get_connection_secret_arn(app, env, secret_name)} "
         "--platform-os linux "

--- a/dbt_platform_helper/commands/conduit.py
+++ b/dbt_platform_helper/commands/conduit.py
@@ -224,28 +224,25 @@ def create_addon_client_task(
         secret_name += "_ENDPOINT"
 
     try:
-        session.client("iam").get_role(RoleName=f"{app.name}-{addon_type}-{app.name}-{env}-ecsTask")
-
-        subprocess.call(
-            f"copilot task run --app {app.name} --env {env} "
-            f"--task-group-name {task_name} "
-            f"--execution-role {app.name}-{addon_type}-{app.name}-{env}-ecsTask "
-            f"--image {CONDUIT_DOCKER_IMAGE_LOCATION}:{addon_type} "
-            f"--secrets CONNECTION_SECRET={get_connection_secret_arn(app, env, secret_name)} "
-            "--platform-os linux "
-            "--platform-arch arm64",
-            shell=True,
+        session.client("iam").get_role(
+            RoleName=f"{app.name}-{addon_type}-{app.name}-{env}-conduitEcsTask"
+        )
+        execution_role = (
+            f"--execution-role {app.name}-{addon_type}-{app.name}-{env}-conduitEcsTask "
         )
     except:
-        subprocess.call(
-            f"copilot task run --app {app.name} --env {env} "
-            f"--task-group-name {task_name} "
-            f"--image {CONDUIT_DOCKER_IMAGE_LOCATION}:{addon_type} "
-            f"--secrets CONNECTION_SECRET={get_connection_secret_arn(app, env, secret_name)} "
-            "--platform-os linux "
-            "--platform-arch arm64",
-            shell=True,
-        )
+        execution_role = ""
+
+    subprocess.call(
+        f"copilot task run --app {app.name} --env {env} "
+        f"--task-group-name {task_name} "
+        f"{execution_role}"
+        f"--image {CONDUIT_DOCKER_IMAGE_LOCATION}:{addon_type} "
+        f"--secrets CONNECTION_SECRET={get_connection_secret_arn(app, env, secret_name)} "
+        "--platform-os linux "
+        "--platform-arch arm64",
+        shell=True,
+    )
 
 
 def addon_client_is_running(app: Application, env: str, cluster_arn: str, task_name: str) -> bool:


### PR DESCRIPTION
Addresses [DBPT-1128](https://uktrade.atlassian.net/browse/DBTP-1128).

Adds in the --execution-role switch to the copilot task run command, which utilises a custom IAM role (created via Terraform) to run the ECS tasks.

As this is a bug fix there are no changes to the existing tests; and no updates to the existing documentation

Regression tests have been completed [here](https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/763451185160/projects/platform-tools-test/build/platform-tools-test%3Afe9f874a-7cc0-407b-80b5-d5c062f6277e/?region=eu-west-2)

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [x] If the work includes user interface changes, before and after screenshots included in description
- [x] Includes any applicable changes to the documentation in this code base
- [x] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [x] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
