### PR TITLE
chore: Bump terraform platform modules version

### DIFF
--- a/dbt_platform_helper/templates/environments/main.tf
+++ b/dbt_platform_helper/templates/environments/main.tf
@@ -30,7 +30,7 @@ terraform {
 }
 
 module "extensions" {
-  source = "git::https://github.com/uktrade/terraform-platform-modules.git//extensions?depth=1&ref=4"
+  source = "git::https://github.com/uktrade/terraform-platform-modules.git//extensions?depth=1&ref=5"
 
   args        = local.args
   environment = "{{ environment }}"


### PR DESCRIPTION
This bumps the version of terraform-platform-modules used in the environment manifest template.
---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [x] If the work includes user interface changes, before and after screenshots included in description
- [x] Includes any applicable changes to the documentation in this code base
- [x] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
