### PR TITLE
fix: DBTP-1265 fix platform helper version file missing

### DIFF
--- a/dbt_platform_helper/utils/versioning.py
+++ b/dbt_platform_helper/utils/versioning.py
@@ -90,7 +90,7 @@ def get_github_released_version(repository: str, tags: bool = False) -> Tuple[in
 
 
 def get_platform_helper_versions() -> PlatformHelperVersions:
-    local_version = parse_version(version("dbt-platform-helper"))
+    locally_installed_version = parse_version(version("dbt-platform-helper"))
 
     package_info = requests.get("https://pypi.org/pypi/dbt-platform-helper/json").json()
     released_versions = package_info["releases"].keys()
@@ -98,10 +98,16 @@ def get_platform_helper_versions() -> PlatformHelperVersions:
     parsed_released_versions.sort(reverse=True)
     latest_release = parsed_released_versions[0]
 
-    version_from_file = parse_version(Path(".platform-helper-version").read_text())
+    version_from_file = None
+    message = "Cannot get dbt-platform-helper version from file '.platform-helper-version. Check if file exists."
+
+    try:
+        version_from_file = parse_version(Path(".platform-helper-version").read_text())
+    except FileNotFoundError:
+        click.secho(f"{message}", fg="yellow")
 
     return PlatformHelperVersions(
-        local_version=local_version,
+        local_version=locally_installed_version,
         latest_release=latest_release,
         platform_helper_file_version=version_from_file,
     )

--- a/dbt_platform_helper/utils/versioning.py
+++ b/dbt_platform_helper/utils/versioning.py
@@ -162,8 +162,8 @@ def validate_template_version(app_version: Tuple[int, int, int], template_file_p
 
 def generate_platform_helper_version_file(directory="."):
     base_path = Path(directory)
-    platform_helper_version = string_version(get_platform_helper_versions().local_version)
-    click.echo(mkfile(base_path, ".platform-helper-version", f"{platform_helper_version}\n"))
+    local_version = string_version(get_platform_helper_versions().local_version)
+    click.echo(mkfile(base_path, ".platform-helper-version", f"{local_version}\n"))
 
 
 def check_platform_helper_version_needs_update():

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -224,7 +224,7 @@ def test_get_platform_helper_versions(mock_version, mock_get, fakefs):
 @patch("click.secho")
 @patch("requests.get")
 @patch("dbt_platform_helper.utils.versioning.version")
-def test_platform_helper_version_file_exists(mock_version, mock_get, secho):
+def test_platform_helper_version_file_does_not_exist(mock_version, mock_get, secho):
     mock_version.return_value = "1.2.3"
     mock_get.return_value.json.return_value = {
         "releases": {"1.2.3": None, "2.3.4": None, "0.1.0": None}

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -221,6 +221,24 @@ def test_get_platform_helper_versions(mock_version, mock_get, fakefs):
     assert versions.platform_helper_file_version == (5, 6, 7)
 
 
+@patch("click.secho")
+@patch("requests.get")
+@patch("dbt_platform_helper.utils.versioning.version")
+def test_platform_helper_version_file_exists(mock_version, mock_get, secho):
+    mock_version.return_value = "1.2.3"
+    mock_get.return_value.json.return_value = {
+        "releases": {"1.2.3": None, "2.3.4": None, "0.1.0": None}
+    }
+
+    versions = get_platform_helper_versions()
+
+    assert versions.platform_helper_file_version is None
+    secho.assert_called_with(
+        f"Cannot get dbt-platform-helper version from file '.platform-helper-version. Check if file exists.",
+        fg="yellow",
+    )
+
+
 def test_get_copilot_versions():
     pass
 


### PR DESCRIPTION
Addresses[DBTP-1265](https://uktrade.atlassian.net/browse/DBTP-1265)

We released `dbt-platform-helper` version "10.5.0" that had code that expected the `platform-helper-version` file to exist at the root of an application-deploy repo.

There are instances of application-deploy repos that don't have a `platform-helper-version` file.
The application would errors because the file is not there and previous code did not account for its absence.

Broken code:
Error when application-deploy repo tries to read non-existant `platform-helper-version` file
![Screenshot 2024-08-01 at 12 35 37](https://github.com/user-attachments/assets/32b0dc8e-a178-4452-b9de-8509b9e17d95)

Updated code:
Error that's produced when application-deploy repo tries to read non-existant `platform-helper-version` file
![Screenshot 2024-08-01 at 12 40 30](https://github.com/user-attachments/assets/1f2a84d3-43bf-4a58-b9f4-18eb37c7166f)

Updated code:
application-deploy repo reads `platform-helper-version` file
![Screenshot 2024-08-01 at 12 41 22](https://github.com/user-attachments/assets/1c2f8acb-a33a-4060-a122-1a3a54d300d3)


---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
