### PR TITLE
fix: DBTP-1282 allow for explicit settings of PUB_PATH_LIST

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,14 @@ If found, it indicates that the new package version exists in PyPI.
 7. Ensure the release notes contain an upgrade path for any breaking changes
 8. Check PyPI for the new published version
 
+
+## Docker Images
+
+### Building the Images
+
+If building on a ARM mac, the image will build but will fail to deploy with the following error:
+exec /usr/bin/dumb-init: exec format error
+
+Instead, build the image via the below command, to build for the linux/amd64 platform.
+
+`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build --tag public.ecr.aws/uktrade/nginx-dbt-platform:<tag> .`

--- a/README.md
+++ b/README.md
@@ -171,14 +171,3 @@ If found, it indicates that the new package version exists in PyPI.
 7. Ensure the release notes contain an upgrade path for any breaking changes
 8. Check PyPI for the new published version
 
-
-## Docker Images
-
-### Building the Images
-
-If building on a ARM mac, the image will build but will fail to deploy with the following error:
-exec /usr/bin/dumb-init: exec format error
-
-Instead, build the image via the below command, to build for the linux/amd64 platform.
-
-`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build --tag public.ecr.aws/uktrade/nginx-dbt-platform:<tag> .`

--- a/images/nginx-dbt-platform/README.md
+++ b/images/nginx-dbt-platform/README.md
@@ -3,3 +3,12 @@ nginx-loadbalancer
 Load balancing with healthcheck used to reverse proxy to instances outside of AWS infrastructure.
 
 Currently published manually. See https://uktrade.atlassian.net/browse/DBTP-752.
+
+### Building the Image
+
+If building on a ARM mac, the image will build but will fail to deploy to Fargate with the following error:
+exec /usr/bin/dumb-init: exec format error
+
+Instead, build the image via the below command, to build for the linux/amd64 platform.
+
+`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build --tag public.ecr.aws/uktrade/nginx-dbt-platform:<tag> .`

--- a/images/nginx-dbt-platform/entrypoint.sh
+++ b/images/nginx-dbt-platform/entrypoint.sh
@@ -12,7 +12,7 @@ set_paths () {
 # To enable IP filter set PRIV_PATH_LIST: '/'
 if ! [ -z ${PRIV_PATH_LIST+x} ]; then
   PUBLIC_PATHS=""
-elif [ -z ${PUB_PATH_LIST+x} ]; then
+elif [ -z ${PUB_PATH_LIST+x} ] || [ "$PUB_PATH_LIST" = '/' ]; then
   set_paths "/" "upstream_server_public" "public_paths.txt"
   PUBLIC_PATHS=$(<public_paths.txt)
 else


### PR DESCRIPTION
Addresses [DBTP-1282](https://uktrade.atlassian.net/browse/DBTP-1282)

Previously setting a PUB_PATH_LIST explicitly to '/' would throw an error when the NGINX container spun up. See ticket for details.

Updated the entrypoint.sh for the image to allow for explicit setting of a PUB_PATH_LIST to '/'

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DBTP-1282]: https://uktrade.atlassian.net/browse/DBTP-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ