### PR TITLE
fix: remove version update check from version group commands

### DIFF
--- a/dbt_platform_helper/commands/version.py
+++ b/dbt_platform_helper/commands/version.py
@@ -2,9 +2,6 @@ import click
 
 from dbt_platform_helper.utils.click import ClickDocOptGroup
 from dbt_platform_helper.utils.platform_config import get_environment_pipeline_names
-from dbt_platform_helper.utils.versioning import (
-    check_platform_helper_version_needs_update,
-)
 from dbt_platform_helper.utils.versioning import get_required_platform_helper_version
 
 
@@ -12,7 +9,6 @@ from dbt_platform_helper.utils.versioning import get_required_platform_helper_ve
 def version():
     """Contains subcommands for getting version information about the current
     project."""
-    check_platform_helper_version_needs_update()
 
 
 @version.command(help="Print the version of platform-tools required by the current project")


### PR DESCRIPTION
[This line](https://github.com/uktrade/terraform-platform-modules/blob/d67710ec1bc72ed7b756b9fa72770a7638e5361a/environment-pipelines/buildspec-install-build-tools.yml#L20) in env pipeline fails because, instead of a version number,`REQUIRED_VERSION` is assigned the output of the version update check i.e.

```
import re, sys; print('tag' if re.match(r'\d+\.\d+\.\d+', 'You are running platform-helper v10.9.1, upgrade to v10.10.0 by running run `pip install --upgrade dbt-platform-helper`.
```