### PR TITLE
feat(nginx-proxy): support proxying websocket connections

### DIFF
--- a/images/nginx-dbt-platform/README.md
+++ b/images/nginx-dbt-platform/README.md
@@ -1,12 +1,22 @@
-nginx-loadbalancer
+# nginx-dbt-platform
 
 Load balancing with healthcheck used to reverse proxy to instances outside of AWS infrastructure.
 
 Currently published manually. See https://uktrade.atlassian.net/browse/DBTP-752.
 
-### Building the Image
+## Configuration
 
-If building on a ARM mac, the image will build but will fail to deploy to Fargate with the following error:
+Configuration is applied via environment variables exposed to the container at run time.
+
+- `ALLOW_WEBSOCKETS` - allow the server to proxy websocket connections (currently not in combination with ip-filter).
+- `PRIV_PATH_LIST` - a list of paths that will be routed via the ip filter container.
+- `PUB_PATH_LIST` - a list of paths that will be routed directly to the application container.
+- `PRIV_HOST_LIST` - a list of domain names that will be routed via the ip filter container.
+- `PUB_HOST_LIST` - a list of domain names that will be routed directly to the application container.
+
+## Building the Image
+
+If building on an ARM mac, the image will build but will fail to deploy to Fargate with the following error:
 exec /usr/bin/dumb-init: exec format error
 
 Instead, build the image via the below command, to build for the linux/amd64 platform.

--- a/images/nginx-dbt-platform/entrypoint.sh
+++ b/images/nginx-dbt-platform/entrypoint.sh
@@ -14,8 +14,17 @@ set_paths () {
         proxy_set_header Host \$host;
         proxy_set_header x-forwarded-for \$proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Prefix $LOCATION_PATH;
-    }
 EOF
+
+  if [[ -n "${ALLOW_WEBSOCKETS+x}" ]]; then
+      cat << EOF >> $OUTPUT_FILE
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+EOF
+  fi
+
+  echo -e "\n    }" >> $OUTPUT_FILE
 }
 
 # Either PRIV_PATH_LIST or PUB_PATH_LIST VARs can be set, not both.

--- a/images/nginx-dbt-platform/entrypoint.sh
+++ b/images/nginx-dbt-platform/entrypoint.sh
@@ -4,7 +4,18 @@ set -euo pipefail
 
 # Proxy pass config.  Pass in $1 path, $2 target (public/private), $3 target_file (public/private).
 set_paths () {
-    echo -e "    location $1 {\n\tproxy_pass http://$2;\n\tproxy_set_header Host \$host;\n\tproxy_set_header x-forwarded-for \$proxy_add_x_forwarded_for;\n\tproxy_set_header X-Forwarded-Prefix $1;\n    }\n" >> $3
+  LOCATION_PATH=$1
+  UPSTREAM_HOST=$2
+  OUTPUT_FILE=$3
+  cat << EOF >> $OUTPUT_FILE
+
+    location $LOCATION_PATH {
+        proxy_pass http://$UPSTREAM_HOST;
+        proxy_set_header Host \$host;
+        proxy_set_header x-forwarded-for \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Prefix $LOCATION_PATH;
+    }
+EOF
 }
 
 # Either PRIV_PATH_LIST or PUB_PATH_LIST VARs can be set, not both.


### PR DESCRIPTION
Addresses [DPM-1231](https://uktrade.atlassian.net/browse/DPM-1231)

One of the services we are migrating uses websockets to manage clashes in edits to forms completed by multiple people. Currently the nginx proxy does not support connection upgrades and this PR introduces support for this along with a refactor for readability.

Tests: no tests currently exist for the nginx container, so I've not added any, though I have tested locally using a docker-compose file which I can commit alongside this PR.

---
## Checklist:

### Title:

- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)

### Description:

- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [x] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:

- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DPM-1231]: https://uktrade.atlassian.net/browse/DPM-1231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ