### PR TITLE
Added new password parameters to opensearch validation

### DIFF
--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -346,6 +346,8 @@ OPENSEARCH_DEFINITION = {
             Optional("index_slow_log_retention_in_days"): int,
             Optional("audit_log_retention_in_days"): int,
             Optional("search_slow_log_retention_in_days"): int,
+            Optional("password_special_characters"): str,
+            Optional("urlencode_password"): bool,
         }
     },
 }

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -468,6 +468,8 @@ extensions:
         plan: small
         engine: '1.3'
         volume_size: 40
+        password_special_characters: "-_.,"
+        urlencode_password: false
 
   test-app-s3-bucket-with-objects:
     type: s3

--- a/tests/platform_helper/fixtures/make_addons/opensearch_addons.yml
+++ b/tests/platform_helper/fixtures/make_addons/opensearch_addons.yml
@@ -9,6 +9,9 @@ extensions:
         plan: tiny
         # supported engine versions as of 03/2024: 2.11, 2.9, 2.7, 2.5, 2.3, 1.3, 1.2, 1.1, 1.0
         engine: '2.3'
+        password_special_characters: "-_.,"
+        urlencode_password: false
+
       production:
         plan: large-ha
         engine: '2.3'

--- a/tests/platform_helper/utils/fixtures/addons_files/opensearch_addons.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/opensearch_addons.yml
@@ -12,6 +12,8 @@ my-opensearch:
       index_slow_log_retention_in_days: 10
       audit_log_retention_in_days: 10
       search_slow_log_retention_in_days: 10
+      password_special_characters: "-_.,"
+      urlencode_password: false
     development:
       plan: small
       volume_size: 100

--- a/tests/platform_helper/utils/fixtures/addons_files/opensearch_addons_bad_data.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/opensearch_addons_bad_data.yml
@@ -97,3 +97,15 @@ my-opensearch-search-slow-log-retention-in-days-should-be-int:
   environments:
     dev:
      search_slow_log_retention_in_days: true
+
+my-opensearch-password-special-characters:
+  type: opensearch
+  environments:
+    dev:
+      password_special_characters: false
+
+my-opensearch-urlencode-password:
+  type: opensearch
+  environments:
+    dev:
+      urlencode_password: "YES"

--- a/tests/platform_helper/utils/test_validation.py
+++ b/tests/platform_helper/utils/test_validation.py
@@ -191,6 +191,8 @@ def test_validate_addons_success(mock_name_is_available, addons_file):
                 "my-opensearch-index-slow-log-retention-in-days-should-be-int": r"environments.*index_slow_log_retention_in_days.*should be instance of 'int'",
                 "my-opensearch-audit-log-retention-in-days-should-be-int": r"environments.*audit_log_retention_in_days.*should be instance of 'int'",
                 "my-opensearch-search-slow-log-retention-in-days-should-be-int": r"environments.*search_slow_log_retention_in_days.*should be instance of 'int'",
+                "my-opensearch-password-special-characters": r"environments.*password_special_characters.*should be instance of 'str'",
+                "my-opensearch-urlencode-password": r"environments.*urlencode_password.*should be instance of 'bool'",
             },
         ),
         (


### PR DESCRIPTION
Addresses [DBTP-1346](https://uktrade.atlassian.net/browse/DBTP-1346)

Digital Workspace OpenSearch integration cannot cope with urlencoded passwords, and also breaks when certain characters are present but not encoded (e.g. @)

This change allows teams to:

disable urlencoding using the "urlencode_password" parameter
define their own set of special characters using the "password_special_characters" parameter.
---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
