### PR TITLE
fix: DBTP-1323 Broken `platform-helper codebase \*` commands

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Addresses <link to ticket>.
+Addresses [DBTP-<ticket>](https://uktrade.atlassian.net/browse/DBTP-<ticket>)
 
 Please add any relevant context for you pull request here, or delete this if none needed.
 

--- a/dbt_platform_helper/utils/versioning.py
+++ b/dbt_platform_helper/utils/versioning.py
@@ -104,7 +104,7 @@ def get_github_released_version(repository: str, tags: bool = False) -> Tuple[in
     return parse_version(package_info["tag_name"])
 
 
-def get_platform_helper_versions(local_and_latest_only=False) -> PlatformHelperVersions:
+def get_platform_helper_versions(include_project_versions=True) -> PlatformHelperVersions:
     try:
         locally_installed_version = parse_version(version("dbt-platform-helper"))
     except PackageNotFoundError:
@@ -118,7 +118,7 @@ def get_platform_helper_versions(local_and_latest_only=False) -> PlatformHelperV
 
     platform_config_default, pipeline_overrides, version_from_file = None, {}, None
 
-    if not local_and_latest_only:
+    if include_project_versions:
         platform_config = load_and_validate_platform_config(disable_aws_validation=True)
         platform_config_default = parse_version(
             platform_config.get("default_versions", {}).get("platform-helper")
@@ -145,7 +145,7 @@ def get_platform_helper_versions(local_and_latest_only=False) -> PlatformHelperV
         pipeline_overrides=pipeline_overrides,
     )
 
-    if not local_and_latest_only:
+    if include_project_versions:
         _process_version_file_warnings(out)
 
     return out
@@ -228,7 +228,7 @@ def check_platform_helper_version_needs_update():
     if not running_as_installed_package() or "PLATFORM_TOOLS_SKIP_VERSION_CHECK" in os.environ:
         return
 
-    versions = get_platform_helper_versions(local_and_latest_only=True)
+    versions = get_platform_helper_versions(include_project_versions=False)
     local_version = versions.local_version
     latest_release = versions.latest_release
     message = (

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -150,7 +150,7 @@ def test_check_platform_helper_version_needs_update(
 
     check_platform_helper_version_needs_update()
 
-    mock_get_platform_helper_versions.assert_called_with(ignore_platform_config_versions=True)
+    mock_get_platform_helper_versions.assert_called_with(local_and_latest_only=True)
 
     if expected_exception == IncompatibleMajorVersion:
         secho.assert_called_with(
@@ -305,7 +305,7 @@ def test_get_platform_helper_versions(
         ),
     ),
 )
-@pytest.mark.parametrize("disable_platform_config_processing", [False, True])
+@pytest.mark.parametrize("local_and_latest_only", [False, True])
 @patch("click.secho")
 @patch("requests.get")
 @patch("dbt_platform_helper.utils.versioning.version")
@@ -320,7 +320,7 @@ def test_platform_helper_version_warnings(
     version_in_platform_config,
     expected_message,
     message_colour,
-    disable_platform_config_processing,
+    local_and_latest_only,
 ):
     mock_version.return_value = "1.2.3"
     mock_get.return_value.json.return_value = {
@@ -334,9 +334,9 @@ def test_platform_helper_version_warnings(
     if version_in_phv_file:
         fakefs.create_file(PLATFORM_HELPER_VERSION_FILE, contents="3.3.3")
 
-    get_platform_helper_versions(ignore_platform_config_versions=disable_platform_config_processing)
+    get_platform_helper_versions(local_and_latest_only=local_and_latest_only)
 
-    if expected_message and not disable_platform_config_processing:
+    if expected_message and not local_and_latest_only:
         secho.assert_called_with(expected_message, fg=message_colour)
     else:
         secho.assert_not_called()

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -150,7 +150,7 @@ def test_check_platform_helper_version_needs_update(
 
     check_platform_helper_version_needs_update()
 
-    mock_get_platform_helper_versions.assert_called_with(local_and_latest_only=True)
+    mock_get_platform_helper_versions.assert_called_with(include_project_versions=False)
 
     if expected_exception == IncompatibleMajorVersion:
         secho.assert_called_with(
@@ -305,7 +305,7 @@ def test_get_platform_helper_versions(
         ),
     ),
 )
-@pytest.mark.parametrize("local_and_latest_only", [False, True])
+@pytest.mark.parametrize("include_project_versions", [False, True])
 @patch("click.secho")
 @patch("requests.get")
 @patch("dbt_platform_helper.utils.versioning.version")
@@ -320,7 +320,7 @@ def test_platform_helper_version_warnings(
     version_in_platform_config,
     expected_message,
     message_colour,
-    local_and_latest_only,
+    include_project_versions,
 ):
     mock_version.return_value = "1.2.3"
     mock_get.return_value.json.return_value = {
@@ -334,9 +334,9 @@ def test_platform_helper_version_warnings(
     if version_in_phv_file:
         fakefs.create_file(PLATFORM_HELPER_VERSION_FILE, contents="3.3.3")
 
-    get_platform_helper_versions(local_and_latest_only=local_and_latest_only)
+    get_platform_helper_versions(include_project_versions=include_project_versions)
 
-    if expected_message and not local_and_latest_only:
+    if expected_message and include_project_versions:
         secho.assert_called_with(expected_message, fg=message_colour)
     else:
         secho.assert_not_called()


### PR DESCRIPTION
A bug introduced in 10.7.2 meant that the `codebase` commands were failing because it could not find a `platform-config.yml` file. The command is used in the codebase repo, not the deploy repo, so it shouldn't be looking for, or failing because of this file.

Addresses [DBTP-1323](https://uktrade.atlassian.net/browse/DBTP-1323)

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [x] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DBTP-1323]: https://uktrade.atlassian.net/browse/DBTP-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ