### PR TITLE
fix: DBTP-1180 - list all latest images tagged as commits

### DIFF
--- a/dbt_platform_helper/commands/codebase.py
+++ b/dbt_platform_helper/commands/codebase.py
@@ -102,7 +102,9 @@ def list_latest_images(ecr_client, ecr_repository_name, codebase_repository):
         reverse=True,
     )
 
-    for image in sorted_images[:20]:
+    MAX_RESULTS = 20
+
+    for image in sorted_images[:MAX_RESULTS]:
         try:
             commit_tag = next(t for t in image["imageTags"] if t.startswith("commit-"))
             if not commit_tag:

--- a/dbt_platform_helper/commands/codebase.py
+++ b/dbt_platform_helper/commands/codebase.py
@@ -89,20 +89,19 @@ def prepare():
 def list_latest_images(ecr_client, ecr_repository_name, codebase_repository):
     paginator = ecr_client.get_paginator("describe_images")
     describe_images_response_iterator = paginator.paginate(
-        repositoryName=ecr_repository_name, 
+        repositoryName=ecr_repository_name,
         filter={"tagStatus": "TAGGED"},
-        
     )
     images = []
     for page in describe_images_response_iterator:
-        images+=page["imageDetails"]
-    
+        images += page["imageDetails"]
+
     sorted_images = sorted(
         images,
         key=lambda i: i["imagePushedAt"],
         reverse=True,
     )
-    
+
     for image in sorted_images[:20]:
         try:
             commit_tag = next(t for t in image["imageTags"] if t.startswith("commit-"))
@@ -110,7 +109,9 @@ def list_latest_images(ecr_client, ecr_repository_name, codebase_repository):
                 continue
 
             commit_hash = commit_tag.replace("commit-", "")
-            click.echo(f"  - https://github.com/{codebase_repository}/commit/{commit_hash} - published: {image['imagePushedAt']}")
+            click.echo(
+                f"  - https://github.com/{codebase_repository}/commit/{commit_hash} - published: {image['imagePushedAt']}"
+            )
         except StopIteration:
             continue
 
@@ -145,7 +146,9 @@ def list(app, with_images):
     for codebase in codebases:
         click.echo(f"- {codebase['name']} (https://github.com/{codebase['repository']})")
         if with_images:
-            list_latest_images(ecr_client, f"{application.name}/{codebase['name']}", codebase['repository'])
+            list_latest_images(
+                ecr_client, f"{application.name}/{codebase['name']}", codebase["repository"]
+            )
 
     click.echo("")
 

--- a/tests/platform_helper/test_command_codebase.py
+++ b/tests/platform_helper/test_command_codebase.py
@@ -605,6 +605,46 @@ class TestCodebaseList:
             in result.output
         )
 
+    @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
+    def test_lists_codebases_with_disordered_images_in_chronological_order(self, get_aws_session_or_abort):
+        client = mock_aws_client(get_aws_session_or_abort)
+        client.get_parameters_by_path.return_value = {
+            "Parameters": [
+                {"Value": json.dumps({"name": "application", "repository": "uktrade/example"})}
+            ],
+        }
+        client.get_paginator.return_value.paginate.return_value = [
+            {
+                "imageDetails": [
+                    {
+                        "imageTags": ["latest", "tag-latest", "tag-1.0", "commit-4"],
+                        "imagePushedAt": datetime(2023, 11, 4, 00, 00, 00),
+                    },
+                    {
+                        "imageTags": ["branch-main", "commit-2"],
+                        "imagePushedAt": datetime(2023, 11, 2, 00, 00, 00),
+                    },
+                ]
+            },
+            {
+                "imageDetails": [
+                    {
+                        "imageTags": ["commit-1"],
+                        "imagePushedAt": datetime(2023, 11, 1, 00, 00, 00),
+                    },
+                    {
+                        "imageTags": ["commit-3"],
+                        "imagePushedAt": datetime(2023, 11, 3, 00, 00, 00),
+                    },
+                ]
+            }
+        ]
+        from dbt_platform_helper.commands.codebase import list
+
+        result = CliRunner().invoke(list, ["--app", "test-application", "--with-images"])
+        
+        assert result.output.index("commit/4") < result.output.index("commit/3") < result.output.index("commit/2") < result.output.index("commit/1")
+
     @patch(
         "dbt_platform_helper.commands.codebase.load_application",
         side_effect=ApplicationNotFoundError,

--- a/tests/platform_helper/test_command_codebase.py
+++ b/tests/platform_helper/test_command_codebase.py
@@ -512,26 +512,28 @@ class TestCodebaseList:
                 {"Value": json.dumps({"name": "application", "repository": "uktrade/example"})}
             ],
         }
-        client.get_paginator.return_value.paginate.return_value = [{
-            "imageDetails": [
-                {
-                    "imageTags": ["latest", "tag-latest", "tag-1.0", "commit-ee4a82c"],
-                    "imagePushedAt": datetime(2023, 11, 8, 17, 55, 35),
-                },
-                {
-                    "imageTags": ["branch-main", "commit-d269d51"],
-                    "imagePushedAt": datetime(2023, 11, 8, 17, 20, 34),
-                },
-                {
-                    "imageTags": ["cache"],
-                    "imagePushedAt": datetime(2023, 11, 8, 10, 31, 8),
-                },
-                {
-                    "imageTags": ["commit-57c0a08"],
-                    "imagePushedAt": datetime(2023, 11, 1, 17, 37, 2),
-                },
-            ]
-        }]
+        client.get_paginator.return_value.paginate.return_value = [
+            {
+                "imageDetails": [
+                    {
+                        "imageTags": ["latest", "tag-latest", "tag-1.0", "commit-ee4a82c"],
+                        "imagePushedAt": datetime(2023, 11, 8, 17, 55, 35),
+                    },
+                    {
+                        "imageTags": ["branch-main", "commit-d269d51"],
+                        "imagePushedAt": datetime(2023, 11, 8, 17, 20, 34),
+                    },
+                    {
+                        "imageTags": ["cache"],
+                        "imagePushedAt": datetime(2023, 11, 8, 10, 31, 8),
+                    },
+                    {
+                        "imageTags": ["commit-57c0a08"],
+                        "imagePushedAt": datetime(2023, 11, 1, 17, 37, 2),
+                    },
+                ]
+            }
+        ]
         from dbt_platform_helper.commands.codebase import list
 
         result = CliRunner().invoke(list, ["--app", "test-application", "--with-images"])
@@ -550,7 +552,7 @@ class TestCodebaseList:
             "- https://github.com/uktrade/example/commit/57c0a08 - published: 2023-11-01 17:37:02"
             in result.output
         )
-        
+
     @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
     def test_lists_codebases_with_multiple_pages_of_images(self, get_aws_session_or_abort):
         client = mock_aws_client(get_aws_session_or_abort)
@@ -583,7 +585,7 @@ class TestCodebaseList:
                         "imagePushedAt": datetime(2023, 11, 7, 00, 00, 00),
                     },
                 ]
-            }
+            },
         ]
         from dbt_platform_helper.commands.codebase import list
 
@@ -606,7 +608,9 @@ class TestCodebaseList:
         )
 
     @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
-    def test_lists_codebases_with_disordered_images_in_chronological_order(self, get_aws_session_or_abort):
+    def test_lists_codebases_with_disordered_images_in_chronological_order(
+        self, get_aws_session_or_abort
+    ):
         client = mock_aws_client(get_aws_session_or_abort)
         client.get_parameters_by_path.return_value = {
             "Parameters": [
@@ -637,13 +641,18 @@ class TestCodebaseList:
                         "imagePushedAt": datetime(2023, 11, 3, 00, 00, 00),
                     },
                 ]
-            }
+            },
         ]
         from dbt_platform_helper.commands.codebase import list
 
         result = CliRunner().invoke(list, ["--app", "test-application", "--with-images"])
-        
-        assert result.output.index("commit/4") < result.output.index("commit/3") < result.output.index("commit/2") < result.output.index("commit/1")
+
+        assert (
+            result.output.index("commit/4")
+            < result.output.index("commit/3")
+            < result.output.index("commit/2")
+            < result.output.index("commit/1")
+        )
 
     @patch(
         "dbt_platform_helper.commands.codebase.load_application",

--- a/tests/platform_helper/test_command_codebase.py
+++ b/tests/platform_helper/test_command_codebase.py
@@ -512,7 +512,7 @@ class TestCodebaseList:
                 {"Value": json.dumps({"name": "application", "repository": "uktrade/example"})}
             ],
         }
-        client.describe_images.return_value = {
+        client.get_paginator.return_value.paginate.return_value = [{
             "imageDetails": [
                 {
                     "imageTags": ["latest", "tag-latest", "tag-1.0", "commit-ee4a82c"],
@@ -531,7 +531,7 @@ class TestCodebaseList:
                     "imagePushedAt": datetime(2023, 11, 1, 17, 37, 2),
                 },
             ]
-        }
+        }]
         from dbt_platform_helper.commands.codebase import list
 
         result = CliRunner().invoke(list, ["--app", "test-application", "--with-images"])


### PR DESCRIPTION
Addresses [DBTP-1180](https://uktrade.atlassian.net/jira/software/c/projects/DBTP/boards/458?selectedIssue=DBTP-1180)

Not all images were being listed with the platform helper command `codebase list --app <app> --with-images`
This is because boto3 describe_images with the MaxResults parameter set does not guarantee to return the latest images if there are more than MaxResults images available.  [Boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_images.html) strongly recommends using pagination for these types of requests, which is implemented in this change and fixes the problem which was due to the truncated results.

Exisiting test was modified for the paginator implementation and new tests added to cover multiple pages and ordering of results.

Manual testing with the platform helper carried out in the datahub repo looks to be returning all of the expected images tagged with commit hashes:

command line output:
```
- frontend (https://github.com/uktrade/data-hub-frontend)
  - https://github.com/uktrade/data-hub-frontend/commit/b1268cb91 - published: 2024-08-07 13:05:01+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/f6b459411 - published: 2024-08-06 14:53:17+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/229f42e21 - published: 2024-08-06 14:01:52+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/fe8483a3d - published: 2024-08-05 14:29:19+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/02757bddd - published: 2024-08-01 12:10:05+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/f1d7c8253 - published: 2024-08-01 11:23:07+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/32f43dede - published: 2024-07-31 17:39:48+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/5b546753a - published: 2024-07-30 12:07:05+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/9d5897059 - published: 2024-07-30 11:32:52+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/242128149 - published: 2024-07-30 10:15:06+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/d709ba18b - published: 2024-07-26 15:21:13+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/920aeb200 - published: 2024-07-25 10:58:26+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/a3109916d - published: 2024-07-25 10:10:48+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/4ea55ddfd - published: 2024-07-22 11:15:14+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/5b09a85ef - published: 2024-07-19 12:36:37+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/496d6abd6 - published: 2024-07-19 10:01:33+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/9ce4334c8 - published: 2024-07-18 16:36:32+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/1c6f0e2b0 - published: 2024-07-18 15:43:07+01:00
  - https://github.com/uktrade/data-hub-frontend/commit/f877a48ca - published: 2024-07-18 15:19:38+01:00
  ```
  
ECR images:

![image](https://github.com/user-attachments/assets/87666894-c45b-4733-9898-c46fbea69d3c)


---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [x] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DBTP-1180]: https://uktrade.atlassian.net/browse/DBTP-1180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ