### PR TITLE
feat(copilot-bootstrap): enable pingdom health checks

### DIFF
--- a/images/copilot-bootstrap/Dockerfile
+++ b/images/copilot-bootstrap/Dockerfile
@@ -3,5 +3,5 @@ FROM nginx:latest
 EXPOSE 8080
 
 COPY default.conf.template /etc/nginx/templates/default.conf.template
-COPY index.html /usr/share/nginx/html
-
+COPY index.html /usr/share/nginx/html/index.html
+COPY ping.xml /usr/share/nginx/html/pingdom/ping.xml

--- a/images/copilot-bootstrap/README.md
+++ b/images/copilot-bootstrap/README.md
@@ -5,3 +5,9 @@ This image is used as a very light placeholder when deploying DBT Platform infra
 As it will almost never change, there is no automated build and publish at present, these are manual steps.
 
 The image is published to `public.ecr.aws/uktrade/copilot-bootstrap:latest` in the `Tools` AWS account.
+
+## Pingdom
+
+To allow for the standard healthcheck endpoint `/pingdom/ping.xml`, this image uses a static XML file. 
+
+This allows for the AWS Copilot configuration for health checks to be set prior to replacing the bootstrap image with an actual application. In addition, pingdom health checks can be created during the environment setup, allowing the migration team to be alerted should the to-be production environment experience issues.

--- a/images/copilot-bootstrap/README.md
+++ b/images/copilot-bootstrap/README.md
@@ -10,4 +10,4 @@ The image is published to `public.ecr.aws/uktrade/copilot-bootstrap:latest` in t
 
 To allow for the standard healthcheck endpoint `/pingdom/ping.xml`, this image uses a static XML file. 
 
-This allows for the AWS Copilot configuration for health checks to be set prior to replacing the bootstrap image with an actual application. In addition, pingdom health checks can be created during the environment setup, allowing the migration team to be alerted should the to-be production environment experience issues.
+This allows the AWS Copilot configuration for health checks to be set prior to replacing the bootstrap image with an actual application. In addition, pingdom health checks can be created during the environment setup, allowing the migration team to be alerted should the to-be production environment experience issues.

--- a/images/copilot-bootstrap/ping.xml
+++ b/images/copilot-bootstrap/ping.xml
@@ -1,0 +1,4 @@
+<pingdom_http_custom_check>
+    <status>OK</status>
+    <response_time>500</response_time>
+</pingdom_http_custom_check>


### PR DESCRIPTION
Addresses [DPM-1232](https://uktrade.atlassian.net/browse/DPM-1232)

During migration of a service the migration team set up two levels of health check: one in the copilot service configuration and one in pingdom (for the to-be production environment). 

To allow us to shift these checks as far left in the migration process as possible, the boostrap image should respond on the standard path with the normal pingdom custom check XML response.

I've taken the liberty of returning a static response time as this is required by the pingdom check.

---
## Checklist:

### Title
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)

### Description
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [x] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DPM-1232]: https://uktrade.atlassian.net/browse/DPM-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ