### PR TITLE
fix: Restrict regression test alerts to toolspr environment

### DIFF
--- a/buildspec.test.yml
+++ b/buildspec.test.yml
@@ -33,7 +33,7 @@ phases:
         echo "git branch --contains \$CODEBUILD_RESOLVED_SOURCE_VERSION: $(git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION)"
         echo "git branch --contains \$CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main": $(git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main" || true)"
       - |
-        if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main"; then
+        if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main" && "${TARGET_ENVIRONMENT:-toolspr}" == "toolspr"; then
           MESSAGE=":alert: @here DBT Platform regression tests have failed in <https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/763451185160/projects/platform-tools-test/build/${CODEBUILD_BUILD_ID}/?region=eu-west-2|build ${CODEBUILD_BUILD_NUMBER}> :sob:"
           platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "" "${MESSAGE}"
         fi


### PR DESCRIPTION
We should not be alerted when the tests are targeting someone's individual environment.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
