### PR TITLE
fix: S3 bucket KMS Key lookup when environments are in multiple AWS ac…

### DIFF
--- a/dbt_platform_helper/commands/copilot.py
+++ b/dbt_platform_helper/commands/copilot.py
@@ -216,8 +216,6 @@ def _generate_svc_overrides(base_path, templates, name):
 
 def _get_s3_kms_alias_arns(session, application_name, config):
     application = load_application(application_name, session)
-    # create kms client
-    kms_client = session.client("kms")
     arns = {}
 
     for environment_name in application.environments:
@@ -225,6 +223,7 @@ def _get_s3_kms_alias_arns(session, application_name, config):
             continue
 
         bucket_name = config[environment_name]["bucket_name"]
+        kms_client = application.environments[environment_name].session.client("kms")
         alias_name = f"alias/{application_name}-{environment_name}-{bucket_name}-key"
 
         try:

--- a/tests/platform_helper/test_command_copilot.py
+++ b/tests/platform_helper/test_command_copilot.py
@@ -3,6 +3,7 @@ import os
 import re
 from pathlib import Path
 from pathlib import PosixPath
+from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -17,6 +18,7 @@ from moto import mock_aws
 from dbt_platform_helper.commands.copilot import copilot
 from dbt_platform_helper.commands.copilot import is_service
 from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
+from dbt_platform_helper.utils.application import Environment
 from dbt_platform_helper.utils.validation import BUCKET_NAME_IN_USE_TEMPLATE
 from tests.platform_helper.conftest import FIXTURES_DIR
 from tests.platform_helper.conftest import mock_aws_client
@@ -49,7 +51,10 @@ S3_STORAGE_CONTENTS = {
         "type": "s3",
         "readonly": True,
         "services": ["web"],
-        "environments": {"development": {"bucket_name": "my-bucket-dev"}},
+        "environments": {
+            "development": {"bucket_name": "my-bucket-dev"},
+            "production": {"bucket_name": "my-bucket-prod"},
+        },
     }
 }
 
@@ -108,13 +113,41 @@ class TestTerraformEnabledMakeAddonCommand:
     )
     @patch("dbt_platform_helper.utils.application.get_aws_session_or_abort")
     @patch("dbt_platform_helper.commands.copilot.get_aws_session_or_abort")
+    @patch("dbt_platform_helper.commands.copilot.load_application", autospec=True)
     @mock_aws
     def test_s3_kms_arn_is_rendered_in_template(
-        self, mock_get_session, mock_get_session2, fakefs, kms_key_exists, kms_key_arn
+        self,
+        mock_application,
+        mock_get_session,
+        mock_get_session2,
+        fakefs,
+        kms_key_exists,
+        kms_key_arn,
     ):
-        client = mock_aws_client(mock_get_session)
-        mock_aws_client(mock_get_session2, client)
+        dev_session = MagicMock(name="dev-session-mock")
+        dev_session.profile_name = "foo"
+        prod_session = MagicMock(name="prod-session-mock")
+        prod_session.profile_name = "bar"
+        client = MagicMock(name="client-mock")
+        dev_session.client.return_value = client
+        prod_session.client.return_value = client
+        mock_get_session.side_effect = [dev_session, prod_session]
+        mock_get_session2.side_effect = [dev_session, prod_session]
 
+        dev = Environment(
+            name="development",
+            account_id="000000000000",
+            sessions={"000000000000": dev_session},
+        )
+        prod = Environment(
+            name="production",
+            account_id="111111111111",
+            sessions={"111111111111": prod_session},
+        )
+        mock_application.return_value.environments = {
+            "development": dev,
+            "production": prod,
+        }
         client.get_parameters_by_path.side_effect = [
             {
                 "Parameters": [
@@ -167,6 +200,9 @@ class TestTerraformEnabledMakeAddonCommand:
             s3_addon["Mappings"]["s3EnvironmentConfigMap"]["development"]["KmsKeyArn"]
             == kms_key_arn
         )
+        dev_session.client.assert_called_with("kms")
+        prod_session.client.assert_called_with("kms")
+        assert dev_session != prod_session
 
     @pytest.mark.parametrize(
         "addon_file, expected_service_addons",
@@ -1192,3 +1228,4 @@ def create_test_manifests(addon_file_contents, fakefs):
     fakefs.create_file(PLATFORM_CONFIG_FILE, contents=content)
     fakefs.create_file("copilot/web/manifest.yml", contents=yaml.dump(WEB_SERVICE_CONTENTS))
     fakefs.create_file("copilot/environments/development/manifest.yml")
+    fakefs.create_file("copilot/environments/production/manifest.yml")


### PR DESCRIPTION
Fixes S3 bucket KMS Key lookup by alias when the environments are in more than 1 account (e.g. prod and non-prod)

**Background:**

- New S3 bucket added to each Datahub environment in https://github.com/uktrade/data-hub-deploy/pull/31
- `terraform apply` run in each environment
- `platform-helper copilot make-addons` run (`v10.6.1`)

**Result:**

KMS Key Arn successfully found and added to config (https://github.com/uktrade/data-hub-deploy/pull/34) for `dev` and `staging` environments (non-prod account) but not for `prod` environment (prod account).

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
