### PR TITLE
chore: extend env pipeline regression test timeout

### DIFF
--- a/regression_tests/stages/run_environment_pipeline.sh
+++ b/regression_tests/stages/run_environment_pipeline.sh
@@ -8,4 +8,4 @@ cd "${CODEBUILD_SRC_DIR}"
 
 source ./regression_tests/src/run_pipeline.sh
 
-run_pipeline "Environment" "demodjango-${TARGET_ENVIRONMENT}-environment-pipeline" 600
+run_pipeline "Environment" "demodjango-${TARGET_ENVIRONMENT}-environment-pipeline" 660


### PR DESCRIPTION
Latest regression test failure was due to a timeout, despite the pipeline completing successfully https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/763451185160/projects/platform-tools-test/build/platform-tools-test%3A71c49a5a-1890-40fd-a4a7-076df4b0aff9/?region=eu-west-2