### PR TITLE
fix: add a policy to allow services to access global SSM parameters

### DIFF
--- a/dbt_platform_helper/templates/svc/overrides/cfn.patches.yml
+++ b/dbt_platform_helper/templates/svc/overrides/cfn.patches.yml
@@ -12,3 +12,15 @@
   path: /Resources/TaskDefinition/Properties/Volumes
   value:
     - Name: temporary-fs
+
+- op: add
+  path: /Resources/ExecutionRole/Properties/Policies/0/PolicyDocument/Statement/4
+  value:
+    Effect: 'Allow'
+    Action:
+      - 'ssm:GetParameters'
+    Resource:
+      - !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
+    Condition:
+      StringEquals:
+          'ssm:ResourceTag/copilot-application': '__all__'

--- a/tests/platform_helper/fixtures/make_addons/expected/web/overrides/cfn.patches.yml
+++ b/tests/platform_helper/fixtures/make_addons/expected/web/overrides/cfn.patches.yml
@@ -12,3 +12,15 @@
   path: /Resources/TaskDefinition/Properties/Volumes
   value:
     - Name: temporary-fs
+
+- op: add
+  path: /Resources/ExecutionRole/Properties/Policies/0/PolicyDocument/Statement/4
+  value:
+    Effect: 'Allow'
+    Action:
+      - 'ssm:GetParameters'
+    Resource:
+      - !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
+    Condition:
+      StringEquals:
+          'ssm:ResourceTag/copilot-application': '__all__'


### PR DESCRIPTION
Addresses [<link to ticket>](https://uktrade.atlassian.net/browse/DBTP-1154).

This PR adds an additional policy to the service task role so that services can retrieve secrets tagged with `Copilot-application = '__all__'`.

This enables services to read SSM parameters that are global/account wide such as the VPC EGRESS_IP SSM parameter, and the prometheus `/observability/prometheus/adot_config` parameters.

There are two associated PRs to add these tags to global SSM params:
https://github.com/uktrade/terraform-platform-modules/pull/201
https://github.com/uktrade/terraform-module-aws_account/pull/74/

A platform-documentation PR is required - it'll be raised before merging this PR.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
