### PR TITLE
fix: Use tag-latest for ci-image-builder

### DIFF
--- a/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
+++ b/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
@@ -108,7 +108,7 @@ export class TransformedStack extends cdk.Stack {
                 type: 'LINUX_CONTAINER',
                 computeType: 'BUILD_GENERAL1_SMALL',
                 privilegedMode: true,
-                image: 'public.ecr.aws/uktrade/ci-image-builder',
+                image: 'public.ecr.aws/uktrade/ci-image-builder:tag-latest',
                 environmentVariables: envVars,
             },
             source: {
@@ -180,7 +180,7 @@ export class TransformedStack extends cdk.Stack {
 
         buildProject.environment = {
             ...buildProject.environment,
-            image: 'public.ecr.aws/uktrade/ci-image-builder',
+            image: 'public.ecr.aws/uktrade/ci-image-builder:tag-latest',
             environmentVariables: [
                 ...currentEnvironmentVariables,
                 {


### PR DESCRIPTION
So that people are less likely to accidentally end up using images not meant for public consumption.

Tested with `platform-documentation-deploy`.
