### PR TITLE
chore: SR-2683 Remove config for sorry.trade.gov.uk

### DIFF
--- a/migration-tools/ci-config.yml
+++ b/migration-tools/ci-config.yml
@@ -174,13 +174,6 @@ applications:
       name: datahub-omis-fe
       namespace: datahub
       scm: git@github.com:uktrade/omis-frontend.git
-    datahub-sorry:
-      environments:
-      - environment: production
-        paas-location: sorry.trade.gov.uk
-      name: datahub-sorry
-      namespace: datahub
-      scm: git@github.com:uktrade/service-shuttering-page.git
     staff-sso:
       environments:
       - environment: prod

--- a/migration-tools/full-config.yml
+++ b/migration-tools/full-config.yml
@@ -2913,14 +2913,6 @@ applications:
       name: datahub-omis-fe
       namespace: datahub
       scm: git@github.com:uktrade/omis-frontend.git
-    datahub-sorry:
-      environments:
-      - environment: production
-        paas: NO-APP-FOUND
-        paas-location: sorry.trade.gov.uk
-      name: datahub-sorry
-      namespace: datahub
-      scm: git@github.com:uktrade/service-shuttering-page.git
     staff-sso:
       environments:
       - environment: prod


### PR DESCRIPTION
Addresses [SR-2682](https://uktrade.atlassian.net/browse/SR-2682)

The maintenance page at sorry.trade.gov.uk is no longer used, and the resources for it have since been removed.

This commit removes its config as it is now non-functional.

There are no relevant tests to be updated.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[SR-2682]: https://uktrade.atlassian.net/browse/SR-2682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ