### PR TITLE
chore: Dbtp-655 image building pipeline unable to delete previous cache image

### DIFF
--- a/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
+++ b/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
@@ -415,6 +415,9 @@ export class TransformedStack extends cdk.Stack {
         (buildProjectPolicy.policyDocument.Statement as Array<any>).push(
             this.getEnvManagerRolePolicyDoc()
         );
+        (buildProjectPolicy.policyDocument.Statement as Array<any>).push(
+            this.addECRBatchDeleteToBuildProjectRolePolicyDoc()
+        );
     }
 
     private getEnvManagerRolePolicyDoc() {
@@ -422,6 +425,14 @@ export class TransformedStack extends cdk.Stack {
             Effect: 'Allow',
             Action: ['sts:AssumeRole'],
             Resource: [`arn:aws:iam::${this.account}:role/${this.appName}-*-EnvManagerRole`],
+        };
+    }
+
+    private addECRBatchDeleteToBuildProjectRolePolicyDoc() {
+        return {
+            Effect: 'Allow',
+            Action: ['ecr:BatchDeleteImage'],
+            Resource: ['*'],
         };
     }
 

--- a/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
+++ b/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
@@ -163,7 +163,8 @@ export class TransformedStack extends cdk.Stack {
                             "ecr:GetDownloadUrlForLayer",
                             "ecr:InitiateLayerUpload",
                             "ecr:PutImage",
-                            "ecr:UploadLayerPart"
+                            "ecr:UploadLayerPart",
+                            "ecr:BatchDeleteImage"
                         ]
                     }
                 ]

--- a/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
+++ b/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
@@ -163,8 +163,7 @@ export class TransformedStack extends cdk.Stack {
                             "ecr:GetDownloadUrlForLayer",
                             "ecr:InitiateLayerUpload",
                             "ecr:PutImage",
-                            "ecr:UploadLayerPart",
-                            "ecr:BatchDeleteImage"
+                            "ecr:UploadLayerPart"
                         ]
                     }
                 ]


### PR DESCRIPTION
Addresses [DBTP-655](https://uktrade.atlassian.net/browse/DBTP-655)

- The `pipeline-<application>-<pipeline>-BuildProjectRole` role is auto generated by AWS Copilot when you execute `copilot pipeline deploy`
- The `pipeline-<application>-<pipeline>-CodeBuildPolicy` is attached to that role & includes ECR permissions. 
- Both the demodjango application image build codebuild job and the pipeline deploy codebuild job use `pipeline-<application>-<pipeline>-BuildProjectRole` as their service role. This service role did not have permission to delete images in ECR.
- AWS Copilot-cli role policy is [here](https://github.com/aws/copilot-cli/blob/mainline/internal/pkg/template/templates/cicd/partials/role-policy-document.yml).
- I've started a [discussion](https://github.com/aws/copilot-cli/discussions/5885) on their repo to enquire as to why the delete images permission is not added by default.
- Added a CDK override to add the delete images permission to ECR.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [x] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DBTP-655]: https://uktrade.atlassian.net/browse/DBTP-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ