### PR TITLE
feat: DBTP-1001 Add optional deploy_repository_branch to the codebase pipeline config

### DIFF
--- a/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
+++ b/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
@@ -201,8 +201,8 @@ export class TransformedStack extends cdk.Stack {
             },
         ];
 
-        if (this.codebaseConfiguration.deploy_repo_branch){
-            deployEnvironmentVariables.push({name: 'DEPLOY_REPOSITORY_BRANCH', value: this.codebaseConfiguration.deploy_repo_branch})
+        if (this.codebaseConfiguration.deploy_repository_branch){
+            deployEnvironmentVariables.push({name: 'DEPLOY_REPOSITORY_BRANCH', value: this.codebaseConfiguration.deploy_repository_branch})
         }
 
         buildProject.environment = {

--- a/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
+++ b/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
@@ -108,7 +108,7 @@ export class TransformedStack extends cdk.Stack {
                 type: 'LINUX_CONTAINER',
                 computeType: 'BUILD_GENERAL1_SMALL',
                 privilegedMode: true,
-                image: 'public.ecr.aws/uktrade/ci-image-builder',
+                image: 'public.ecr.aws/uktrade/ci-image-builder:tag-latest',
                 environmentVariables: envVars,
             },
             source: {

--- a/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
+++ b/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
@@ -207,7 +207,7 @@ export class TransformedStack extends cdk.Stack {
 
         buildProject.environment = {
             ...buildProject.environment,
-            image: 'public.ecr.aws/uktrade/ci-image-builder',
+            image: 'public.ecr.aws/uktrade/ci-image-builder:tag-latest',
             environmentVariables: deployEnvironmentVariables
         } as cdk.aws_codebuild.CfnProject.EnvironmentProperty;
 

--- a/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
+++ b/dbt_platform_helper/templates/pipelines/codebase/overrides/stack.ts
@@ -108,7 +108,7 @@ export class TransformedStack extends cdk.Stack {
                 type: 'LINUX_CONTAINER',
                 computeType: 'BUILD_GENERAL1_SMALL',
                 privilegedMode: true,
-                image: 'public.ecr.aws/uktrade/ci-image-builder:tag-latest',
+                image: 'public.ecr.aws/uktrade/ci-image-builder',
                 environmentVariables: envVars,
             },
             source: {
@@ -177,33 +177,38 @@ export class TransformedStack extends cdk.Stack {
 
         const currentEnvironment = buildProject.environment as cdk.aws_codebuild.CfnProject.EnvironmentProperty;
         const currentEnvironmentVariables = currentEnvironment.environmentVariables as Array<cdk.aws_codebuild.CfnProject.EnvironmentVariableProperty>;
+        const deployEnvironmentVariables = [
+            ...currentEnvironmentVariables,
+            {
+                name: 'CODESTAR_CONNECTION_ID',
+                value: this.codestarConnection.id
+            },
+            {
+                name: 'DEPLOY_REPOSITORY',
+                value: this.deployRepository
+            },
+            {
+                name: 'CODEBASE_REPOSITORY',
+                value: this.codebaseConfiguration.repository
+            },
+            {
+                name: 'COPILOT_SERVICES',
+                value: this.codebaseConfiguration.services.join(' ')
+            },
+            {
+                name: 'ECR_REPOSITORY',
+                value: this.ecrRepository()
+            },
+        ];
+
+        if (this.codebaseConfiguration.deploy_repo_branch){
+            deployEnvironmentVariables.push({name: 'DEPLOY_REPOSITORY_BRANCH', value: this.codebaseConfiguration.deploy_repo_branch})
+        }
 
         buildProject.environment = {
             ...buildProject.environment,
-            image: 'public.ecr.aws/uktrade/ci-image-builder:tag-latest',
-            environmentVariables: [
-                ...currentEnvironmentVariables,
-                {
-                    name: 'CODESTAR_CONNECTION_ID',
-                    value: this.codestarConnection.id
-                },
-                {
-                    name: 'DEPLOY_REPOSITORY',
-                    value: this.deployRepository
-                },
-                {
-                    name: 'CODEBASE_REPOSITORY',
-                    value: this.codebaseConfiguration.repository
-                },
-                {
-                    name: 'COPILOT_SERVICES',
-                    value: this.codebaseConfiguration.services.join(' ')
-                },
-                {
-                    name: 'ECR_REPOSITORY',
-                    value: this.ecrRepository()
-                },
-            ]
+            image: 'public.ecr.aws/uktrade/ci-image-builder',
+            environmentVariables: deployEnvironmentVariables
         } as cdk.aws_codebuild.CfnProject.EnvironmentProperty;
 
         const currentSource = buildProject.source as cdk.aws_codebuild.CfnProject.SourceProperty;

--- a/dbt_platform_helper/templates/pipelines/codebase/overrides/types.ts
+++ b/dbt_platform_helper/templates/pipelines/codebase/overrides/types.ts
@@ -26,7 +26,7 @@ export interface PipelinesConfiguration {
     codebase_pipelines: Array<{
         name: string;
         repository: string;
-        deploy_repo_branch?: string;
+        deploy_repository_branch?: string;
         additional_ecr_repository?: string;
         services: Array<string>;
         pipelines: Array<{

--- a/dbt_platform_helper/templates/pipelines/codebase/overrides/types.ts
+++ b/dbt_platform_helper/templates/pipelines/codebase/overrides/types.ts
@@ -26,6 +26,7 @@ export interface PipelinesConfiguration {
     codebase_pipelines: Array<{
         name: string;
         repository: string;
+        deploy_repo_branch?: string;
         additional_ecr_repository?: string;
         services: Array<string>;
         pipelines: Array<{

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -409,6 +409,7 @@ CODEBASE_PIPELINES_DEFINITION = [
         "name": str,
         "repository": str,
         Optional("additional_ecr_repository"): str,
+        Optional("deploy_repo_branch"): str,
         "services": list[str],
         "pipelines": [
             Or(

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -409,7 +409,7 @@ CODEBASE_PIPELINES_DEFINITION = [
         "name": str,
         "repository": str,
         Optional("additional_ecr_repository"): str,
-        Optional("deploy_repo_branch"): str,
+        Optional("deploy_repository_branch"): str,
         "services": list[str],
         "pipelines": [
             Or(

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -549,7 +549,7 @@ environment_pipelines:
 codebase_pipelines:
   - name: application
     repository: uktrade/test-app
-    deploy_repo_branch: feature-branch
+    deploy_repository_branch: feature-branch
     additional_ecr_repository: public.ecr.aws/my-public-repo/test-app/application
     services:
       - celery-worker

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -549,6 +549,7 @@ environment_pipelines:
 codebase_pipelines:
   - name: application
     repository: uktrade/test-app
+    deploy_repo_branch: feature-branch
     additional_ecr_repository: public.ecr.aws/my-public-repo/test-app/application
     services:
       - celery-worker


### PR DESCRIPTION
This is to support building an image from a branch of a deploy repo.

Addresses [DBTP-1001](https://uktrade.atlassian.net/browse/DBTP-1001)

Note no tests for the change in the stack.ts as the javascript files do not currently get tested. (See [DBT-1342](https://uktrade.atlassian.net/browse/DBTP-1342) for details of fixing this)

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [x] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DBTP-1001]: https://uktrade.atlassian.net/browse/DBTP-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ