### PR TITLE
docs: Update regression tests documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,15 @@ To allow pdb to work correctly, disable multiple processes using the `--numproce
 
 #### Regression tests
 
-The regression tests will attempt to deploy `demodjango` to the `toolspr` environment and run smoke tests.
+Amongst other things designed to exercise our tools together, the regression tests will attempt to deploy `demodjango` to the `toolspr` environment and run the smoke tests.
 
-This is currently only triggered on merges to the `main` branch for this code base and on a schedule early every morning.
+At present, this is currently only triggered on merges to the `main` branch for this code base and on a schedule early every morning.
 
-You can trigger a regression test run for your branch using the following command...
+You can manually trigger a run from the `platform-tools-test` AWS CodeBuild project.
 
-```shell
-aws codebuild start-build --project-name platform-tools-test --profile platform-tools --source-version <branch_name>
-```
+To test your `platform-tools` changes before merging, use "Start build with overrides" and set the "Source version" to your branch name
 
-Note that this could be flaky if it runs at the same time as other people are doing the same for their branches, so communication within the team is crucial.
+Because we are currently targeting the same environment for all runs and AWS CodeBuild does not support queueing, it is essential that we do not start a regression test run while another is in progress, communicate with the team and check in the `platform-tools-test` AWS CodeBuild project.
 
 #### Manual testing
 


### PR DESCRIPTION
No ticket.

This has been on my to do list for a couple of weeks.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [x] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
