### PR TITLE
fix: ensure delete_listener_rule deletes multiple rules with same name

### DIFF
--- a/dbt_platform_helper/commands/environment.py
+++ b/dbt_platform_helper/commands/environment.py
@@ -483,11 +483,11 @@ def delete_listener_rule(tag_descriptions: list, tag_name: str, lb_client: boto3
         tags = {t["Key"]: t["Value"] for t in description["Tags"]}
         if tags.get("name") == tag_name:
             current_rule_arn = description["ResourceArn"]
+            if current_rule_arn:
+                lb_client.delete_rule(RuleArn=current_rule_arn)
 
     if not current_rule_arn:
         return current_rule_arn
-
-    lb_client.delete_rule(RuleArn=current_rule_arn)
 
     return current_rule_arn
 

--- a/dbt_platform_helper/commands/environment.py
+++ b/dbt_platform_helper/commands/environment.py
@@ -486,9 +486,6 @@ def delete_listener_rule(tag_descriptions: list, tag_name: str, lb_client: boto3
             if current_rule_arn:
                 lb_client.delete_rule(RuleArn=current_rule_arn)
 
-    if not current_rule_arn:
-        return current_rule_arn
-
     return current_rule_arn
 
 

--- a/regression_tests/pull_request_tests.sh
+++ b/regression_tests/pull_request_tests.sh
@@ -15,7 +15,7 @@ source ./regression_tests/stages/set_up_git_config.sh
 
 # ./regression_tests/stages/clone_demodjango_deploy.sh
 
-# ./regression_tests/stages/clone_demodjango.sh
+./regression_tests/stages/clone_demodjango.sh
 
 # ./regression_tests/stages/run_platform_helper_environment_generate.sh
 

--- a/regression_tests/pull_request_tests.sh
+++ b/regression_tests/pull_request_tests.sh
@@ -13,7 +13,7 @@ source ./regression_tests/stages/set_up_git_config.sh
 
 ./regression_tests/stages/build_platform_helper.sh
 
-# ./regression_tests/stages/clone_demodjango_deploy.sh
+./regression_tests/stages/clone_demodjango_deploy.sh
 
 ./regression_tests/stages/clone_demodjango.sh
 

--- a/regression_tests/pull_request_tests.sh
+++ b/regression_tests/pull_request_tests.sh
@@ -13,11 +13,11 @@ source ./regression_tests/stages/set_up_git_config.sh
 
 ./regression_tests/stages/build_platform_helper.sh
 
-./regression_tests/stages/clone_demodjango_deploy.sh
+# ./regression_tests/stages/clone_demodjango_deploy.sh
 
-./regression_tests/stages/clone_demodjango.sh
+# ./regression_tests/stages/clone_demodjango.sh
 
-./regression_tests/stages/run_platform_helper_environment_generate.sh
+# ./regression_tests/stages/run_platform_helper_environment_generate.sh
 
 ./regression_tests/stages/run_platform_helper_generate.sh
 
@@ -25,13 +25,13 @@ source ./regression_tests/stages/set_up_git_config.sh
 
 # Todo: DBTP-1074 Include deploying codebase pipelines in regression tests
 
-./regression_tests/stages/run_environment_pipeline.sh
+# ./regression_tests/stages/run_environment_pipeline.sh
 
-./regression_tests/stages/run_codebase_pipeline.sh
+# ./regression_tests/stages/run_codebase_pipeline.sh
 
 ./regression_tests/stages/ensure_not_under_maintenance.sh
 
-source ./regression_tests/stages/run_demodjango_smoke_tests.sh
+# source ./regression_tests/stages/run_demodjango_smoke_tests.sh
 
 ./regression_tests/stages/run_maintenance_page_tests.sh
 

--- a/regression_tests/pull_request_tests.sh
+++ b/regression_tests/pull_request_tests.sh
@@ -31,7 +31,7 @@ source ./regression_tests/stages/set_up_git_config.sh
 
 ./regression_tests/stages/ensure_not_under_maintenance.sh
 
-# source ./regression_tests/stages/run_demodjango_smoke_tests.sh
+source ./regression_tests/stages/run_demodjango_smoke_tests.sh
 
 ./regression_tests/stages/run_maintenance_page_tests.sh
 

--- a/regression_tests/pull_request_tests.sh
+++ b/regression_tests/pull_request_tests.sh
@@ -19,7 +19,7 @@ source ./regression_tests/stages/set_up_git_config.sh
 
 # ./regression_tests/stages/run_platform_helper_environment_generate.sh
 
-./regression_tests/stages/run_platform_helper_generate.sh
+# ./regression_tests/stages/run_platform_helper_generate.sh
 
 # Todo: DBTP-1073 Include deploying environment pipelines in regression tests
 

--- a/regression_tests/pull_request_tests.sh
+++ b/regression_tests/pull_request_tests.sh
@@ -17,17 +17,17 @@ source ./regression_tests/stages/set_up_git_config.sh
 
 ./regression_tests/stages/clone_demodjango.sh
 
-# ./regression_tests/stages/run_platform_helper_environment_generate.sh
+./regression_tests/stages/run_platform_helper_environment_generate.sh
 
-# ./regression_tests/stages/run_platform_helper_generate.sh
+./regression_tests/stages/run_platform_helper_generate.sh
 
 # Todo: DBTP-1073 Include deploying environment pipelines in regression tests
 
 # Todo: DBTP-1074 Include deploying codebase pipelines in regression tests
 
-# ./regression_tests/stages/run_environment_pipeline.sh
+./regression_tests/stages/run_environment_pipeline.sh
 
-# ./regression_tests/stages/run_codebase_pipeline.sh
+./regression_tests/stages/run_codebase_pipeline.sh
 
 ./regression_tests/stages/ensure_not_under_maintenance.sh
 

--- a/regression_tests/stages/run_maintenance_page_tests.sh
+++ b/regression_tests/stages/run_maintenance_page_tests.sh
@@ -19,8 +19,8 @@ OUTPUT=$(echo "y" | AWS_PROFILE=platform-sandbox PLATFORM_TOOLS_SKIP_VERSION_CHE
 echo "$OUTPUT"
 MAINTENANCE_PAGE_BYPASS_VALUE=$(echo "$OUTPUT" | grep -oP 'Bypass-Key` header with value \K[^\s]+')
 
-echo -e "Give time for ALB to add the maintainence page config."
-sleep 16
+echo -e "Give time for ALB to add the maintenance page config."
+sleep 25
 
 echo -e "\nCheck maintenance page is working and that we can view the site with Bypass-Key header"
 cd "${CODEBUILD_SRC_DIR}/demodjango"
@@ -32,7 +32,7 @@ echo -e "\nRunning online command"
 echo "y" | AWS_PROFILE=platform-sandbox PLATFORM_TOOLS_SKIP_VERSION_CHECK=true platform-helper environment online --app demodjango --env ${TARGET_ENVIRONMENT}
 
 echo -e "Give time for ALB to remove the maintainence page config."
-sleep 15
+sleep 25
 
 echo -e "\nCheck we can view the page again (running smoke tests)"
 cd "${CODEBUILD_SRC_DIR}/demodjango"
@@ -56,8 +56,8 @@ OUTPUT=$(echo "y" | AWS_PROFILE=platform-sandbox PLATFORM_TOOLS_SKIP_VERSION_CHE
 echo "$OUTPUT"
 MAINTENANCE_PAGE_BYPASS_VALUE=$(echo "$OUTPUT" | grep -oP 'Bypass-Key` header with value \K[^\s]+')
 
-echo -e "Give time for ALB to add the maintainence page config."
-sleep 15
+echo -e "Give time for ALB to add the maintenance page config."
+sleep 25
 
 echo -e "\nCheck maintenance page is working and that we can view the site with Bypass-Key header"
 cd "${CODEBUILD_SRC_DIR}/demodjango"
@@ -67,7 +67,7 @@ echo -e "\nRunning online command"
 echo "y" | AWS_PROFILE=platform-sandbox PLATFORM_TOOLS_SKIP_VERSION_CHECK=true platform-helper environment online --app demodjango --env ${TARGET_ENVIRONMENT}
 
 echo -e "Give time for ALB to remove the maintainence page config."
-sleep 15
+sleep 25
 
 echo -e "\nCheck we can view the landing page"
 cd "${CODEBUILD_SRC_DIR}/demodjango"

--- a/regression_tests/stages/run_maintenance_page_tests.sh
+++ b/regression_tests/stages/run_maintenance_page_tests.sh
@@ -26,8 +26,6 @@ echo -e "\nCheck maintenance page is working and that we can view the site with 
 cd "${CODEBUILD_SRC_DIR}/demodjango"
 ./tests/browser/run.sh ${TARGET_ENVIRONMENT} maintenance_pages ${MAINTENANCE_PAGE_BYPASS_VALUE}
 
-#TODO check env ip is whitelisted https://uktrade.atlassian.net/browse/DBTP-1161
-
 echo -e "\nRunning online command"
 echo "y" | AWS_PROFILE=platform-sandbox PLATFORM_TOOLS_SKIP_VERSION_CHECK=true platform-helper environment online --app demodjango --env ${TARGET_ENVIRONMENT}
 

--- a/regression_tests/stages/run_maintenance_page_tests.sh
+++ b/regression_tests/stages/run_maintenance_page_tests.sh
@@ -14,7 +14,7 @@ cd "${CODEBUILD_SRC_DIR}/demodjango"
 ./smoke_tests.sh ${TARGET_ENVIRONMENT} smoke
 
 echo -e "\nRunning offline command"
-OUTPUT=$(echo "y" | AWS_PROFILE=platform-sandbox PLATFORM_TOOLS_SKIP_VERSION_CHECK=true platform-helper environment offline --app demodjango --env "${TARGET_ENVIRONMENT}" --vpc platform-sandbox-dev)
+OUTPUT=$(echo "y" | AWS_PROFILE=platform-sandbox PLATFORM_TOOLS_SKIP_VERSION_CHECK=true platform-helper environment offline --app demodjango --env "${TARGET_ENVIRONMENT}" --svc "*" --vpc platform-sandbox-dev)
 
 echo "$OUTPUT"
 MAINTENANCE_PAGE_BYPASS_VALUE=$(echo "$OUTPUT" | grep -oP 'Bypass-Key` header with value \K[^\s]+')


### PR DESCRIPTION
There can be multiple listener rules with the same name. When we run `online`, we want to delete all of these. Currently only one of each name will be deleted