### PR TITLE
chore: Add TARGET_ENVIRONMENT value to regression tests scripts outputs

### DIFF
--- a/regression_tests/actions/ensure_not_under_maintenance.sh
+++ b/regression_tests/actions/ensure_not_under_maintenance.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo -e "\n\n### Ensure environment not under maintenance\n"
+echo -e "\n\n### Ensure ${TARGET_ENVIRONMENT} environment not under maintenance\n"
 
 cd "${CODEBUILD_SRC_DIR}/demodjango"
 

--- a/regression_tests/actions/run_codebase_pipeline.sh
+++ b/regression_tests/actions/run_codebase_pipeline.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo -e "\n\n### Run codebase pipeline\n"
+echo -e "\n\n### Run codebase pipeline for ${TARGET_ENVIRONMENT} environment\n"
 
 cd "${CODEBUILD_SRC_DIR}"
 

--- a/regression_tests/actions/run_demodjango_smoke_tests.sh
+++ b/regression_tests/actions/run_demodjango_smoke_tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo -e "\n\n### Run demodjango smoke tests"
+echo -e "\n\n### Run demodjango smoke tests for ${TARGET_ENVIRONMENT} environment"
 
 cd "${CODEBUILD_SRC_DIR}/demodjango"
 

--- a/regression_tests/actions/run_environment_pipeline.sh
+++ b/regression_tests/actions/run_environment_pipeline.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo -e "\n\n### Run environment pipeline\n"
+echo -e "\n\n### Run environment pipeline for ${TARGET_ENVIRONMENT} environment\n"
 
 cd "${CODEBUILD_SRC_DIR}"
 

--- a/regression_tests/actions/run_maintenance_page_tests.sh
+++ b/regression_tests/actions/run_maintenance_page_tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo -e "\n\n### Run maintenance page tests\n"
+echo -e "\n\n### Run maintenance page tests for${TARGET_ENVIRONMENT} environment \n"
 
 cd "${CODEBUILD_SRC_DIR}/demodjango-deploy"
 echo "Current demodjango-deploy branch/commit: $(git rev-parse --abbrev-ref HEAD)/$(git rev-parse HEAD)"

--- a/regression_tests/actions/run_platform_helper_environment_generate.sh
+++ b/regression_tests/actions/run_platform_helper_environment_generate.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo -e "\n\n### Run platform-helper environment generate\n"
+echo -e "\n\n### Run platform-helper environment generate for ${TARGET_ENVIRONMENT} environment\n"
 
 cd "${CODEBUILD_SRC_DIR}/demodjango-deploy"
 

--- a/regression_tests/actions/run_s3_to_s3_data_migration_tests.sh
+++ b/regression_tests/actions/run_s3_to_s3_data_migration_tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo -e "\n\n### Run S3 to S3 data migration tests\n"
+echo -e "\n\n### Run S3 to S3 data migration tests for ${TARGET_ENVIRONMENT} environment\n"
 
 S3_MIGRATION_ROLE="demodjango-${TARGET_ENVIRONMENT}-shared-S3MigrationRole"
 DESTINATION_BUCKET="demodjango-${TARGET_ENVIRONMENT}-shared"


### PR DESCRIPTION
Addresses[DBTP-1291]( https://uktrade.atlassian.net/jira/software/c/projects/DBTP/boards/458?selectedIssue=DBTP-1291)

Add the value of the target environment to the echo statements in the various regression tests scripts

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
