### PR TITLE
fix: correct conduit log group name

### DIFF
--- a/dbt_platform_helper/commands/conduit.py
+++ b/dbt_platform_helper/commands/conduit.py
@@ -352,7 +352,7 @@ def update_conduit_stack_resources(
         DeletionPolicy: Retain
         Properties:
           RoleArn: {log_filter_role_arn}
-          LogGroupName: /copilot/{task_name}/{access}
+          LogGroupName: /copilot/{task_name}
           FilterName: /copilot/conduit/{app.name}/{env}/{addon_type}/{addon_name}/{task_name.rsplit("-", 1)[1]}/{access}
           FilterPattern: ''
           DestinationArn: {destination_arn}

--- a/tests/platform_helper/test_command_conduit.py
+++ b/tests/platform_helper/test_command_conduit.py
@@ -411,7 +411,7 @@ def test_update_conduit_stack_resources(
     assert template_yml["Resources"]["TaskNameParameter"]["Properties"]["Name"] == parameter_name
     assert (
         template_yml["Resources"]["SubscriptionFilter"]["Properties"]["LogGroupName"]
-        == f"/copilot/{task_name}/read"
+        == f"/copilot/{task_name}"
     )
     assert (
         "dev_account_id"


### PR DESCRIPTION
I only needed to change filter name, not log group name, in [this ticket](https://github.com/uktrade/platform-tools/pull/520)