### PR TITLE
fix: DBTP-1207 - align extensions module name

### DIFF
--- a/dbt_platform_helper/templates/environments/main.tf
+++ b/dbt_platform_helper/templates/environments/main.tf
@@ -37,6 +37,10 @@ module "extensions" {
   vpc_name    = "{{ config.vpc }}"
 }
 
+{% comment %} 
+Clean up because terraform modules were initially deployed with a -tf suffix.  This block moves those modules to naming without a suffix.
+Can be removed once all services have moved to the new naming.
+{% endcomment %}
 moved {
   from = module.extensions-tf
   to   = module.extensions

--- a/dbt_platform_helper/templates/environments/main.tf
+++ b/dbt_platform_helper/templates/environments/main.tf
@@ -36,3 +36,8 @@ module "extensions" {
   environment = "{{ environment }}"
   vpc_name    = "{{ config.vpc }}"
 }
+
+moved {
+  from = module.extensions-tf
+  to   = module.extensions
+}

--- a/dbt_platform_helper/templates/environments/main.tf
+++ b/dbt_platform_helper/templates/environments/main.tf
@@ -37,10 +37,10 @@ module "extensions" {
   vpc_name    = "{{ config.vpc }}"
 }
 
-{% comment %} 
+/* 
 Clean up because terraform modules were initially deployed with a -tf suffix.  This block moves those modules to naming without a suffix.
 Can be removed once all services have moved to the new naming.
-{% endcomment %}
+*/
 moved {
   from = module.extensions-tf
   to   = module.extensions

--- a/tests/platform_helper/test_command_environment.py
+++ b/tests/platform_helper/test_command_environment.py
@@ -511,12 +511,13 @@ class TestGenerate:
     @patch("dbt_platform_helper.commands.environment.get_aws_session_or_abort")
     @patch("dbt_platform_helper.commands.environment.is_terraform_project", return_value=True)
     @pytest.mark.parametrize(
-        "env_modules_version, cli_modules_version, expected_version",
+        "env_modules_version, cli_modules_version, expected_version, should_include_moved_block",
         [
-            (None, None, "5"),
-            ("7", None, "7"),
-            (None, "8", "8"),
-            ("9", "10", "10"),
+            (None, None, "5", False),
+            ("7", None, "7", False),
+            (None, "8", "8", False),
+            ("9", "10", "10", False),
+            ("9-tf", "10", "10", True),
         ],
     )
     def test_generate_terraform(
@@ -528,6 +529,7 @@ class TestGenerate:
         env_modules_version,
         cli_modules_version,
         expected_version,
+        should_include_moved_block,
     ):
         from dbt_platform_helper.commands.environment import generate_terraform
 

--- a/tests/platform_helper/test_command_environment.py
+++ b/tests/platform_helper/test_command_environment.py
@@ -513,10 +513,10 @@ class TestGenerate:
     @pytest.mark.parametrize(
         "env_modules_version, cli_modules_version, expected_version, should_include_moved_block",
         [
-            (None, None, "5", False),
-            ("7", None, "7", False),
-            (None, "8", "8", False),
-            ("9", "10", "10", False),
+            (None, None, "5", True),
+            ("7", None, "7", True),
+            (None, "8", "8", True),
+            ("9", "10", "10", True),
             ("9-tf", "10", "10", True),
         ],
     )
@@ -576,6 +576,8 @@ class TestGenerate:
             f"git::https://github.com/uktrade/terraform-platform-modules.git//extensions?depth=1&ref={expected_version}"
             in content
         )
+        moved_block = "moved {\n  from = module.extensions-tf\n  to   = module.extensions\n}\n"
+        assert moved_block in content
 
     @patch("dbt_platform_helper.jinja2_tags.version", new=Mock(return_value="v0.1-TEST"))
     @patch("dbt_platform_helper.commands.environment.is_terraform_project", return_value=False)

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -230,6 +230,9 @@ def test_platform_helper_version_file_does_not_exist(mock_version, mock_get, sec
         "releases": {"1.2.3": None, "2.3.4": None, "0.1.0": None}
     }
 
+    if os.path.exists(".platform-helper-version"):
+        os.remove(".platform-helper-version")
+
     versions = get_platform_helper_versions()
 
     assert versions.platform_helper_file_version is None


### PR DESCRIPTION
Addresses [DBTP-1207](https://uktrade.atlassian.net/jira/software/c/projects/DBTP/boards/458?selectedIssue=DBTP-1207).

The terraform extensions module was initially generated with a suffix in its name, `extensions-tf`.  

When the terraform was subsequently regenerated by running the command,
`platform-helper environment generate-terraform --name <env>`

This caused an inconsistency in the generated code and the terraform state because the module name has been changed to `extensions` without a suffix in later terraform-platform-module versions.

We tested this change in the demo-django repo in our own environment.  We applied terraform with the `-tf` suffix on the extensions module name.  We regenerated the terraform using the new command which includes a moved block for the extensions module.  We applied the change and saw 'No changes' as expected.  We applied again (after the module name had already been updated) and the apply was also successful without changes.



---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [x] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DBTP-1207]: https://uktrade.atlassian.net/browse/DBTP-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ