### PR TITLE
feat: Allow override of platform-helper version in regression pipeline

### DIFF
--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -42,7 +42,7 @@
 - [platform-helper database](#platform-helper-database)
 - [platform-helper database copy](#platform-helper-database-copy)
 - [platform-helper version](#platform-helper-version)
-- [platform-helper version print-desired](#platform-helper-version-print-desired)
+- [platform-helper version get-required-platform-helper](#platform-helper-version-get-required-platform-helper)
 
 # platform-helper
 
@@ -1005,7 +1005,7 @@ platform-helper database copy <source_db> <target_db>
 ## Usage
 
 ```
-platform-helper version print-desired 
+platform-helper version get-required-platform-helper 
 ```
 
 ## Options
@@ -1015,18 +1015,18 @@ platform-helper version print-desired
 
 ## Commands
 
-- [`print-desired` ↪](#platform-helper-version-print-desired)
+- [`get-required-platform-helper` ↪](#platform-helper-version-get-required-platform-helper)
 
-# platform-helper version print-desired
+# platform-helper version get-required-platform-helper
 
 [↩ Parent](#platform-helper-version)
 
-    Print the version of platform-tools desired by the current project
+    Print the version of platform-tools required by the current project
 
 ## Usage
 
 ```
-platform-helper version print-desired [--pipeline (main|test|prod-main)] 
+platform-helper version get-required-platform-helper [--pipeline (main|test|prod-main)] 
 ```
 
 ## Options

--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -41,6 +41,8 @@
 - [platform-helper notify add-comment](#platform-helper-notify-add-comment)
 - [platform-helper database](#platform-helper-database)
 - [platform-helper database copy](#platform-helper-database-copy)
+- [platform-helper version](#platform-helper-version)
+- [platform-helper version print-desired](#platform-helper-version-print-desired)
 
 # platform-helper
 
@@ -73,6 +75,7 @@ platform-helper <command> [--version]
 - [`notify` ↪](#platform-helper-notify)
 - [`pipeline` ↪](#platform-helper-pipeline)
 - [`secrets` ↪](#platform-helper-secrets)
+- [`version` ↪](#platform-helper-version)
 
 # platform-helper application
 
@@ -992,5 +995,43 @@ platform-helper database copy <source_db> <target_db>
 
 ## Options
 
+- `--help <boolean>` _Defaults to False._
+  - Show this message and exit.
+
+# platform-helper version
+
+[↩ Parent](#platform-helper)
+
+## Usage
+
+```
+platform-helper version print-desired 
+```
+
+## Options
+
+- `--help <boolean>` _Defaults to False._
+  - Show this message and exit.
+
+## Commands
+
+- [`print-desired` ↪](#platform-helper-version-print-desired)
+
+# platform-helper version print-desired
+
+[↩ Parent](#platform-helper-version)
+
+    Print the version of platform-tools desired by the current project
+
+## Usage
+
+```
+platform-helper version print-desired [--pipeline <pipeline>] 
+```
+
+## Options
+
+- `--pipeline <text>`
+  - Take into account the specified pipeline
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.

--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -1026,12 +1026,12 @@ platform-helper version print-desired
 ## Usage
 
 ```
-platform-helper version print-desired [--pipeline <pipeline>] 
+platform-helper version print-desired [--pipeline (main|test|prod-main)] 
 ```
 
 ## Options
 
-- `--pipeline <text>`
+- `--pipeline <choice>`
   - Take into account the specified pipeline
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.

--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -1002,6 +1002,9 @@ platform-helper database copy <source_db> <target_db>
 
 [↩ Parent](#platform-helper)
 
+    Contains subcommands for getting version information about the current
+    project.
+
 ## Usage
 
 ```

--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -42,7 +42,7 @@
 - [platform-helper database](#platform-helper-database)
 - [platform-helper database copy](#platform-helper-database-copy)
 - [platform-helper version](#platform-helper-version)
-- [platform-helper version get-platform-helper-for-app](#platform-helper-version-get-platform-helper-for-app)
+- [platform-helper version get-platform-helper-for-project](#platform-helper-version-get-platform-helper-for-project)
 
 # platform-helper
 
@@ -1008,7 +1008,7 @@ platform-helper database copy <source_db> <target_db>
 ## Usage
 
 ```
-platform-helper version get-platform-helper-for-app 
+platform-helper version get-platform-helper-for-project 
 ```
 
 ## Options
@@ -1018,9 +1018,9 @@ platform-helper version get-platform-helper-for-app
 
 ## Commands
 
-- [`get-platform-helper-for-app` ↪](#platform-helper-version-get-platform-helper-for-app)
+- [`get-platform-helper-for-project` ↪](#platform-helper-version-get-platform-helper-for-project)
 
-# platform-helper version get-platform-helper-for-app
+# platform-helper version get-platform-helper-for-project
 
 [↩ Parent](#platform-helper-version)
 
@@ -1029,7 +1029,7 @@ platform-helper version get-platform-helper-for-app
 ## Usage
 
 ```
-platform-helper version get-platform-helper-for-app [--pipeline (main|test|prod-main)] 
+platform-helper version get-platform-helper-for-project [--pipeline (main|test|prod-main)] 
 ```
 
 ## Options

--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -1032,6 +1032,6 @@ platform-helper version print-desired [--pipeline (main|test|prod-main)]
 ## Options
 
 - `--pipeline <choice>`
-  - Take into account the specified pipeline
+  - Take into account platform-tools version overrides in the specified pipeline
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.

--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -42,7 +42,7 @@
 - [platform-helper database](#platform-helper-database)
 - [platform-helper database copy](#platform-helper-database-copy)
 - [platform-helper version](#platform-helper-version)
-- [platform-helper version get-required-platform-helper](#platform-helper-version-get-required-platform-helper)
+- [platform-helper version get-platform-helper-for-app](#platform-helper-version-get-platform-helper-for-app)
 
 # platform-helper
 
@@ -1008,7 +1008,7 @@ platform-helper database copy <source_db> <target_db>
 ## Usage
 
 ```
-platform-helper version get-required-platform-helper 
+platform-helper version get-platform-helper-for-app 
 ```
 
 ## Options
@@ -1018,9 +1018,9 @@ platform-helper version get-required-platform-helper
 
 ## Commands
 
-- [`get-required-platform-helper` ↪](#platform-helper-version-get-required-platform-helper)
+- [`get-platform-helper-for-app` ↪](#platform-helper-version-get-platform-helper-for-app)
 
-# platform-helper version get-required-platform-helper
+# platform-helper version get-platform-helper-for-app
 
 [↩ Parent](#platform-helper-version)
 
@@ -1029,7 +1029,7 @@ platform-helper version get-required-platform-helper
 ## Usage
 
 ```
-platform-helper version get-required-platform-helper [--pipeline (main|test|prod-main)] 
+platform-helper version get-platform-helper-for-app [--pipeline (main|test|prod-main)] 
 ```
 
 ## Options

--- a/dbt_platform_helper/commands/conduit.py
+++ b/dbt_platform_helper/commands/conduit.py
@@ -12,7 +12,7 @@ from dbt_platform_helper.utils.application import Application
 from dbt_platform_helper.utils.application import load_application
 from dbt_platform_helper.utils.aws import update_postgres_parameter_with_master_secret
 from dbt_platform_helper.utils.click import ClickDocOptCommand
-from dbt_platform_helper.utils.files import is_terraform_project
+from dbt_platform_helper.utils.platform_config import is_terraform_project
 from dbt_platform_helper.utils.versioning import (
     check_platform_helper_version_needs_update,
 )

--- a/dbt_platform_helper/commands/copilot.py
+++ b/dbt_platform_helper/commands/copilot.py
@@ -10,14 +10,14 @@ from pathlib import PosixPath
 import click
 import yaml
 
+from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.utils.application import get_application_name
 from dbt_platform_helper.utils.application import load_application
 from dbt_platform_helper.utils.aws import get_aws_session_or_abort
 from dbt_platform_helper.utils.click import ClickDocOptGroup
-from dbt_platform_helper.utils.files import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.utils.files import generate_override_files
-from dbt_platform_helper.utils.files import is_terraform_project
 from dbt_platform_helper.utils.files import mkfile
+from dbt_platform_helper.utils.platform_config import is_terraform_project
 from dbt_platform_helper.utils.template import camel_case
 from dbt_platform_helper.utils.template import setup_templates
 from dbt_platform_helper.utils.validation import config_file_check

--- a/dbt_platform_helper/commands/environment.py
+++ b/dbt_platform_helper/commands/environment.py
@@ -17,8 +17,8 @@ from dbt_platform_helper.utils.application import load_application
 from dbt_platform_helper.utils.aws import get_aws_session_or_abort
 from dbt_platform_helper.utils.click import ClickDocOptGroup
 from dbt_platform_helper.utils.files import apply_environment_defaults
-from dbt_platform_helper.utils.files import is_terraform_project
 from dbt_platform_helper.utils.files import mkfile
+from dbt_platform_helper.utils.platform_config import is_terraform_project
 from dbt_platform_helper.utils.template import setup_templates
 from dbt_platform_helper.utils.validation import load_and_validate_platform_config
 from dbt_platform_helper.utils.versioning import (

--- a/dbt_platform_helper/commands/generate.py
+++ b/dbt_platform_helper/commands/generate.py
@@ -5,7 +5,6 @@ from dbt_platform_helper.commands.copilot import make_addons
 from dbt_platform_helper.commands.pipeline import generate as pipeline_generate
 from dbt_platform_helper.utils.click import ClickDocOptCommand
 from dbt_platform_helper.utils.versioning import check_platform_helper_version_mismatch
-from dbt_platform_helper.utils.versioning import generate_platform_helper_version_file
 
 
 @click.command(cls=ClickDocOptCommand)
@@ -18,7 +17,6 @@ def generate(ctx: click.Context):
     Wraps pipeline generate and make-addons.
     """
 
-    generate_platform_helper_version_file()
     check_platform_helper_version_mismatch()
     ctx.invoke(pipeline_generate)
     ctx.invoke(make_addons)

--- a/dbt_platform_helper/commands/pipeline.py
+++ b/dbt_platform_helper/commands/pipeline.py
@@ -12,10 +12,10 @@ from dbt_platform_helper.utils.aws import get_public_repository_arn
 from dbt_platform_helper.utils.click import ClickDocOptGroup
 from dbt_platform_helper.utils.files import apply_environment_defaults
 from dbt_platform_helper.utils.files import generate_override_files_from_template
-from dbt_platform_helper.utils.files import is_terraform_project
 from dbt_platform_helper.utils.files import mkfile
 from dbt_platform_helper.utils.git import git_remote
 from dbt_platform_helper.utils.messages import abort_with_error
+from dbt_platform_helper.utils.platform_config import is_terraform_project
 from dbt_platform_helper.utils.template import setup_templates
 from dbt_platform_helper.utils.validation import load_and_validate_platform_config
 from dbt_platform_helper.utils.versioning import (

--- a/dbt_platform_helper/commands/version.py
+++ b/dbt_platform_helper/commands/version.py
@@ -5,7 +5,7 @@ from dbt_platform_helper.utils.platform_config import get_environment_pipeline_n
 from dbt_platform_helper.utils.versioning import (
     check_platform_helper_version_needs_update,
 )
-from dbt_platform_helper.utils.versioning import get_desired_platform_helper_version
+from dbt_platform_helper.utils.versioning import get_required_platform_helper_version
 
 
 @click.group(chain=True, cls=ClickDocOptGroup)
@@ -13,13 +13,13 @@ def version():
     check_platform_helper_version_needs_update()
 
 
-@version.command(help="Print the version of platform-tools desired by the current project")
+@version.command(help="Print the version of platform-tools required by the current project")
 @click.option(
     "--pipeline",
     required=False,
     type=click.Choice(get_environment_pipeline_names()),
     help="Take into account platform-tools version overrides in the specified pipeline",
 )
-def print_desired(pipeline):
-    desired_version = get_desired_platform_helper_version(pipeline)
-    click.secho(desired_version)
+def get_required_platform_helper(pipeline):
+    required_version = get_required_platform_helper_version(pipeline)
+    click.secho(required_version)

--- a/dbt_platform_helper/commands/version.py
+++ b/dbt_platform_helper/commands/version.py
@@ -10,6 +10,8 @@ from dbt_platform_helper.utils.versioning import get_required_platform_helper_ve
 
 @click.group(chain=True, cls=ClickDocOptGroup)
 def version():
+    """Contains subcommands for getting version information about the current
+    project."""
     check_platform_helper_version_needs_update()
 
 
@@ -21,5 +23,16 @@ def version():
     help="Take into account platform-tools version overrides in the specified pipeline",
 )
 def get_required_platform_helper(pipeline):
+    """
+    Version precedence is in this order:
+        - if the --pipeline option is supplied, the version in 'platform-config.yml' in:
+            environment_pipelines:
+                <pipeline>:
+                    ...
+                    versions:
+                        platform-helper
+        - The version from default_versions/platform-helper in 'platform-config.yml'
+        - Fall back on the version in the deprecated '.platform-helper-version' file
+    """
     required_version = get_required_platform_helper_version(pipeline)
     click.secho(required_version)

--- a/dbt_platform_helper/commands/version.py
+++ b/dbt_platform_helper/commands/version.py
@@ -22,7 +22,7 @@ def version():
     type=click.Choice(get_environment_pipeline_names()),
     help="Take into account platform-tools version overrides in the specified pipeline",
 )
-def get_platform_helper_for_app(pipeline):
+def get_platform_helper_for_project(pipeline):
     """
     Version precedence is in this order:
         - if the --pipeline option is supplied, the version in 'platform-config.yml' in:

--- a/dbt_platform_helper/commands/version.py
+++ b/dbt_platform_helper/commands/version.py
@@ -1,0 +1,19 @@
+import click
+
+from dbt_platform_helper.utils.click import ClickDocOptGroup
+from dbt_platform_helper.utils.versioning import (
+    check_platform_helper_version_needs_update,
+)
+
+
+@click.group(chain=True, cls=ClickDocOptGroup)
+def version():
+    check_platform_helper_version_needs_update()
+
+
+@version.command()
+# @click.argument("source_environment")
+# @click.argument("target_environment")
+# @click.option("--project-profile", required=True, help="AWS account profile name")
+def required(project_profile, source_environment, target_environment):
+    pass

--- a/dbt_platform_helper/commands/version.py
+++ b/dbt_platform_helper/commands/version.py
@@ -4,6 +4,7 @@ from dbt_platform_helper.utils.click import ClickDocOptGroup
 from dbt_platform_helper.utils.versioning import (
     check_platform_helper_version_needs_update,
 )
+from dbt_platform_helper.utils.versioning import get_desired_platform_helper_version
 
 
 @click.group(chain=True, cls=ClickDocOptGroup)
@@ -11,9 +12,8 @@ def version():
     check_platform_helper_version_needs_update()
 
 
-@version.command()
-# @click.argument("source_environment")
-# @click.argument("target_environment")
-# @click.option("--project-profile", required=True, help="AWS account profile name")
-def required(project_profile, source_environment, target_environment):
-    pass
+@version.command(help="Print the version of platform-tools desired by the current project")
+@click.option("--pipeline", required=False, help="Take into account the specified pipeline")
+def print_desired(pipeline):
+    desired_version = get_desired_platform_helper_version(pipeline)
+    click.secho(desired_version)

--- a/dbt_platform_helper/commands/version.py
+++ b/dbt_platform_helper/commands/version.py
@@ -13,7 +13,11 @@ def version():
 
 
 @version.command(help="Print the version of platform-tools desired by the current project")
-@click.option("--pipeline", required=False, help="Take into account the specified pipeline")
+@click.option(
+    "--pipeline",
+    required=False,
+    help="Take into account the specified pipeline",
+)
 def print_desired(pipeline):
     desired_version = get_desired_platform_helper_version(pipeline)
     click.secho(desired_version)

--- a/dbt_platform_helper/commands/version.py
+++ b/dbt_platform_helper/commands/version.py
@@ -1,6 +1,7 @@
 import click
 
 from dbt_platform_helper.utils.click import ClickDocOptGroup
+from dbt_platform_helper.utils.platform_config import get_environment_pipeline_names
 from dbt_platform_helper.utils.versioning import (
     check_platform_helper_version_needs_update,
 )
@@ -16,6 +17,7 @@ def version():
 @click.option(
     "--pipeline",
     required=False,
+    type=click.Choice(get_environment_pipeline_names()),
     help="Take into account the specified pipeline",
 )
 def print_desired(pipeline):

--- a/dbt_platform_helper/commands/version.py
+++ b/dbt_platform_helper/commands/version.py
@@ -18,7 +18,7 @@ def version():
     "--pipeline",
     required=False,
     type=click.Choice(get_environment_pipeline_names()),
-    help="Take into account the specified pipeline",
+    help="Take into account platform-tools version overrides in the specified pipeline",
 )
 def print_desired(pipeline):
     desired_version = get_desired_platform_helper_version(pipeline)

--- a/dbt_platform_helper/commands/version.py
+++ b/dbt_platform_helper/commands/version.py
@@ -22,7 +22,7 @@ def version():
     type=click.Choice(get_environment_pipeline_names()),
     help="Take into account platform-tools version overrides in the specified pipeline",
 )
-def get_required_platform_helper(pipeline):
+def get_platform_helper_for_app(pipeline):
     """
     Version precedence is in this order:
         - if the --pipeline option is supplied, the version in 'platform-config.yml' in:

--- a/dbt_platform_helper/constants.py
+++ b/dbt_platform_helper/constants.py
@@ -1,4 +1,5 @@
 PLATFORM_CONFIG_FILE = "platform-config.yml"
+PLATFORM_HELPER_VERSION_FILE = ".platform-helper-version"
 CODEBASE_PIPELINES_KEY = "codebase_pipelines"
 ENVIRONMENTS_KEY = "environments"
 DEFAULT_TERRAFORM_PLATFORM_MODULES_VERSION = "5"

--- a/dbt_platform_helper/utils/files.py
+++ b/dbt_platform_helper/utils/files.py
@@ -88,9 +88,14 @@ def apply_environment_defaults(config):
     without_defaults_entry = {
         name: data if data else {} for name, data in environments.items() if name != "*"
     }
-    defaulted_envs = {
-        name: {**env_defaults, **data} for name, data in without_defaults_entry.items()
-    }
+
+    def combine(data):
+        out = {**env_defaults, **data}
+        if "versions" in data:
+            out["versions"] = {**env_defaults.get("versions", {}), **data["versions"]}
+        return out
+
+    defaulted_envs = {name: combine(data) for name, data in without_defaults_entry.items()}
 
     enriched_config["environments"] = defaulted_envs
 

--- a/dbt_platform_helper/utils/files.py
+++ b/dbt_platform_helper/utils/files.py
@@ -7,12 +7,6 @@ import yaml
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 
-CONFIG_FILE_MESSAGES = {
-    "storage.yml": " under the key 'extensions'",
-    "extensions.yml": " under the key 'extensions'",
-    "pipelines.yml": ", change the key 'codebases' to 'codebase_pipelines'",
-}
-
 
 def to_yaml(value):
     return yaml.dump(value, sort_keys=False)

--- a/dbt_platform_helper/utils/files.py
+++ b/dbt_platform_helper/utils/files.py
@@ -7,8 +7,6 @@ import yaml
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 
-from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
-
 CONFIG_FILE_MESSAGES = {
     "storage.yml": " under the key 'extensions'",
     "extensions.yml": " under the key 'extensions'",
@@ -110,8 +108,3 @@ def apply_environment_defaults(config):
     enriched_config["environments"] = defaulted_envs
 
     return enriched_config
-
-
-def is_terraform_project() -> bool:
-    config = yaml.safe_load(Path(PLATFORM_CONFIG_FILE).read_text())
-    return not config.get("legacy_project", False)

--- a/dbt_platform_helper/utils/files.py
+++ b/dbt_platform_helper/utils/files.py
@@ -89,13 +89,23 @@ def apply_environment_defaults(config):
         name: data if data else {} for name, data in environments.items() if name != "*"
     }
 
-    def combine(data):
-        out = {**env_defaults, **data}
-        if "versions" in data:
-            out["versions"] = {**env_defaults.get("versions", {}), **data["versions"]}
-        return out
+    default_versions = config.get("default_versions", {})
 
-    defaulted_envs = {name: combine(data) for name, data in without_defaults_entry.items()}
+    def combine_env_data(data):
+        return {
+            **env_defaults,
+            **data,
+            "versions": {
+                **default_versions,
+                **env_defaults.get("versions", {}),
+                **data.get("versions", {}),
+            },
+        }
+
+    defaulted_envs = {
+        env_name: combine_env_data(env_data)
+        for env_name, env_data in without_defaults_entry.items()
+    }
 
     enriched_config["environments"] = defaulted_envs
 

--- a/dbt_platform_helper/utils/platform_config.py
+++ b/dbt_platform_helper/utils/platform_config.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import yaml
+
+from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
+from dbt_platform_helper.utils.validation import load_and_validate_platform_config
+
+
+def get_environment_pipeline_names():
+    if not Path(PLATFORM_CONFIG_FILE).exists():
+        return {}
+
+    config = load_and_validate_platform_config(disable_aws_validation=True)
+    return config.get("environment_pipelines", {}).keys()
+
+
+def is_terraform_project() -> bool:
+    config = yaml.safe_load(Path(PLATFORM_CONFIG_FILE).read_text())
+    return not config.get("legacy_project", False)

--- a/dbt_platform_helper/utils/platform_config.py
+++ b/dbt_platform_helper/utils/platform_config.py
@@ -10,7 +10,7 @@ def get_environment_pipeline_names():
     if not Path(PLATFORM_CONFIG_FILE).exists():
         return {}
 
-    config = load_and_validate_platform_config(disable_aws_validation=True)
+    config = load_and_validate_platform_config(disable_aws_validation=True, disable_file_check=True)
     return config.get("environment_pipelines", {}).keys()
 
 

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -15,6 +15,7 @@ from yaml.parser import ParserError
 from dbt_platform_helper.constants import CODEBASE_PIPELINES_KEY
 from dbt_platform_helper.constants import ENVIRONMENTS_KEY
 from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
+from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_FILE
 from dbt_platform_helper.utils.aws import get_aws_session_or_abort
 from dbt_platform_helper.utils.files import apply_environment_defaults
 from dbt_platform_helper.utils.messages import abort_with_error
@@ -599,7 +600,7 @@ def config_file_check(path=PLATFORM_CONFIG_FILE):
             "instruction": ", change the key 'codebases' to 'codebase_pipelines'",
             "type": errors,
         },
-        ".platform-helper-version": {
+        PLATFORM_HELPER_VERSION_FILE: {
             "instruction": ", under the key `default_versions: platform-helper:`",
             "type": warnings,
         },

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -574,8 +574,11 @@ def _validate_environment_pipelines_triggers(config):
         abort_with_error(error_message + "\n  ".join(errors))
 
 
-def load_and_validate_platform_config(path=PLATFORM_CONFIG_FILE, disable_aws_validation=False):
-    config_file_check(path)
+def load_and_validate_platform_config(
+    path=PLATFORM_CONFIG_FILE, disable_aws_validation=False, disable_file_check=False
+):
+    if not disable_file_check:
+        config_file_check(path)
     try:
         conf = yaml.safe_load(Path(path).read_text())
         validate_platform_config(conf, disable_aws_validation)

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -437,6 +437,7 @@ ENVIRONMENT_PIPELINES_DEFINITION = {
         Optional("account"): str,
         Optional("branch", default="main"): str,
         Optional("pipeline_to_trigger"): str,
+        Optional("versions"): _VERSIONS_DEFINITION,
         "slack_channel": str,
         "trigger_on_push": bool,
         "environments": {str: Or(None, _ENVIRONMENTS_PARAMS)},

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -376,8 +376,14 @@ PROMETHEUS_POLICY_DEFINITION = {
     },
 }
 
-_VERSIONS_DEFINITION = {
+_DEFAULT_VERSIONS_DEFINITION = {
     Optional("terraform-platform-modules"): str,
+    Optional("platform-helper"): str,
+}
+_ENVIRONMENTS_VERSIONS_OVERRIDES = {
+    Optional("terraform-platform-modules"): str,
+}
+_PIPELINE_VERSIONS_OVERRIDES = {
     Optional("platform-helper"): str,
 }
 
@@ -393,7 +399,7 @@ _ENVIRONMENTS_PARAMS = {
         },
     },
     Optional("requires_approval"): bool,
-    Optional("versions"): _VERSIONS_DEFINITION,
+    Optional("versions"): _ENVIRONMENTS_VERSIONS_OVERRIDES,
     Optional("vpc"): str,
 }
 
@@ -437,7 +443,7 @@ ENVIRONMENT_PIPELINES_DEFINITION = {
         Optional("account"): str,
         Optional("branch", default="main"): str,
         Optional("pipeline_to_trigger"): str,
-        Optional("versions"): _VERSIONS_DEFINITION,
+        Optional("versions"): _PIPELINE_VERSIONS_OVERRIDES,
         "slack_channel": str,
         "trigger_on_push": bool,
         "environments": {str: Or(None, _ENVIRONMENTS_PARAMS)},
@@ -449,6 +455,7 @@ PLATFORM_CONFIG_SCHEMA = Schema(
         # The following line is for the AWS Copilot version, will be removed under DBTP-1002
         "application": str,
         Optional("legacy_project", default=False): bool,
+        Optional("default_versions"): _DEFAULT_VERSIONS_DEFINITION,
         Optional("accounts"): list[str],
         Optional("environments"): ENVIRONMENTS_DEFINITION,
         Optional("codebase_pipelines"): CODEBASE_PIPELINES_DEFINITION,

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -604,13 +604,10 @@ def config_file_check(path=PLATFORM_CONFIG_FILE):
 
     for file in messages.keys():
         if Path(file).exists():
-            if platform_config_exists:
-                message = f"`{file}` has been superseded by `{PLATFORM_CONFIG_FILE}` and should be deleted."
-            else:
-                message = (
-                    f"`{file}` is no longer supported. Please move its contents into a file named "
-                    f"`{PLATFORM_CONFIG_FILE}`{messages[file]['instruction']} and delete `{file}`."
-                )
+            message = (
+                f"`{file}` is no longer supported. Please move its contents into the "
+                f"`{PLATFORM_CONFIG_FILE}` file{messages[file]['instruction']} and delete `{file}`."
+            )
             messages[file]["type"].append(message)
 
     if not errors and not warnings and not platform_config_exists:
@@ -620,9 +617,9 @@ def config_file_check(path=PLATFORM_CONFIG_FILE):
         )
 
     if warnings:
-        click.secho("\n".join(warnings), bg="yellow")
+        click.secho("\n".join(warnings), bg="yellow", fg="black")
     if errors:
-        click.secho("\n".join(errors), bg="red")
+        click.secho("\n".join(errors), bg="red", fg="white")
         exit(1)
 
 

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -376,6 +376,11 @@ PROMETHEUS_POLICY_DEFINITION = {
     },
 }
 
+_VERSIONS_DEFINITION = {
+    Optional("terraform-platform-modules"): str,
+    Optional("platform-helper"): str,
+}
+
 _ENVIRONMENTS_PARAMS = {
     Optional("accounts"): {
         "deploy": {
@@ -388,14 +393,11 @@ _ENVIRONMENTS_PARAMS = {
         },
     },
     Optional("requires_approval"): bool,
+    Optional("versions"): _VERSIONS_DEFINITION,
     Optional("vpc"): str,
 }
 
-ENVIRONMENTS_DEFINITION = {
-    str: Or(
-        None, {**_ENVIRONMENTS_PARAMS, Optional("versions"): {"terraform-platform-modules": str}}
-    )
-}
+ENVIRONMENTS_DEFINITION = {str: Or(None, _ENVIRONMENTS_PARAMS)}
 
 CODEBASE_PIPELINES_DEFINITION = [
     {

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -476,7 +476,6 @@ PLATFORM_CONFIG_SCHEMA = Schema(
 
 
 def _validate_s3_bucket_uniqueness(enriched_config):
-    # Don't waste time calling AWS if the bucket name is not even valid.
     extensions = enriched_config.get("extensions", {})
     bucket_extensions = [
         s3_ext

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -499,11 +499,7 @@ def validate_platform_config(config, disable_aws_validation=False):
     _validate_environment_pipelines_triggers(enriched_config)
     _validate_codebase_pipelines(enriched_config)
     if not disable_aws_validation:
-        _run_aws_checks(enriched_config)
-
-
-def _run_aws_checks(enriched_config):
-    _validate_s3_bucket_uniqueness(enriched_config)
+        _validate_s3_bucket_uniqueness(enriched_config)
 
 
 def _validate_environment_pipelines(config):

--- a/dbt_platform_helper/utils/versioning.py
+++ b/dbt_platform_helper/utils/versioning.py
@@ -259,7 +259,7 @@ def running_as_installed_package():
     return "site-packages" in __file__
 
 
-def get_desired_platform_helper_version(pipeline: str = None) -> str:
+def get_required_platform_helper_version(pipeline: str = None) -> str:
     versions = get_platform_helper_versions()
     pipeline_version = versions.pipeline_overrides.get(pipeline)
     version_precedence = [

--- a/dbt_platform_helper/utils/versioning.py
+++ b/dbt_platform_helper/utils/versioning.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version
 from pathlib import Path
 from typing import Optional
@@ -104,7 +105,10 @@ def get_github_released_version(repository: str, tags: bool = False) -> Tuple[in
 
 
 def get_platform_helper_versions() -> PlatformHelperVersions:
-    locally_installed_version = parse_version(version("dbt-platform-helper"))
+    try:
+        locally_installed_version = parse_version(version("dbt-platform-helper"))
+    except PackageNotFoundError:
+        locally_installed_version = None
 
     package_info = requests.get("https://pypi.org/pypi/dbt-platform-helper/json").json()
     released_versions = package_info["releases"].keys()

--- a/dbt_platform_helper/utils/versioning.py
+++ b/dbt_platform_helper/utils/versioning.py
@@ -5,7 +5,6 @@ from importlib.metadata import version
 from pathlib import Path
 from typing import Optional
 from typing import Tuple
-from typing import TypeAlias
 from typing import Union
 
 import click
@@ -18,7 +17,7 @@ from dbt_platform_helper.exceptions import ValidationException
 from dbt_platform_helper.utils.files import mkfile
 from dbt_platform_helper.utils.validation import load_and_validate_platform_config
 
-VersionTuple: TypeAlias = Optional[Tuple[int, int, int]]
+VersionTuple = Optional[Tuple[int, int, int]]
 
 
 class Versions:

--- a/dbt_platform_helper/utils/versioning.py
+++ b/dbt_platform_helper/utils/versioning.py
@@ -112,7 +112,7 @@ def get_platform_helper_versions() -> PlatformHelperVersions:
     parsed_released_versions = [parse_version(v) for v in released_versions]
     parsed_released_versions.sort(reverse=True)
     latest_release = parsed_released_versions[0]
-    platform_config = load_and_validate_platform_config()
+    platform_config = load_and_validate_platform_config(disable_aws_validation=True)
     platform_config_default = parse_version(
         platform_config.get("default_versions", {}).get("platform-helper")
     )

--- a/platform-config.yml
+++ b/platform-config.yml
@@ -1,0 +1,69 @@
+# This file is just here to support the tests.
+# In particular, testing the Choices for the click commands as these are evaluated at compile-time (being decorators)
+# and so the functions that populate the Choice objects are evaluated before tests can patch them.
+# e.g. dbt_platform_helper.utils.platform_config.get_environment_pipeline_names
+application: test-app
+
+environments:
+  "*":
+    accounts:
+      deploy:
+        name: "non-prod-acc"
+        id: "1122334455"
+      dns:
+        name: "non-prod-dns-acc"
+        id: "6677889900"
+    requires_approval: false
+    vpc: non-prod-vpc
+  dev:
+  test:
+    versions:
+      terraform-platform-modules: 1.2.3
+  staging:
+  prod:
+    accounts:
+      deploy:
+        name: "prod-acc"
+        id: "9999999999"
+      dns:
+        name: "prod-dns-acc"
+        id: "7777777777"
+    requires_approval: true
+    vpc: prod-vpc
+    
+environment_pipelines:
+  main:
+    account: non-prod-acc
+    slack_channel: "/codebuild/notification_channel"
+    trigger_on_push: true
+    pipeline_to_trigger: "prod-main"
+    environments:
+      dev:
+      staging:
+  test:
+    branch: my-feature-branch
+    slack_channel: "/codebuild/notification_channel"
+    trigger_on_push: false
+    versions:
+      platform-helper: main
+    environments:
+      test:
+        requires_approval: true
+        vpc: testing_vpc
+        accounts:
+          deploy:
+            name: "prod-acc"
+            id: "9999999999"
+          dns:
+            name: "prod-dns-acc"
+            id: "7777777777"
+  prod-main:
+    account: prod-acc
+    branch: main
+    slack_channel: "/codebuild/slack_oauth_channel"
+    trigger_on_push: false
+    versions:
+      platform-helper: 9.0.9
+    environments:
+      prod:
+        requires_approval: true

--- a/platform-config.yml
+++ b/platform-config.yml
@@ -30,7 +30,7 @@ environments:
         id: "7777777777"
     requires_approval: true
     vpc: prod-vpc
-    
+
 environment_pipelines:
   main:
     account: non-prod-acc

--- a/platform_helper.py
+++ b/platform_helper.py
@@ -20,6 +20,7 @@ from dbt_platform_helper.commands.generate import generate as generate_commands
 from dbt_platform_helper.commands.notify import notify as notify_commands
 from dbt_platform_helper.commands.pipeline import pipeline as pipeline_commands
 from dbt_platform_helper.commands.secrets import secrets as secrets_commands
+from dbt_platform_helper.commands.version import version as version_commands
 from dbt_platform_helper.utils.click import ClickDocOptGroup
 
 
@@ -46,6 +47,7 @@ platform_helper.add_command(pipeline_commands)
 platform_helper.add_command(secrets_commands)
 platform_helper.add_command(notify_commands)
 platform_helper.add_command(database_commands)
+platform_helper.add_command(version_commands)
 
 if __name__ == "__main__":
     platform_helper()

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -521,6 +521,8 @@ environment_pipelines:
     branch: my-feature-branch
     slack_channel: "/codebuild/notification_channel"
     trigger_on_push: false
+    versions:
+        platform-helper: 1.2.3
     environments:
       test:
         requires_approval: true

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -396,6 +396,10 @@ def valid_platform_config():
 application: test-app
 legacy_project: true
 
+default_versions: 
+    platform-helper: 10.2.0
+    terraform-platform-modules: 1.2.3
+
 environments:
   "*":
     accounts:
@@ -406,16 +410,12 @@ environments:
         name: "non-prod-dns-acc"
         id: "6677889900"
     requires_approval: false
-    versions:
-        platform-helper: 10.2.0
     vpc: non-prod-vpc
   dev:
   test:
     versions:
         terraform-platform-modules: 1.2.3
   staging:
-    versions:
-        platform-helper: 10.2.0
   prod:
     accounts:
       deploy:

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -522,7 +522,7 @@ environment_pipelines:
     slack_channel: "/codebuild/notification_channel"
     trigger_on_push: false
     versions:
-        platform-helper: 1.2.3
+        platform-helper: main
     environments:
       test:
         requires_approval: true
@@ -539,6 +539,8 @@ environment_pipelines:
     branch: main
     slack_channel: "/codebuild/slack_oauth_channel"
     trigger_on_push: false
+    versions:
+        platform-helper: 9.0.9
     environments:
       prod:
         requires_approval: true

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -406,12 +406,16 @@ environments:
         name: "non-prod-dns-acc"
         id: "6677889900"
     requires_approval: false
+    versions:
+        platform-helper: 10.2.0
     vpc: non-prod-vpc
   dev:
   test:
     versions:
         terraform-platform-modules: 1.2.3
   staging:
+    versions:
+        platform-helper: 10.2.0
   prod:
     accounts:
       deploy:

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -12,6 +12,7 @@ import yaml
 from moto import mock_aws
 from moto.ec2 import utils as ec2_utils
 
+from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.utils.aws import AWS_SESSION_CACHE
 from dbt_platform_helper.utils.versioning import PlatformHelperVersions
 
@@ -592,3 +593,33 @@ def platform_env_config():
             },
         },
     }
+
+
+@pytest.fixture
+def s3_extensions_fixture(fakefs):
+    fakefs.create_file(
+        PLATFORM_CONFIG_FILE,
+        contents=yaml.dump(
+            {
+                "application": "my_app",
+                "extensions": {
+                    "one": {
+                        "type": "s3",
+                        "environments": {
+                            "env1": {"bucket_name": "bucket-one"},
+                            "env2": {"bucket_name": "bucket-two"},
+                        },
+                    },
+                    "two": {
+                        "type": "s3-policy",
+                        "environments": {
+                            "env3": {"bucket_name": "bucket-three"},
+                        },
+                    },
+                    "three": {
+                        "type": "s3",
+                    },
+                },
+            }
+        ),
+    )

--- a/tests/platform_helper/test_command_copilot.py
+++ b/tests/platform_helper/test_command_copilot.py
@@ -16,7 +16,7 @@ from moto import mock_aws
 
 from dbt_platform_helper.commands.copilot import copilot
 from dbt_platform_helper.commands.copilot import is_service
-from dbt_platform_helper.utils.files import PLATFORM_CONFIG_FILE
+from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.utils.validation import BUCKET_NAME_IN_USE_TEMPLATE
 from tests.platform_helper.conftest import FIXTURES_DIR
 from tests.platform_helper.conftest import mock_aws_client

--- a/tests/platform_helper/test_command_copilot.py
+++ b/tests/platform_helper/test_command_copilot.py
@@ -890,6 +890,7 @@ class TestMakeAddonCommand:
         "dbt_platform_helper.utils.versioning.running_as_installed_package",
         new=Mock(return_value=False),
     )
+    @patch("dbt_platform_helper.utils.validation.get_aws_session_or_abort", new=Mock())
     def test_exit_if_services_key_invalid(self, fakefs):
         """
         The services key can be set to a list of services, or '__all__' which

--- a/tests/platform_helper/test_command_environment.py
+++ b/tests/platform_helper/test_command_environment.py
@@ -12,8 +12,8 @@ import yaml
 from click.testing import CliRunner
 from moto import mock_aws
 
+from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.utils.application import Service
-from dbt_platform_helper.utils.files import PLATFORM_CONFIG_FILE
 from tests.platform_helper.conftest import BASE_DIR
 
 

--- a/tests/platform_helper/test_command_generate.py
+++ b/tests/platform_helper/test_command_generate.py
@@ -6,13 +6,8 @@ from click.testing import CliRunner
 from dbt_platform_helper.commands.generate import generate as platform_helper_generate
 from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_FILE
 from dbt_platform_helper.utils.versioning import PlatformHelperVersions
-from dbt_platform_helper.utils.versioning import generate_platform_helper_version_file
 
 
-@patch(
-    "dbt_platform_helper.commands.generate.generate_platform_helper_version_file",
-    new=Mock(return_value=None),
-)
 @patch("dbt_platform_helper.commands.generate.make_addons", return_value=None)
 @patch("dbt_platform_helper.commands.generate.pipeline_generate", return_value=None)
 def test_platform_helper_generate_creates_the_pipeline_configuration_and_addons(
@@ -38,10 +33,6 @@ def test_platform_helper_generate_creates_the_pipeline_configuration_and_addons(
 )
 @patch("dbt_platform_helper.commands.generate.make_addons", new=Mock(return_value=True))
 @patch("dbt_platform_helper.commands.generate.pipeline_generate", new=Mock(return_value=True))
-@patch(
-    "dbt_platform_helper.commands.generate.generate_platform_helper_version_file",
-    new=Mock(return_value=None),
-)
 def test_platform_helper_generate_shows_a_warning_when_version_is_different_than_on_file(
     mock_secho, tmp_path
 ):
@@ -59,25 +50,6 @@ def test_platform_helper_generate_shows_a_warning_when_version_is_different_than
 )
 @patch("dbt_platform_helper.commands.generate.make_addons", new=Mock(return_value=None))
 @patch("dbt_platform_helper.commands.generate.pipeline_generate", new=Mock(return_value=None))
-def test_platform_helper_generate_generates_version_file_if_not_exist(tmp_path):
-    contents = "1.0.0\n"
-    version_file_path = tmp_path / PLATFORM_HELPER_VERSION_FILE
-
-    assert not version_file_path.exists()
-
-    with patch.object(generate_platform_helper_version_file, "__defaults__", (tmp_path,)):
-        CliRunner().invoke(platform_helper_generate)
-
-    assert version_file_path.exists()
-    assert version_file_path.read_text() == contents
-
-
-@patch(
-    "dbt_platform_helper.utils.versioning.get_platform_helper_versions",
-    new=Mock(return_value=PlatformHelperVersions((1, 0, 0), (1, 0, 0))),
-)
-@patch("dbt_platform_helper.commands.generate.make_addons", new=Mock(return_value=None))
-@patch("dbt_platform_helper.commands.generate.pipeline_generate", new=Mock(return_value=None))
 def test_platform_helper_generate_does_not_override_version_file_if_exists(tmp_path):
     contents = "2.0.0"
     version_file_path = tmp_path / PLATFORM_HELPER_VERSION_FILE
@@ -86,8 +58,7 @@ def test_platform_helper_generate_does_not_override_version_file_if_exists(tmp_p
 
     assert version_file_path.exists()
 
-    with patch.object(generate_platform_helper_version_file, "__defaults__", (tmp_path,)):
-        CliRunner().invoke(platform_helper_generate)
+    CliRunner().invoke(platform_helper_generate)
 
     assert version_file_path.exists()
     assert version_file_path.read_text() == contents

--- a/tests/platform_helper/test_command_generate.py
+++ b/tests/platform_helper/test_command_generate.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from dbt_platform_helper.commands.generate import generate as platform_helper_generate
+from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_FILE
 from dbt_platform_helper.utils.versioning import PlatformHelperVersions
 from dbt_platform_helper.utils.versioning import generate_platform_helper_version_file
 
@@ -47,7 +48,7 @@ def test_platform_helper_generate_shows_a_warning_when_version_is_different_than
     CliRunner().invoke(platform_helper_generate)
 
     mock_secho.assert_called_once_with(
-        f"WARNING: You are running platform-helper v1.0.1 against v1.0.0 specified by .platform-helper-version.",
+        f"WARNING: You are running platform-helper v1.0.1 against v1.0.0 specified by {PLATFORM_HELPER_VERSION_FILE}.",
         fg="red",
     )
 
@@ -60,7 +61,7 @@ def test_platform_helper_generate_shows_a_warning_when_version_is_different_than
 @patch("dbt_platform_helper.commands.generate.pipeline_generate", new=Mock(return_value=None))
 def test_platform_helper_generate_generates_version_file_if_not_exist(tmp_path):
     contents = "1.0.0\n"
-    version_file_path = tmp_path / ".platform-helper-version"
+    version_file_path = tmp_path / PLATFORM_HELPER_VERSION_FILE
 
     assert not version_file_path.exists()
 
@@ -79,7 +80,7 @@ def test_platform_helper_generate_generates_version_file_if_not_exist(tmp_path):
 @patch("dbt_platform_helper.commands.generate.pipeline_generate", new=Mock(return_value=None))
 def test_platform_helper_generate_does_not_override_version_file_if_exists(tmp_path):
     contents = "2.0.0"
-    version_file_path = tmp_path / ".platform-helper-version"
+    version_file_path = tmp_path / PLATFORM_HELPER_VERSION_FILE
     version_file_path.touch()
     version_file_path.write_text(contents)
 

--- a/tests/platform_helper/test_command_pipeline.py
+++ b/tests/platform_helper/test_command_pipeline.py
@@ -9,7 +9,7 @@ from freezegun.api import freeze_time
 
 from dbt_platform_helper.commands.pipeline import CODEBASE_PIPELINES_KEY
 from dbt_platform_helper.commands.pipeline import generate
-from dbt_platform_helper.utils.files import PLATFORM_CONFIG_FILE
+from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from tests.platform_helper.conftest import EXPECTED_FILES_DIR
 from tests.platform_helper.conftest import FIXTURES_DIR
 from tests.platform_helper.conftest import assert_file_created_in_stdout

--- a/tests/platform_helper/test_command_version.py
+++ b/tests/platform_helper/test_command_version.py
@@ -1,0 +1,9 @@
+def test_calls_versioning_function():
+    # result = CliRunner().invoke(
+    #    required,
+    #    ["development", "newenv", "--project-profile", "foo"],
+    # )
+
+    # assert result.exit_code == 0
+    # assert "1.2.3" == result.output
+    pass

--- a/tests/platform_helper/test_command_version.py
+++ b/tests/platform_helper/test_command_version.py
@@ -1,9 +1,32 @@
-def test_calls_versioning_function():
-    # result = CliRunner().invoke(
-    #    required,
-    #    ["development", "newenv", "--project-profile", "foo"],
-    # )
+import re
+from unittest.mock import patch
 
-    # assert result.exit_code == 0
-    # assert "1.2.3" == result.output
-    pass
+from click.testing import CliRunner
+
+from dbt_platform_helper.commands.version import print_desired
+
+
+@patch("dbt_platform_helper.commands.version.get_desired_platform_helper_version")
+def test_calls_versioning_function_and_prints_returned_version(
+    mock_get_desired_platform_helper_version,
+):
+    mock_get_desired_platform_helper_version.return_value = "1.2.3"
+    result = CliRunner().invoke(print_desired, [])
+
+    assert len(mock_get_desired_platform_helper_version.mock_calls) == 1
+    assert mock_get_desired_platform_helper_version.mock_calls[0].args == (None,)
+    assert result.exit_code == 0
+    assert re.match(r"\s*1\.2\.3\s*", result.output)
+
+
+@patch("dbt_platform_helper.commands.version.get_desired_platform_helper_version")
+def test_calls_versioning_function_and_prints_returned_version_with_pipeline_override(
+    mock_get_desired_platform_helper_version,
+):
+    mock_get_desired_platform_helper_version.return_value = "1.2.3"
+    result = CliRunner().invoke(print_desired, ["--pipeline", "main"])
+
+    assert len(mock_get_desired_platform_helper_version.mock_calls) == 1
+    assert mock_get_desired_platform_helper_version.mock_calls[0].args == ("main",)
+    assert result.exit_code == 0
+    assert re.match(r"\s*1\.2\.3\s*", result.output)

--- a/tests/platform_helper/test_command_version.py
+++ b/tests/platform_helper/test_command_version.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import yaml
 from click.testing import CliRunner
 
-from dbt_platform_helper.commands.version import get_platform_helper_for_app
+from dbt_platform_helper.commands.version import get_platform_helper_for_project
 from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 
 
@@ -18,7 +18,7 @@ def test_calls_versioning_function_and_prints_returned_version(
     fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
     mock_get_required_platform_helper_version.return_value = "1.2.3"
 
-    result = CliRunner().invoke(get_platform_helper_for_app, [])
+    result = CliRunner().invoke(get_platform_helper_for_project, [])
 
     assert len(mock_get_required_platform_helper_version.mock_calls) == 1
     assert mock_get_required_platform_helper_version.mock_calls[0].args == (None,)
@@ -35,7 +35,7 @@ def test_calls_versioning_function_and_prints_returned_version_with_pipeline_ove
     fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
     mock_get_required_platform_helper_version.return_value = "1.2.3"
 
-    result = CliRunner().invoke(get_platform_helper_for_app, ["--pipeline", "main"])
+    result = CliRunner().invoke(get_platform_helper_for_project, ["--pipeline", "main"])
 
     assert len(mock_get_required_platform_helper_version.mock_calls) == 1
     assert mock_get_required_platform_helper_version.mock_calls[0].args == ("main",)
@@ -49,7 +49,7 @@ def test_fail_if_pipeline_option_is_not_a_pipeline(
 ):
     fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
 
-    result = CliRunner().invoke(get_platform_helper_for_app, ["--pipeline", "bogus"])
+    result = CliRunner().invoke(get_platform_helper_for_project, ["--pipeline", "bogus"])
 
     assert result.exit_code != 0
     assert "'bogus' is not one of" in result.output

--- a/tests/platform_helper/test_command_version.py
+++ b/tests/platform_helper/test_command_version.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import yaml
 from click.testing import CliRunner
 
-from dbt_platform_helper.commands.version import get_required_platform_helper
+from dbt_platform_helper.commands.version import get_platform_helper_for_app
 from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 
 
@@ -18,7 +18,7 @@ def test_calls_versioning_function_and_prints_returned_version(
     fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
     mock_get_required_platform_helper_version.return_value = "1.2.3"
 
-    result = CliRunner().invoke(get_required_platform_helper, [])
+    result = CliRunner().invoke(get_platform_helper_for_app, [])
 
     assert len(mock_get_required_platform_helper_version.mock_calls) == 1
     assert mock_get_required_platform_helper_version.mock_calls[0].args == (None,)
@@ -35,7 +35,7 @@ def test_calls_versioning_function_and_prints_returned_version_with_pipeline_ove
     fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
     mock_get_required_platform_helper_version.return_value = "1.2.3"
 
-    result = CliRunner().invoke(get_required_platform_helper, ["--pipeline", "main"])
+    result = CliRunner().invoke(get_platform_helper_for_app, ["--pipeline", "main"])
 
     assert len(mock_get_required_platform_helper_version.mock_calls) == 1
     assert mock_get_required_platform_helper_version.mock_calls[0].args == ("main",)
@@ -49,7 +49,7 @@ def test_fail_if_pipeline_option_is_not_a_pipeline(
 ):
     fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
 
-    result = CliRunner().invoke(get_required_platform_helper, ["--pipeline", "bogus"])
+    result = CliRunner().invoke(get_platform_helper_for_app, ["--pipeline", "bogus"])
 
     assert result.exit_code != 0
     assert "'bogus' is not one of" in result.output

--- a/tests/platform_helper/test_command_version.py
+++ b/tests/platform_helper/test_command_version.py
@@ -5,40 +5,40 @@ from unittest.mock import patch
 import yaml
 from click.testing import CliRunner
 
-from dbt_platform_helper.commands.version import print_desired
+from dbt_platform_helper.commands.version import get_required_platform_helper
 from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 
 
-@patch("dbt_platform_helper.commands.version.get_desired_platform_helper_version")
+@patch("dbt_platform_helper.commands.version.get_required_platform_helper_version")
 def test_calls_versioning_function_and_prints_returned_version(
-    mock_get_desired_platform_helper_version,
+    mock_get_required_platform_helper_version,
     fakefs,
     valid_platform_config,
 ):
     fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
-    mock_get_desired_platform_helper_version.return_value = "1.2.3"
+    mock_get_required_platform_helper_version.return_value = "1.2.3"
 
-    result = CliRunner().invoke(print_desired, [])
+    result = CliRunner().invoke(get_required_platform_helper, [])
 
-    assert len(mock_get_desired_platform_helper_version.mock_calls) == 1
-    assert mock_get_desired_platform_helper_version.mock_calls[0].args == (None,)
+    assert len(mock_get_required_platform_helper_version.mock_calls) == 1
+    assert mock_get_required_platform_helper_version.mock_calls[0].args == (None,)
     assert result.exit_code == 0
     assert re.match(r"\s*1\.2\.3\s*", result.output)
 
 
-@patch("dbt_platform_helper.commands.version.get_desired_platform_helper_version")
+@patch("dbt_platform_helper.commands.version.get_required_platform_helper_version")
 def test_calls_versioning_function_and_prints_returned_version_with_pipeline_override(
-    mock_get_desired_platform_helper_version,
+    mock_get_required_platform_helper_version,
     fakefs,
     valid_platform_config,
 ):
     fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
-    mock_get_desired_platform_helper_version.return_value = "1.2.3"
+    mock_get_required_platform_helper_version.return_value = "1.2.3"
 
-    result = CliRunner().invoke(print_desired, ["--pipeline", "main"])
+    result = CliRunner().invoke(get_required_platform_helper, ["--pipeline", "main"])
 
-    assert len(mock_get_desired_platform_helper_version.mock_calls) == 1
-    assert mock_get_desired_platform_helper_version.mock_calls[0].args == ("main",)
+    assert len(mock_get_required_platform_helper_version.mock_calls) == 1
+    assert mock_get_required_platform_helper_version.mock_calls[0].args == ("main",)
     assert result.exit_code == 0
     assert re.match(r"\s*1\.2\.3\s*", result.output)
 
@@ -49,7 +49,7 @@ def test_fail_if_pipeline_option_is_not_a_pipeline(
 ):
     fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
 
-    result = CliRunner().invoke(print_desired, ["--pipeline", "bogus"])
+    result = CliRunner().invoke(get_required_platform_helper, ["--pipeline", "bogus"])
 
     assert result.exit_code != 0
     assert "'bogus' is not one of" in result.output

--- a/tests/platform_helper/test_command_version.py
+++ b/tests/platform_helper/test_command_version.py
@@ -1,16 +1,23 @@
 import re
+from pathlib import Path
 from unittest.mock import patch
 
+import yaml
 from click.testing import CliRunner
 
 from dbt_platform_helper.commands.version import print_desired
+from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 
 
 @patch("dbt_platform_helper.commands.version.get_desired_platform_helper_version")
 def test_calls_versioning_function_and_prints_returned_version(
     mock_get_desired_platform_helper_version,
+    fakefs,
+    valid_platform_config,
 ):
+    fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
     mock_get_desired_platform_helper_version.return_value = "1.2.3"
+
     result = CliRunner().invoke(print_desired, [])
 
     assert len(mock_get_desired_platform_helper_version.mock_calls) == 1
@@ -22,11 +29,28 @@ def test_calls_versioning_function_and_prints_returned_version(
 @patch("dbt_platform_helper.commands.version.get_desired_platform_helper_version")
 def test_calls_versioning_function_and_prints_returned_version_with_pipeline_override(
     mock_get_desired_platform_helper_version,
+    fakefs,
+    valid_platform_config,
 ):
+    fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
     mock_get_desired_platform_helper_version.return_value = "1.2.3"
+
     result = CliRunner().invoke(print_desired, ["--pipeline", "main"])
 
     assert len(mock_get_desired_platform_helper_version.mock_calls) == 1
     assert mock_get_desired_platform_helper_version.mock_calls[0].args == ("main",)
     assert result.exit_code == 0
     assert re.match(r"\s*1\.2\.3\s*", result.output)
+
+
+def test_fail_if_pipeline_option_is_not_a_pipeline(
+    fakefs,
+    valid_platform_config,
+):
+    fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
+
+    result = CliRunner().invoke(print_desired, ["--pipeline", "bogus"])
+
+    assert result.exit_code != 0
+    assert "'bogus' is not one of" in result.output
+    assert "'main'" in result.output

--- a/tests/platform_helper/test_platform_helper.py
+++ b/tests/platform_helper/test_platform_helper.py
@@ -33,4 +33,5 @@ class TestCopilotHelperCli:
             "secrets",
             "notify",
             "database",
+            "version",
         ]

--- a/tests/platform_helper/utils/test_files.py
+++ b/tests/platform_helper/utils/test_files.py
@@ -114,49 +114,100 @@ def test_apply_defaults():
     assert result == {
         "application": "my-app",
         "environments": {
-            "one": {"a": "aaa", "b": {"c": "ccc"}},
-            "two": {"a": "aaa", "b": {"c": "ccc"}},
-            "three": {"a": "override_aaa", "b": {"d": "ddd"}, "c": "ccc"},
+            "one": {"a": "aaa", "b": {"c": "ccc"}, "versions": {}},
+            "two": {"a": "aaa", "b": {"c": "ccc"}, "versions": {}},
+            "three": {"a": "override_aaa", "b": {"d": "ddd"}, "c": "ccc", "versions": {}},
         },
     }
 
 
 @pytest.mark.parametrize(
-    "env_config, expected_result",
+    "default_versions, env_default_versions, env_versions, expected_result",
     [
-        (None, {"platform-helper": "10.0.0"}),
-        ({}, {"platform-helper": "10.0.0"}),
+        # Empty cases
+        (None, None, None, {}),
+        (None, None, {}, {}),
+        (None, {}, None, {}),
+        ({}, None, None, {}),
+        # Env versions populated
         (
-            {"versions": {"platform-helper": "8.0.0", "terraform-platform-modules": "1.0.0"}},
+            None,
+            None,
+            {"platform-helper": "8.0.0", "terraform-platform-modules": "1.0.0"},
             {"platform-helper": "8.0.0", "terraform-platform-modules": "1.0.0"},
         ),
         (
-            {"versions": {"terraform-platform-modules": "2.0.0"}},
+            None,
+            None,
+            {"terraform-platform-modules": "2.0.0"},
+            {"terraform-platform-modules": "2.0.0"},
+        ),
+        (None, None, {"platform-helper": "9.0.0"}, {"platform-helper": "9.0.0"}),
+        # env_default_versions populated
+        (None, {"platform-helper": "10.0.0"}, None, {"platform-helper": "10.0.0"}),
+        (None, {"platform-helper": "10.0.0"}, {}, {"platform-helper": "10.0.0"}),
+        (
+            None,
+            {"platform-helper": "10.0.0"},
+            {"platform-helper": "8.0.0", "terraform-platform-modules": "1.0.0"},
+            {"platform-helper": "8.0.0", "terraform-platform-modules": "1.0.0"},
+        ),
+        (
+            None,
+            {"platform-helper": "10.0.0"},
+            {"terraform-platform-modules": "2.0.0"},
             {"platform-helper": "10.0.0", "terraform-platform-modules": "2.0.0"},
         ),
-        ({"versions": {"platform-helper": "9.0.0"}}, {"platform-helper": "9.0.0"}),
+        # default_versions populated
+        (
+            None,
+            {"platform-helper": "10.0.0"},
+            {"platform-helper": "9.0.0"},
+            {"platform-helper": "9.0.0"},
+        ),
+        (
+            {"terraform-platform-modules": "1.0.0"},
+            None,
+            None,
+            {"terraform-platform-modules": "1.0.0"},
+        ),
+        (
+            {"terraform-platform-modules": "2.0.0"},
+            {"terraform-platform-modules": "3.0.0"},
+            None,
+            {"terraform-platform-modules": "3.0.0"},
+        ),
+        (
+            {"terraform-platform-modules": "3.0.0"},
+            None,
+            {"terraform-platform-modules": "4.0.0"},
+            {"terraform-platform-modules": "4.0.0"},
+        ),
+        (
+            {"terraform-platform-modules": "4.0.0"},
+            {"terraform-platform-modules": "5.0.0"},
+            {"terraform-platform-modules": "6.0.0"},
+            {"terraform-platform-modules": "6.0.0"},
+        ),
     ],
 )
-def test_apply_defaults_for_versions(env_config, expected_result):
-    config = {
-        "application": "my-app",
-        "environments": {"*": {"versions": {"platform-helper": "10.0.0"}}, "one": env_config},
-    }
-
-    result = apply_environment_defaults(config)
-
-    assert result["environments"]["one"]["versions"] == expected_result
-
-
-def test_apply_defaults_when_versions_missing():
+def test_apply_defaults_for_versions(
+    default_versions, env_default_versions, env_versions, expected_result
+):
     config = {
         "application": "my-app",
         "environments": {"*": {}, "one": {}},
     }
+    if default_versions:
+        config["default_versions"] = default_versions
+    if env_default_versions:
+        config["environments"]["*"]["versions"] = env_default_versions
+    if env_versions:
+        config["environments"]["one"]["versions"] = env_versions
 
     result = apply_environment_defaults(config)
 
-    assert result["environments"]["one"] == {}
+    assert result["environments"]["one"].get("versions") == expected_result
 
 
 def test_apply_defaults_with_no_defaults():
@@ -175,7 +226,11 @@ def test_apply_defaults_with_no_defaults():
 
     assert result == {
         "application": "my-app",
-        "environments": {"one": {}, "two": {}, "three": {"a": "aaa"}},
+        "environments": {
+            "one": {"versions": {}},
+            "two": {"versions": {}},
+            "three": {"a": "aaa", "versions": {}},
+        },
     }
 
 

--- a/tests/platform_helper/utils/test_files.py
+++ b/tests/platform_helper/utils/test_files.py
@@ -121,6 +121,44 @@ def test_apply_defaults():
     }
 
 
+@pytest.mark.parametrize(
+    "env_config, expected_result",
+    [
+        (None, {"platform-helper": "10.0.0"}),
+        ({}, {"platform-helper": "10.0.0"}),
+        (
+            {"versions": {"platform-helper": "8.0.0", "terraform-platform-modules": "1.0.0"}},
+            {"platform-helper": "8.0.0", "terraform-platform-modules": "1.0.0"},
+        ),
+        (
+            {"versions": {"terraform-platform-modules": "2.0.0"}},
+            {"platform-helper": "10.0.0", "terraform-platform-modules": "2.0.0"},
+        ),
+        ({"versions": {"platform-helper": "9.0.0"}}, {"platform-helper": "9.0.0"}),
+    ],
+)
+def test_apply_defaults_for_versions(env_config, expected_result):
+    config = {
+        "application": "my-app",
+        "environments": {"*": {"versions": {"platform-helper": "10.0.0"}}, "one": env_config},
+    }
+
+    result = apply_environment_defaults(config)
+
+    assert result["environments"]["one"]["versions"] == expected_result
+
+
+def test_apply_defaults_when_versions_missing():
+    config = {
+        "application": "my-app",
+        "environments": {"*": {}, "one": {}},
+    }
+
+    result = apply_environment_defaults(config)
+
+    assert result["environments"]["one"] == {}
+
+
 def test_apply_defaults_with_no_defaults():
     config = {
         "application": "my-app",

--- a/tests/platform_helper/utils/test_files.py
+++ b/tests/platform_helper/utils/test_files.py
@@ -3,11 +3,9 @@ from pathlib import Path
 
 import pytest
 
-from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.utils.files import apply_environment_defaults
 from dbt_platform_helper.utils.files import generate_override_files
 from dbt_platform_helper.utils.files import generate_override_files_from_template
-from dbt_platform_helper.utils.files import is_terraform_project
 from dbt_platform_helper.utils.files import mkfile
 
 
@@ -232,17 +230,3 @@ def test_apply_defaults_with_no_defaults():
             "three": {"a": "aaa", "versions": {}},
         },
     }
-
-
-@pytest.mark.parametrize(
-    "platform_config_content, expected_result",
-    [
-        ("application: my-app\nlegacy_project: True", False),
-        ("application: my-app\nlegacy_project: False", True),
-        ("application: my-app", True),
-    ],
-)
-def test_is_terraform_project(fakefs, platform_config_content, expected_result):
-    fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=platform_config_content)
-
-    assert is_terraform_project() == expected_result

--- a/tests/platform_helper/utils/test_platform_config.py
+++ b/tests/platform_helper/utils/test_platform_config.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
+from dbt_platform_helper.utils.platform_config import get_environment_pipeline_names
+from dbt_platform_helper.utils.platform_config import is_terraform_project
+
+
+def test_get_environment_pipeline_names(fakefs, valid_platform_config):
+    fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(valid_platform_config))
+
+    names = get_environment_pipeline_names()
+
+    assert {"main", "test", "prod-main"} == names
+
+
+def test_get_environment_pipeline_names_defaults_to_empty_list_when_theres_no_platform_config(
+    fakefs,
+):
+    names = get_environment_pipeline_names()
+
+    assert {} == names
+
+
+@pytest.mark.parametrize(
+    "platform_config_content, expected_result",
+    [
+        ("application: my-app\nlegacy_project: True", False),
+        ("application: my-app\nlegacy_project: False", True),
+        ("application: my-app", True),
+    ],
+)
+def test_is_terraform_project(fakefs, platform_config_content, expected_result):
+    fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=platform_config_content)
+
+    assert is_terraform_project() == expected_result

--- a/tests/platform_helper/utils/test_validation.py
+++ b/tests/platform_helper/utils/test_validation.py
@@ -685,6 +685,17 @@ def test_aws_validation_does_not_warn_for_duplicate_s3_bucket_names_if_aws_valid
     assert not mock_get_session.called
 
 
+@patch("dbt_platform_helper.utils.validation.get_aws_session_or_abort", new=Mock())
+@patch("dbt_platform_helper.utils.validation.config_file_check")
+def test_load_and_validate_platform_config_skips_file_check_when_disable_file_check_parameter_passed(
+    mock_config_file_check, capfd, fakefs
+):
+    fakefs.create_file(PLATFORM_CONFIG_FILE, contents=yaml.dump({"application": "my_app"}))
+    load_and_validate_platform_config(disable_file_check=True)
+
+    assert not mock_config_file_check.called
+
+
 @pytest.mark.parametrize(
     "files, expected_messages",
     [

--- a/tests/platform_helper/utils/test_validation.py
+++ b/tests/platform_helper/utils/test_validation.py
@@ -697,51 +697,26 @@ def test_aws_validation_does_not_warn_for_duplicate_s3_bucket_names_if_aws_valid
         (
             ["storage.yml"],
             [
-                f"`storage.yml` is no longer supported. Please move its contents into a file named `{PLATFORM_CONFIG_FILE}` under the key 'extensions' and delete `storage.yml`."
+                f"`storage.yml` is no longer supported. Please move its contents into the `{PLATFORM_CONFIG_FILE}` file under the key 'extensions' and delete `storage.yml`."
             ],
         ),
         (
             ["extensions.yml"],
             [
-                f"`extensions.yml` is no longer supported. Please move its contents into a file named `{PLATFORM_CONFIG_FILE}` under the key 'extensions' and delete `extensions.yml`."
+                f"`extensions.yml` is no longer supported. Please move its contents into the `{PLATFORM_CONFIG_FILE}` file under the key 'extensions' and delete `extensions.yml`."
             ],
         ),
         (
             ["pipelines.yml"],
             [
-                f"`pipelines.yml` is no longer supported. Please move its contents into a file named `{PLATFORM_CONFIG_FILE}`, change the key 'codebases' to 'codebase_pipelines' and delete `pipelines.yml`."
+                f"`pipelines.yml` is no longer supported. Please move its contents into the `{PLATFORM_CONFIG_FILE}` file, change the key 'codebases' to 'codebase_pipelines' and delete `pipelines.yml`."
             ],
         ),
         (
             ["storage.yml", "pipelines.yml"],
             [
-                f"`storage.yml` is no longer supported. Please move its contents into a file named `{PLATFORM_CONFIG_FILE}` under the key 'extensions' and delete `storage.yml`.",
-                f"`pipelines.yml` is no longer supported. Please move its contents into a file named `{PLATFORM_CONFIG_FILE}`, change the key 'codebases' to 'codebase_pipelines' and delete `pipelines.yml`.",
-            ],
-        ),
-        (
-            [PLATFORM_CONFIG_FILE, "storage.yml"],
-            [
-                f"`storage.yml` has been superseded by `{PLATFORM_CONFIG_FILE}` and should be deleted."
-            ],
-        ),
-        (
-            [PLATFORM_CONFIG_FILE, "extensions.yml"],
-            [
-                f"`extensions.yml` has been superseded by `{PLATFORM_CONFIG_FILE}` and should be deleted."
-            ],
-        ),
-        (
-            [PLATFORM_CONFIG_FILE, "pipelines.yml"],
-            [
-                f"`pipelines.yml` has been superseded by `{PLATFORM_CONFIG_FILE}` and should be deleted."
-            ],
-        ),
-        (
-            [PLATFORM_CONFIG_FILE, "pipelines.yml", "extensions.yml"],
-            [
-                f"`pipelines.yml` has been superseded by `{PLATFORM_CONFIG_FILE}` and should be deleted.",
-                f"`extensions.yml` has been superseded by `{PLATFORM_CONFIG_FILE}` and should be deleted.",
+                f"`storage.yml` is no longer supported. Please move its contents into the `{PLATFORM_CONFIG_FILE}` file under the key 'extensions' and delete `storage.yml`.",
+                f"`pipelines.yml` is no longer supported. Please move its contents into the `{PLATFORM_CONFIG_FILE}` file, change the key 'codebases' to 'codebase_pipelines' and delete `pipelines.yml`.",
             ],
         ),
     ],
@@ -767,14 +742,9 @@ def test_config_file_check_fails_for_unsupported_files_exist(
         (
             [".platform-helper-version"],
             [
-                f"`.platform-helper-version` is no longer supported. Please move its contents into a file named `{PLATFORM_CONFIG_FILE}`,"
+                f"`.platform-helper-version` is no longer supported. "
+                f"Please move its contents into the `{PLATFORM_CONFIG_FILE}` file,"
                 " under the key `default_versions: platform-helper:` and delete `.platform-helper-version`."
-            ],
-        ),
-        (
-            [PLATFORM_CONFIG_FILE, ".platform-helper-version"],
-            [
-                f"`.platform-helper-version` has been superseded by `{PLATFORM_CONFIG_FILE}` and should be deleted."
             ],
         ),
     ],

--- a/tests/platform_helper/utils/test_validation.py
+++ b/tests/platform_helper/utils/test_validation.py
@@ -596,30 +596,44 @@ def test_validation_fails_if_invalid_default_version_keys_present(
     assert "Wrong key 'something-invalid'" in str(ex)
 
 
+@pytest.mark.parametrize(
+    "invalid_key",
+    (
+        "",
+        "invalid-key",
+        "platform-helper",  # platform-helper is not valid in the environment overrides.
+    ),
+)
 def test_validation_fails_if_invalid_environment_version_override_keys_present(
-    fakefs, capsys, valid_platform_config
+    invalid_key, fakefs, capsys, valid_platform_config
 ):
-    valid_platform_config["environments"]["*"]["versions"] = {"platform-helper": "1.2.3"}
+    valid_platform_config["environments"]["*"]["versions"] = {invalid_key: "1.2.3"}
     Path(PLATFORM_CONFIG_FILE).write_text(yaml.dump(valid_platform_config))
 
     with pytest.raises(SchemaError) as ex:
         load_and_validate_platform_config()
 
-    assert "Wrong key 'platform-helper'" in str(ex)
+    assert f"Wrong key '{invalid_key}'" in str(ex)
 
 
+@pytest.mark.parametrize(
+    "invalid_key",
+    (
+        "",
+        "invalid-key",
+        "terraform-platform-modules",  # terraform-platform-modules is not valid in the pipeline overrides.
+    ),
+)
 def test_validation_fails_if_invalid_pipeline_version_override_keys_present(
-    fakefs, capsys, valid_platform_config
+    invalid_key, fakefs, capsys, valid_platform_config
 ):
-    valid_platform_config["environment_pipelines"]["test"]["versions"][
-        "terraform-platform-modules"
-    ] = "1.2.3"
+    valid_platform_config["environment_pipelines"]["test"]["versions"][invalid_key] = "1.2.3"
     Path(PLATFORM_CONFIG_FILE).write_text(yaml.dump(valid_platform_config))
 
     with pytest.raises(SchemaError) as ex:
         load_and_validate_platform_config()
 
-    assert "Wrong key 'terraform-platform-modules'" in str(ex)
+    assert f"Wrong key '{invalid_key}'" in str(ex)
 
 
 def test_load_and_validate_platform_config_fails_with_invalid_yaml(fakefs, capsys):

--- a/tests/platform_helper/utils/test_validation.py
+++ b/tests/platform_helper/utils/test_validation.py
@@ -11,6 +11,7 @@ from moto import mock_aws
 from schema import SchemaError
 
 from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
+from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_FILE
 from dbt_platform_helper.utils.validation import AVAILABILITY_UNCERTAIN_TEMPLATE
 from dbt_platform_helper.utils.validation import BUCKET_NAME_IN_USE_TEMPLATE
 from dbt_platform_helper.utils.validation import S3_BUCKET_NAME_ERROR_TEMPLATE
@@ -751,11 +752,11 @@ def test_config_file_check_fails_for_unsupported_files_exist(
     "files, expected_messages",
     [
         (
-            [".platform-helper-version"],
+            [PLATFORM_HELPER_VERSION_FILE],
             [
-                f"`.platform-helper-version` is no longer supported. "
+                f"`{PLATFORM_HELPER_VERSION_FILE}` is no longer supported. "
                 f"Please move its contents into the `{PLATFORM_CONFIG_FILE}` file,"
-                " under the key `default_versions: platform-helper:` and delete `.platform-helper-version`."
+                f" under the key `default_versions: platform-helper:` and delete `{PLATFORM_HELPER_VERSION_FILE}`."
             ],
         ),
     ],

--- a/tests/platform_helper/utils/test_validation.py
+++ b/tests/platform_helper/utils/test_validation.py
@@ -746,7 +746,7 @@ def test_aws_validation_does_not_warn_for_duplicate_s3_bucket_names_if_aws_valid
         ),
     ],
 )
-def test_file_compatibility_check_fails_if_platform_config_not_present(
+def test_config_file_check_fails_for_unsupported_files_exist(
     fakefs, capsys, files, expected_messages
 ):
     for file in files:
@@ -754,6 +754,38 @@ def test_file_compatibility_check_fails_if_platform_config_not_present(
 
     with pytest.raises(SystemExit):
         config_file_check()
+
+    console_message = capsys.readouterr().out
+
+    for expected_message in expected_messages:
+        assert expected_message in console_message
+
+
+@pytest.mark.parametrize(
+    "files, expected_messages",
+    [
+        (
+            [".platform-helper-version"],
+            [
+                f"`.platform-helper-version` is no longer supported. Please move its contents into a file named `{PLATFORM_CONFIG_FILE}`,"
+                " under the key `default_versions: platform-helper:` and delete `.platform-helper-version`."
+            ],
+        ),
+        (
+            [PLATFORM_CONFIG_FILE, ".platform-helper-version"],
+            [
+                f"`.platform-helper-version` has been superseded by `{PLATFORM_CONFIG_FILE}` and should be deleted."
+            ],
+        ),
+    ],
+)
+def test_config_file_check_warns_if_deprecated_files_exist(
+    fakefs, capsys, files, expected_messages
+):
+    for file in files:
+        fakefs.create_file(file)
+
+    config_file_check()
 
     console_message = capsys.readouterr().out
 

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -15,6 +15,8 @@ from dbt_platform_helper.utils.versioning import check_platform_helper_version_m
 from dbt_platform_helper.utils.versioning import (
     check_platform_helper_version_needs_update,
 )
+from dbt_platform_helper.utils.versioning import get_aws_versions
+from dbt_platform_helper.utils.versioning import get_copilot_versions
 from dbt_platform_helper.utils.versioning import get_github_released_version
 from dbt_platform_helper.utils.versioning import get_platform_helper_versions
 from dbt_platform_helper.utils.versioning import parse_version
@@ -242,9 +244,22 @@ def test_platform_helper_version_file_does_not_exist(mock_version, mock_get, sec
     )
 
 
-def test_get_copilot_versions():
-    pass
+@patch("subprocess.run")
+@patch("dbt_platform_helper.utils.versioning.get_github_released_version", return_value=(2, 0, 0))
+def test_get_copilot_versions(mock_get_github_released_version, mock_run):
+    mock_run.return_value.stdout = b"1.0.0"
+
+    versions = get_copilot_versions()
+
+    assert versions.local_version == (1, 0, 0)
+    assert versions.latest_release == (2, 0, 0)
 
 
-def test_get_aws_versions():
-    pass
+@patch("subprocess.run")
+@patch("dbt_platform_helper.utils.versioning.get_github_released_version", return_value=(2, 0, 0))
+def test_get_aws_versions(mock_get_github_released_version, mock_run):
+    mock_run.return_value.stdout = b"aws-cli/1.0.0"
+    versions = get_aws_versions()
+
+    assert versions.local_version == (1, 0, 0)
+    assert versions.latest_release == (2, 0, 0)

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -20,9 +20,9 @@ from dbt_platform_helper.utils.versioning import (
 )
 from dbt_platform_helper.utils.versioning import get_aws_versions
 from dbt_platform_helper.utils.versioning import get_copilot_versions
-from dbt_platform_helper.utils.versioning import get_desired_platform_helper_version
 from dbt_platform_helper.utils.versioning import get_github_released_version
 from dbt_platform_helper.utils.versioning import get_platform_helper_versions
+from dbt_platform_helper.utils.versioning import get_required_platform_helper_version
 from dbt_platform_helper.utils.versioning import parse_version
 from dbt_platform_helper.utils.versioning import string_version
 from dbt_platform_helper.utils.versioning import validate_template_version
@@ -321,7 +321,7 @@ def test_get_aws_versions(mock_get_github_released_version, mock_run):
 @patch("dbt_platform_helper.utils.versioning.version", return_value="0.0.0")
 @patch("requests.get")
 @patch("dbt_platform_helper.utils.validation.get_aws_session_or_abort", new=Mock())
-def test_get_desired_platform_helper_version(
+def test_get_required_platform_helper_version(
     mock_get,
     mock_version,
     fakefs,
@@ -347,9 +347,9 @@ def test_get_desired_platform_helper_version(
 
     Path(PLATFORM_CONFIG_FILE).write_text(yaml.dump(platform_config))
 
-    desired_version = get_desired_platform_helper_version()
+    required_version = get_required_platform_helper_version()
 
-    assert desired_version == expected_version
+    assert required_version == expected_version
 
 
 @pytest.mark.parametrize(
@@ -366,7 +366,7 @@ def test_get_desired_platform_helper_version(
 @patch("dbt_platform_helper.utils.versioning.version", return_value="0.0.0")
 @patch("requests.get")
 @patch("dbt_platform_helper.utils.validation.get_aws_session_or_abort", new=Mock())
-def test_get_desired_platform_helper_version_in_pipeline(
+def test_get_required_platform_helper_version_in_pipeline(
     mock_get,
     mock_version,
     fakefs,
@@ -398,6 +398,6 @@ def test_get_desired_platform_helper_version_in_pipeline(
 
     Path(PLATFORM_CONFIG_FILE).write_text(yaml.dump(platform_config))
 
-    desired_version = get_desired_platform_helper_version("main")
+    required_version = get_required_platform_helper_version("main")
 
-    assert desired_version == expected_version
+    assert required_version == expected_version

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -214,25 +214,22 @@ def test_check_platform_helper_version_skips_when_skip_environment_variable_is_s
 @patch("requests.get")
 @patch("dbt_platform_helper.utils.versioning.version")
 @patch("dbt_platform_helper.utils.validation.get_aws_session_or_abort", new=Mock())
-def test_get_platform_helper_versions(mock_version, mock_get, fakefs):
-    mock_version.return_value = "1.2.3"
+def test_get_platform_helper_versions(mock_version, mock_get, fakefs, valid_platform_config):
+    mock_version.return_value = "1.1.1"
     mock_get.return_value.json.return_value = {
         "releases": {"1.2.3": None, "2.3.4": None, "0.1.0": None}
     }
     fakefs.create_file(PLATFORM_HELPER_VERSION_FILE, contents="5.6.7")
-    fakefs.create_file(
-        PLATFORM_CONFIG_FILE,
-        contents=yaml.dump(
-            {"application": "my-app", "default_versions": {"platform-helper": "9.0.0"}}
-        ),
-    )
+    config = valid_platform_config
+    fakefs.create_file(PLATFORM_CONFIG_FILE, contents=yaml.dump(config))
 
     versions = get_platform_helper_versions()
 
-    assert versions.local_version == (1, 2, 3)
+    assert versions.local_version == (1, 1, 1)
     assert versions.latest_release == (2, 3, 4)
     assert versions.platform_helper_file_version == (5, 6, 7)
-    assert versions.platform_config_default == (9, 0, 0)
+    assert versions.platform_config_default == (10, 2, 0)
+    assert versions.pipeline_overrides == {"test": "main", "prod-main": (9, 0, 9)}
 
 
 @patch("click.secho")

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -213,8 +213,10 @@ def test_check_platform_helper_version_skips_when_skip_environment_variable_is_s
 
 @patch("requests.get")
 @patch("dbt_platform_helper.utils.versioning.version")
-@patch("dbt_platform_helper.utils.validation.get_aws_session_or_abort", new=Mock())
-def test_get_platform_helper_versions(mock_version, mock_get, fakefs, valid_platform_config):
+@patch("dbt_platform_helper.utils.validation.get_aws_session_or_abort")
+def test_get_platform_helper_versions(
+    mock_aws, mock_version, mock_get, fakefs, valid_platform_config
+):
     mock_version.return_value = "1.1.1"
     mock_get.return_value.json.return_value = {
         "releases": {"1.2.3": None, "2.3.4": None, "0.1.0": None}
@@ -230,6 +232,7 @@ def test_get_platform_helper_versions(mock_version, mock_get, fakefs, valid_plat
     assert versions.platform_helper_file_version == (5, 6, 7)
     assert versions.platform_config_default == (10, 2, 0)
     assert versions.pipeline_overrides == {"test": "main", "prod-main": "9.0.9"}
+    assert not mock_aws.called
 
 
 @patch("click.secho")
@@ -255,6 +258,7 @@ def test_platform_helper_version_file_does_not_exist(
         f"Cannot get dbt-platform-helper version from file '{PLATFORM_HELPER_VERSION_FILE}'. Check if file exists.",
         fg="yellow",
     )
+    assert not mock_aws.called
 
 
 @patch("subprocess.run")

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -287,14 +287,19 @@ def test_get_aws_versions(mock_get_github_released_version, mock_run):
     ],
 )
 @patch("dbt_platform_helper.utils.versioning.version", return_value="0.0.0")
+@patch("requests.get")
 @patch("dbt_platform_helper.utils.validation.get_aws_session_or_abort", new=Mock())
 def test_get_desired_platform_helper_version(
+    mock_get,
     mock_version,
     fakefs,
     platform_helper_version_file_version,
     platform_config_default_version,
     expected_version,
 ):
+    mock_get.return_value.json.return_value = {
+        "releases": {"1.2.3": None, "2.3.4": None, "0.1.0": None}
+    }
     if platform_helper_version_file_version:
         Path(PLATFORM_HELPER_VERSION_FILE).write_text("0.0.1")
 
@@ -308,7 +313,6 @@ def test_get_desired_platform_helper_version(
     if platform_config_default_version:
         platform_config["default_versions"] = {"platform-helper": platform_config_default_version}
 
-    # platform_config["environment_pipelines"]["main"]["versions"] = {"platform-helper": "2.0.0"}
     Path(PLATFORM_CONFIG_FILE).write_text(yaml.dump(platform_config))
 
     desired_version = get_desired_platform_helper_version()
@@ -328,8 +332,10 @@ def test_get_desired_platform_helper_version(
     ],
 )
 @patch("dbt_platform_helper.utils.versioning.version", return_value="0.0.0")
+@patch("requests.get")
 @patch("dbt_platform_helper.utils.validation.get_aws_session_or_abort", new=Mock())
 def test_get_desired_platform_helper_version_in_pipeline(
+    mock_get,
     mock_version,
     fakefs,
     platform_helper_version_file_version,
@@ -337,6 +343,9 @@ def test_get_desired_platform_helper_version_in_pipeline(
     pipeline_override,
     expected_version,
 ):
+    mock_get.return_value.json.return_value = {
+        "releases": {"1.2.3": None, "2.3.4": None, "0.1.0": None}
+    }
     if platform_helper_version_file_version:
         Path(PLATFORM_HELPER_VERSION_FILE).write_text("0.0.1")
 


### PR DESCRIPTION
Addresses [DBTP-1153](https://uktrade.atlassian.net/browse/DBTP-1153)

Adds a command `platform-helper version print-desired` which gets the version of platform-helper that the project wants to be installed.

It has an option "--pipeline" which must be one of the configured environment-pipelines which is used to see if the desired version is overridden in the pipeline config. 

The PR also adds in a "versions" parameter to each environment pipeline in the platform-config.yml validation that supports the pipeline-level override.

Version precedence is in this order:
- if the --pipeline option is supplied, the version from the value in `environment_pipelines/<pipeline>/versions/platform-helper` in `platform-config.yml`
- The version from `default_versions/platform-helper` in `platform-config.yml`
- Fall back on the version in the `.platform-helper-version` file

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DBTP-1153]: https://uktrade.atlassian.net/browse/DBTP-1153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ