### PR TITLE
chore: DBTP-1264 Add the access type to the log subscription filter name for conduit logs

### DIFF
--- a/dbt_platform_helper/commands/conduit.py
+++ b/dbt_platform_helper/commands/conduit.py
@@ -353,7 +353,7 @@ def update_conduit_stack_resources(
         Properties:
           RoleArn: {log_filter_role_arn}
           LogGroupName: /copilot/{task_name}/{access}
-          FilterName: /copilot/conduit/{app.name}/{env}/{addon_type}/{addon_name}/{task_name.rsplit("-", 1)[1]}
+          FilterName: /copilot/conduit/{app.name}/{env}/{addon_type}/{addon_name}/{task_name.rsplit("-", 1)[1]}/{access}
           FilterPattern: ''
           DestinationArn: {destination_arn}
         """

--- a/dbt_platform_helper/commands/conduit.py
+++ b/dbt_platform_helper/commands/conduit.py
@@ -315,6 +315,7 @@ def update_conduit_stack_resources(
     addon_name: str,
     task_name: str,
     parameter_name: str,
+    access: str,
 ):
     session = app.environments[env].session
     cloudformation_client = session.client("cloudformation")
@@ -351,7 +352,7 @@ def update_conduit_stack_resources(
         DeletionPolicy: Retain
         Properties:
           RoleArn: {log_filter_role_arn}
-          LogGroupName: /copilot/{task_name}
+          LogGroupName: /copilot/{task_name}/{access}
           FilterName: /copilot/conduit/{app.name}/{env}/{addon_type}/{addon_name}/{task_name.rsplit("-", 1)[1]}
           FilterPattern: ''
           DestinationArn: {destination_arn}
@@ -386,7 +387,7 @@ def start_conduit(
         create_addon_client_task(application, env, addon_type, addon_name, task_name, access)
         add_stack_delete_policy_to_task_role(application, env, task_name)
         update_conduit_stack_resources(
-            application, env, addon_type, addon_name, task_name, parameter_name
+            application, env, addon_type, addon_name, task_name, parameter_name, access
         )
 
     connect_to_addon_client_task(application, env, cluster_arn, task_name)

--- a/tests/platform_helper/test_command_conduit.py
+++ b/tests/platform_helper/test_command_conduit.py
@@ -402,7 +402,7 @@ def test_update_conduit_stack_resources(
     parameter_name = mock_parameter_name(mock_application, addon_type, addon_name)
 
     update_conduit_stack_resources(
-        mock_application, "development", addon_type, addon_name, task_name, parameter_name
+        mock_application, "development", addon_type, addon_name, task_name, parameter_name, "read"
     )
 
     template = boto3.client("cloudformation").get_template(StackName=f"task-{task_name}")
@@ -411,7 +411,7 @@ def test_update_conduit_stack_resources(
     assert template_yml["Resources"]["TaskNameParameter"]["Properties"]["Name"] == parameter_name
     assert (
         template_yml["Resources"]["SubscriptionFilter"]["Properties"]["LogGroupName"]
-        == f"/copilot/{task_name}"
+        == f"/copilot/{task_name}/read"
     )
     assert (
         "dev_account_id"
@@ -604,7 +604,7 @@ def test_start_conduit(
         mock_application, "development", task_name
     )
     update_conduit_stack_resources.assert_called_once_with(
-        mock_application, "development", addon_type, addon_name, task_name, parameter_name
+        mock_application, "development", addon_type, addon_name, task_name, parameter_name, "read"
     )
     connect_to_addon_client_task.assert_called_once_with(
         mock_application, "development", "test-arn", task_name
@@ -780,7 +780,7 @@ def test_start_conduit_when_addon_client_task_fails_to_start(
         mock_application, "development", task_name
     )
     update_conduit_stack_resources.assert_called_once_with(
-        mock_application, "development", addon_type, addon_name, task_name, parameter_name
+        mock_application, "development", addon_type, addon_name, task_name, parameter_name, "read"
     )
     connect_to_addon_client_task.assert_called_once_with(
         mock_application, "development", "test-arn", task_name
@@ -903,7 +903,7 @@ def test_start_conduit_with_access_permissions(
         mock_application, "development", task_name
     )
     update_conduit_stack_resources.assert_called_once_with(
-        mock_application, "development", addon_type, addon_name, task_name, parameter_name
+        mock_application, "development", addon_type, addon_name, task_name, parameter_name, access
     )
     connect_to_addon_client_task.assert_called_once_with(
         mock_application, "development", "test-arn", task_name

--- a/tests/platform_helper/test_command_conduit.py
+++ b/tests/platform_helper/test_command_conduit.py
@@ -419,7 +419,7 @@ def test_update_conduit_stack_resources(
     )
     assert (
         template_yml["Resources"]["SubscriptionFilter"]["Properties"]["FilterName"]
-        == f"/copilot/conduit/{mock_application.name}/development/{addon_type}/{addon_name}/{task_name.rsplit('-', 1)[1]}"
+        == f"/copilot/conduit/{mock_application.name}/development/{addon_type}/{addon_name}/{task_name.rsplit('-', 1)[1]}/read"
     )
 
 


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1264

Please add any relevant context for you pull request here, or delete this if none needed.

---
## Checklist:

### Title:
- [X] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [X] Link to ticket included (unless it's a quick out of ticket thing)
- [X] Includes tests (or an explanation for why it doesn't)
- [X] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://github.com/uktrade/platform-documentation/pull/356)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
