### PR TITLE
fix: Small fix that allows you to generate environment config without chan…

### DIFF
--- a/dbt_platform_helper/commands/environment.py
+++ b/dbt_platform_helper/commands/environment.py
@@ -275,8 +275,6 @@ def generate(name, vpc_name):
         )
         raise click.Abort
 
-    session = get_aws_session_or_abort()
-
     try:
         conf = load_and_validate_platform_config()
     except SchemaError as ex:
@@ -284,6 +282,9 @@ def generate(name, vpc_name):
         raise click.Abort
 
     env_config = apply_environment_defaults(conf)["environments"][name]
+    profile_for_environment = env_config.get("accounts", {}).get("deploy", {}).get("name")
+    click.secho(f"Using {profile_for_environment} for this AWS session")
+    session = get_aws_session_or_abort(profile_for_environment)
 
     _generate_copilot_environment_manifests(name, conf["application"], env_config, session)
 

--- a/tests/platform_helper/test_command_environment.py
+++ b/tests/platform_helper/test_command_environment.py
@@ -502,6 +502,7 @@ class TestGenerate:
         mock_get_vpc_id.assert_called_once_with(mocked_session, "test", expected_vpc)
         mock_get_subnet_ids.assert_called_once_with(mocked_session, "vpc-abc123")
         mock_get_cert_arn.assert_called_once_with(mocked_session, "my-app", "test")
+        mock_get_aws_session_1.assert_called_once_with("non-prod-acc")
 
         assert actual == expected
         assert "File copilot/environments/test/manifest.yml created" in result.output


### PR DESCRIPTION
…ging profiles

Looks up the profile for you rather than having to remember to change profiles when you generate different envs.

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
