### PR TITLE
chore: Add slack notification for codebuild build failure

### DIFF
--- a/dbt_platform_helper/templates/pipelines/codebase/overrides/buildspec.image.yml
+++ b/dbt_platform_helper/templates/pipelines/codebase/overrides/buildspec.image.yml
@@ -42,7 +42,7 @@ phases:
           echo -e "\nInstalling dependencies"
           pip install dbt-platform-helper
 
-          MESSAGE=":no_entry::building_construction: Build failure in codebuild project: <https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/${AWS_ACCOUNT_ID}/projects/${BUILD_ID_PREFIX}/build/${CODEBUILD_BUILD_ID}/?region=eu-west-2|${BUILD_ID_PREFIX} - build ${CODEBUILD_BUILD_NUMBER}>"
+          MESSAGE=":no_entry::building_construction: Image build failure in codebuild project: <https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/${AWS_ACCOUNT_ID}/projects/${BUILD_ID_PREFIX}/build/${CODEBUILD_BUILD_ID}/?region=eu-west-2|${BUILD_ID_PREFIX} - build ${CODEBUILD_BUILD_NUMBER}>"
 
           platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "" "${MESSAGE}"
         fi

--- a/dbt_platform_helper/templates/pipelines/codebase/overrides/buildspec.image.yml
+++ b/dbt_platform_helper/templates/pipelines/codebase/overrides/buildspec.image.yml
@@ -34,3 +34,16 @@ phases:
         if [ -f .copilot/phases/post_build.sh ]; then 
           bash .copilot/phases/post_build.sh; 
         fi
+        
+        if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ]; then
+          BUILD_ID_PREFIX=$(echo $CODEBUILD_BUILD_ID | cut -d':' -f1)
+          echo "BUILD_ID_PREFIX - ${BUILD_ID_PREFIX}"
+
+          echo -e "\nInstalling dependencies"
+          pip install dbt-platform-helper
+
+          MESSAGE=":no_entry::building_construction: Build failure in codebuild project: <https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/${AWS_ACCOUNT_ID}/projects/${BUILD_ID_PREFIX}/build/${CODEBUILD_BUILD_ID}/?region=eu-west-2|${BUILD_ID_PREFIX} - build ${CODEBUILD_BUILD_NUMBER}>"
+
+          platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "" "${MESSAGE}"
+        fi
+        


### PR DESCRIPTION
Addresses [DBTP-1187 Set up slack alert for failed image building pipelines](https://uktrade.atlassian.net/browse/DBTP-1187)

![Screenshot 2024-07-17 at 09 18 06](https://github.com/user-attachments/assets/dc8d2cf5-86ff-4bf8-9a92-5c7c824e2bb2)

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [x] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [x] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
