### PR TITLE
fix: DBTP-1331 Ensure environment generate retrieves correct certificate for load balancer

### DIFF
--- a/tests/platform_helper/test_command_environment.py
+++ b/tests/platform_helper/test_command_environment.py
@@ -879,6 +879,7 @@ class TestFindHTTPSCertificate:
             ]
         }
 
+
         certificate_arn = find_https_certificate(boto_mock, "test-application", "development")
         assert "certificate_arn_default" == certificate_arn
 

--- a/tests/platform_helper/test_command_environment.py
+++ b/tests/platform_helper/test_command_environment.py
@@ -860,6 +860,7 @@ class TestFindHTTPSCertificate:
             "Certificates": [{"CertificateArn": "certificate_arn", "IsDefault": "True"}]
         }
 
+
         certificate_arn = find_https_certificate(boto_mock, "test-application", "development")
         assert "certificate_arn" == certificate_arn
 

--- a/tests/platform_helper/test_command_environment.py
+++ b/tests/platform_helper/test_command_environment.py
@@ -860,7 +860,6 @@ class TestFindHTTPSCertificate:
             "Certificates": [{"CertificateArn": "certificate_arn", "IsDefault": "True"}]
         }
 
-
         certificate_arn = find_https_certificate(boto_mock, "test-application", "development")
         assert "certificate_arn" == certificate_arn
 
@@ -878,7 +877,6 @@ class TestFindHTTPSCertificate:
                 {"CertificateArn": "certificate_arn_not_default", "IsDefault": "False"},
             ]
         }
-
 
         certificate_arn = find_https_certificate(boto_mock, "test-application", "development")
         assert "certificate_arn_default" == certificate_arn

--- a/tests/platform_helper/test_command_environment.py
+++ b/tests/platform_helper/test_command_environment.py
@@ -844,6 +844,7 @@ class TestFindHTTPSCertificate:
 
         boto_mock = MagicMock()
         boto_mock.client().describe_listener_certificates.return_value = {"Certificates": []}
+
         with pytest.raises(CertificateNotFoundError):
             find_https_certificate(boto_mock, "test-application", "development")
 


### PR DESCRIPTION
Addresses [DBTP-1331](https://uktrade.atlassian.net/browse/DBTP-1331)

The `platform-helper environment generate --name <env>` command retrieves the ARN of a certificate to add into the copilot manifest file. Currently a list of all certificates containing the string of the environment name will be retrieved and the ARN of the first certificate retrieved is used. In the event that there are multiple certificates containing the environment name this may result in the incorrect certificate being added to the manifest.

This PR changes the way that the certificate ARN is retrieved. Rather than querying the certificate store for all certificates that contain the environment name; we now retrieve the certificate ARN from the default certificate that is associated with the HTTPS listener on the LB. As this is the certificate attached to the LB it should always be valid.

---
## Checklist:

### Title:
- [X] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [X] Link to ticket included (unless it's a quick out of ticket thing)
- [X] Includes tests (or an explanation for why it doesn't)
- [X] If the work includes user interface changes, before and after screenshots included in description

N/A No UI changes made

- [X] Includes any applicable changes to the documentation in this code base
- [X] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [X] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing - [Passing Tests](https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/763451185160/projects/platform-tools-test/build/platform-tools-test%3A135bc431-2db8-4af0-ae52-6dee6b0a6858/?region=eu-west-2)



[DBTP-1331]: https://uktrade.atlassian.net/browse/DBTP-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ