### PR TITLE
chore: DBTP-1291 Sort out regression test Slack alerts

### DIFF
--- a/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
+++ b/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
@@ -8,7 +8,6 @@ phases:
   build:
     commands:
       - echo -e "\nCurrent platform-tools branch/commit $(git rev-parse --abbrev-ref HEAD)/$(git rev-parse HEAD)"
-      - exit 1
 
       - source ./regression_tests/actions/create_virtual_environment.sh
 

--- a/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
+++ b/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
-    SLACK_CHANNEL_ID: /codebuild/slack_channel_id_test_command_output
+#    SLACK_CHANNEL_ID: /codebuild/slack_channel_id_test_command_output
 
 phases:
   build:

--- a/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
+++ b/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
@@ -3,7 +3,6 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
-    SLACK_CHANNEL_ID: /codebuild/slack_channel_id_test_command_output
 
 phases:
   build:

--- a/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
+++ b/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
@@ -3,12 +3,14 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
-    SLACK_CHANNEL_ID: /codebuild/slack_oauth_channel
+    SLACK_CHANNEL_ID: /codebuild/slack_channel_id_test_command_output
 
 phases:
   build:
     commands:
+      - echo -e "\nCurrent platform-tools branch/commit: $(git rev-parse --abbrev-ref HEAD)/$(git rev-parse HEAD)"
       - exit 1
+
       - source ./regression_tests/actions/create_virtual_environment.sh
 
       - source ./regression_tests/actions/set_up_git_config.sh

--- a/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
+++ b/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
@@ -8,7 +8,7 @@ env:
 phases:
   build:
     commands:
-      - echo -e "\nCurrent platform-tools branch/commit: $(git rev-parse --abbrev-ref HEAD)/$(git rev-parse HEAD)"
+      - echo -e "\nCurrent platform-tools branch/commit $(git rev-parse --abbrev-ref HEAD)/$(git rev-parse HEAD)"
       - exit 1
 
       - source ./regression_tests/actions/create_virtual_environment.sh

--- a/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
+++ b/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
+    SLACK_CHANNEL_ID: /codebuild/slack_channel_id_test_command_output
 
 phases:
   build:

--- a/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
+++ b/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
@@ -3,7 +3,6 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
-#    SLACK_CHANNEL_ID: /codebuild/slack_channel_id_test_command_output
 
 phases:
   build:

--- a/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
+++ b/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
@@ -7,7 +7,6 @@ env:
 phases:
   build:
     commands:
-      - exit 1
       - echo -e "\nCurrent platform-tools branch/commit $(git rev-parse --abbrev-ref HEAD)/$(git rev-parse HEAD)"
 
       - source ./regression_tests/actions/create_virtual_environment.sh

--- a/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
+++ b/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
@@ -6,7 +6,7 @@ env:
     SLACK_CHANNEL_ID: /codebuild/slack_oauth_channel
 
 phases:
-  install:
+  build:
     commands:
       - exit 1
       - source ./regression_tests/actions/create_virtual_environment.sh
@@ -24,8 +24,6 @@ phases:
       - ./regression_tests/actions/clone_demodjango.sh
       - cd demodjango && poetry install && cd $CODEBUILD_SRC_DIR
 
-  build:
-    commands:
       - ./regression_tests/actions/build_platform_helper.sh
 
   post_build:

--- a/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
+++ b/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
@@ -7,6 +7,7 @@ env:
 phases:
   build:
     commands:
+      - exit 1
       - echo -e "\nCurrent platform-tools branch/commit $(git rev-parse --abbrev-ref HEAD)/$(git rev-parse HEAD)"
 
       - source ./regression_tests/actions/create_virtual_environment.sh

--- a/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
+++ b/regression_tests/buildspecs/stages/build/build-platform-helper-and-reclone-demodjango-repositories-action.yml
@@ -8,6 +8,7 @@ env:
 phases:
   install:
     commands:
+      - exit 1
       - source ./regression_tests/actions/create_virtual_environment.sh
 
       - source ./regression_tests/actions/set_up_git_config.sh
@@ -29,13 +30,7 @@ phases:
 
   post_build:
     commands:
-      # Todo: Look to extract to a helper script in a followup pull request
-      - |
-        if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main" && "${TARGET_ENVIRONMENT:-toolspr}" == "toolspr"; then
-          pip install dbt-platform-helper
-          MESSAGE=":alert: @here DBT Platform regression tests have failed in <https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/763451185160/projects/platform-tools-test/build/${CODEBUILD_BUILD_ID}/?region=eu-west-2|build ${CODEBUILD_BUILD_NUMBER}> :sob:"
-          platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "" "${MESSAGE}"
-        fi
+      - ./regression_tests/src/send_failure_alerts.sh
 
 artifacts:
   files:

--- a/regression_tests/buildspecs/stages/deploy/run-codebase-deploy-pipeline.yml
+++ b/regression_tests/buildspecs/stages/deploy/run-codebase-deploy-pipeline.yml
@@ -17,13 +17,7 @@ phases:
 
   post_build:
     commands:
-      # Todo: Look to extract to a helper script in a followup pull request
-      - |
-        if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main" && "${TARGET_ENVIRONMENT:-toolspr}" == "toolspr"; then
-          pip install dbt-platform-helper
-          MESSAGE=":alert: @here DBT Platform regression tests have failed in <https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/763451185160/projects/platform-tools-test/build/${CODEBUILD_BUILD_ID}/?region=eu-west-2|build ${CODEBUILD_BUILD_NUMBER}> :sob:"
-          platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "" "${MESSAGE}"
-        fi
+      - ./regression_tests/src/send_failure_alerts.sh
 
 artifacts:
   files:

--- a/regression_tests/buildspecs/stages/deploy/run-codebase-deploy-pipeline.yml
+++ b/regression_tests/buildspecs/stages/deploy/run-codebase-deploy-pipeline.yml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
+    SLACK_CHANNEL_ID: /codebuild/slack_oauth_channel
 
 phases:
   install:

--- a/regression_tests/buildspecs/stages/deploy/run-codebase-deploy-pipeline.yml
+++ b/regression_tests/buildspecs/stages/deploy/run-codebase-deploy-pipeline.yml
@@ -5,13 +5,10 @@ env:
     SLACK_TOKEN: /codebuild/slack_oauth_token
 
 phases:
-  install:
+  build:
     commands:
       - source ./regression_tests/actions/reactivate_virtual_environment.sh
       - source ./regression_tests/actions/set_up_aws_config.sh
-
-  build:
-    commands:
       - ./regression_tests/actions/run_codebase_pipeline.sh
 
   post_build:

--- a/regression_tests/buildspecs/stages/deploy/run-codebase-deploy-pipeline.yml
+++ b/regression_tests/buildspecs/stages/deploy/run-codebase-deploy-pipeline.yml
@@ -3,7 +3,6 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
-    SLACK_CHANNEL_ID: /codebuild/slack_oauth_channel
 
 phases:
   install:

--- a/regression_tests/buildspecs/stages/deploy/run-environment-pipeline.yml
+++ b/regression_tests/buildspecs/stages/deploy/run-environment-pipeline.yml
@@ -17,13 +17,7 @@ phases:
 
   post_build:
     commands:
-      # Todo: Look to extract to a helper script in a followup pull request
-      - |
-        if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main" && "${TARGET_ENVIRONMENT:-toolspr}" == "toolspr"; then
-          pip install dbt-platform-helper
-          MESSAGE=":alert: @here DBT Platform regression tests have failed in <https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/763451185160/projects/platform-tools-test/build/${CODEBUILD_BUILD_ID}/?region=eu-west-2|build ${CODEBUILD_BUILD_NUMBER}> :sob:"
-          platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "" "${MESSAGE}"
-        fi
+      - ./regression_tests/src/send_failure_alerts.sh
 
 artifacts:
   files:

--- a/regression_tests/buildspecs/stages/deploy/run-environment-pipeline.yml
+++ b/regression_tests/buildspecs/stages/deploy/run-environment-pipeline.yml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
+    SLACK_CHANNEL_ID: /codebuild/slack_oauth_channel
 
 phases:
   install:

--- a/regression_tests/buildspecs/stages/deploy/run-environment-pipeline.yml
+++ b/regression_tests/buildspecs/stages/deploy/run-environment-pipeline.yml
@@ -5,14 +5,11 @@ env:
     SLACK_TOKEN: /codebuild/slack_oauth_token
 
 phases:
-  install:
+  build:
     commands:
       - source ./regression_tests/actions/reactivate_virtual_environment.sh
       - source ./regression_tests/actions/set_up_aws_config.sh
-
-  build:
-    commands:
-       - ./regression_tests/actions/run_environment_pipeline.sh
+      - ./regression_tests/actions/run_environment_pipeline.sh
 
   post_build:
     commands:

--- a/regression_tests/buildspecs/stages/deploy/run-environment-pipeline.yml
+++ b/regression_tests/buildspecs/stages/deploy/run-environment-pipeline.yml
@@ -3,7 +3,6 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
-    SLACK_CHANNEL_ID: /codebuild/slack_oauth_channel
 
 phases:
   install:

--- a/regression_tests/buildspecs/stages/test/run-browser-tests.yml
+++ b/regression_tests/buildspecs/stages/test/run-browser-tests.yml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
+    SLACK_CHANNEL_ID: /codebuild/slack_oauth_channel
 
 phases:
   install:

--- a/regression_tests/buildspecs/stages/test/run-browser-tests.yml
+++ b/regression_tests/buildspecs/stages/test/run-browser-tests.yml
@@ -21,13 +21,7 @@ phases:
 
   post_build:
     commands:
-      # Todo: Look to extract to a helper script in a followup pull request
-      - |
-        if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main" && "${TARGET_ENVIRONMENT:-toolspr}" == "toolspr"; then
-          pip install dbt-platform-helper
-          MESSAGE=":alert: @here DBT Platform regression tests have failed in <https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/763451185160/projects/platform-tools-test/build/${CODEBUILD_BUILD_ID}/?region=eu-west-2|build ${CODEBUILD_BUILD_NUMBER}> :sob:"
-          platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "" "${MESSAGE}"
-        fi
+      - ./regression_tests/src/send_failure_alerts.sh
 
 artifacts:
   files:

--- a/regression_tests/buildspecs/stages/test/run-browser-tests.yml
+++ b/regression_tests/buildspecs/stages/test/run-browser-tests.yml
@@ -5,13 +5,10 @@ env:
     SLACK_TOKEN: /codebuild/slack_oauth_token
 
 phases:
-  install:
+  build:
     commands:
       - source ./regression_tests/actions/reactivate_virtual_environment.sh
       - ./regression_tests/actions/set_up_aws_config.sh
-
-  build:
-    commands:
       # Todo: For a followup pull request, we could install the playwright dependencies in parallel with the environment pipeline so we don't have to wait for them here
       # Todo: Do we really need to install all the browsers in demodjango/tests/browser/run.sh?
       - ./regression_tests/actions/ensure_not_under_maintenance.sh

--- a/regression_tests/buildspecs/stages/test/run-browser-tests.yml
+++ b/regression_tests/buildspecs/stages/test/run-browser-tests.yml
@@ -3,7 +3,6 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
-    SLACK_CHANNEL_ID: /codebuild/slack_oauth_channel
 
 phases:
   install:

--- a/regression_tests/buildspecs/stages/test/run-s3-to-s3-data-migration-tests.yml
+++ b/regression_tests/buildspecs/stages/test/run-s3-to-s3-data-migration-tests.yml
@@ -17,13 +17,7 @@ phases:
 
   post_build:
     commands:
-      # Todo: Look to extract to a helper script in a followup pull request
-      - |
-        if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main" && "${TARGET_ENVIRONMENT:-toolspr}" == "toolspr"; then
-          pip install dbt-platform-helper
-          MESSAGE=":alert: @here DBT Platform regression tests have failed in <https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/763451185160/projects/platform-tools-test/build/${CODEBUILD_BUILD_ID}/?region=eu-west-2|build ${CODEBUILD_BUILD_NUMBER}> :sob:"
-          platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "" "${MESSAGE}"
-        fi
+      - ./regression_tests/src/send_failure_alerts.sh
 
 artifacts:
   files:

--- a/regression_tests/buildspecs/stages/test/run-s3-to-s3-data-migration-tests.yml
+++ b/regression_tests/buildspecs/stages/test/run-s3-to-s3-data-migration-tests.yml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
+    SLACK_CHANNEL_ID: /codebuild/slack_oauth_channel
 
 phases:
   install:

--- a/regression_tests/buildspecs/stages/test/run-s3-to-s3-data-migration-tests.yml
+++ b/regression_tests/buildspecs/stages/test/run-s3-to-s3-data-migration-tests.yml
@@ -5,13 +5,10 @@ env:
     SLACK_TOKEN: /codebuild/slack_oauth_token
 
 phases:
-  install:
+  build:
     commands:
       - source ./regression_tests/actions/reactivate_virtual_environment.sh
       - ./regression_tests/actions/set_up_aws_config.sh
-
-  build:
-    commands:
       - ./regression_tests/actions/run_s3_to_s3_data_migration_tests.sh
 
   post_build:

--- a/regression_tests/buildspecs/stages/test/run-s3-to-s3-data-migration-tests.yml
+++ b/regression_tests/buildspecs/stages/test/run-s3-to-s3-data-migration-tests.yml
@@ -3,7 +3,6 @@ version: 0.2
 env:
   parameter-store:
     SLACK_TOKEN: /codebuild/slack_oauth_token
-    SLACK_CHANNEL_ID: /codebuild/slack_oauth_channel
 
 phases:
   install:

--- a/regression_tests/src/send_failure_alerts.sh
+++ b/regression_tests/src/send_failure_alerts.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-env
+echo "TARGET_ENVIRONMENT: ${TARGET_ENVIRONMENT}"
 
-if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main" && [ "${TARGET_ENVIRONMENT:-toolspr}" == "toolspr" ]; then
+if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "1291-sort-out-alerts" && [ "${TARGET_ENVIRONMENT:-toolspr}" == "tony" ]; then
     echo -e "\nAction failed sending alert"
     pip install dbt-platform-helper
     MESSAGE=":alert: @here DBT Platform regression tests have failed in <https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/763451185160/projects/platform-tools-test/build/${CODEBUILD_BUILD_ID}/?region=eu-west-2|build ${CODEBUILD_BUILD_NUMBER}> :sob:"

--- a/regression_tests/src/send_failure_alerts.sh
+++ b/regression_tests/src/send_failure_alerts.sh
@@ -3,7 +3,7 @@
 echo "TARGET_ENVIRONMENT: ${TARGET_ENVIRONMENT}"
 
 function is_platform_tools_branch_main() {
-    git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "1291-sort-out-alerts"
+    git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main"
 }
 
 function is_demodjango_deploy_branch_main() {

--- a/regression_tests/src/send_failure_alerts.sh
+++ b/regression_tests/src/send_failure_alerts.sh
@@ -2,27 +2,22 @@
 
 echo "TARGET_ENVIRONMENT: ${TARGET_ENVIRONMENT}"
 
-function is_platform_tools_branch_main() {
+function is_everything_on_branch_main() {
     git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main"
-}
 
-function is_demodjango_deploy_branch_main() {
     cd demodjango-deploy
     git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main"
     cd "$CODEBUILD_SRC_DIR"
-}
 
-function is_demodjango_branch_main() {
     cd demodjango
     git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main"
     cd "$CODEBUILD_SRC_DIR"
+
+    #todo: Add terraform-platform-tools when we are targeting branches
 }
 
-#todo: Add terraform-platform-tools when we are targeting branches
 if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && \
-    is_platform_tools_branch_main && \
-    is_demodjango_deploy_branch_main && \
-    is_demodjango_branch_main && \
+    is_everything_on_branch_main && \
     [ "${TARGET_ENVIRONMENT:-toolspr}" == "tony" ]; then
 
     echo -e "\nAction failed sending alert"

--- a/regression_tests/src/send_failure_alerts.sh
+++ b/regression_tests/src/send_failure_alerts.sh
@@ -18,7 +18,7 @@ function is_everything_on_branch_main() {
 
 if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && \
     is_everything_on_branch_main && \
-    [ "${TARGET_ENVIRONMENT:-toolspr}" == "tony" ]; then
+    [ "${TARGET_ENVIRONMENT:-toolspr}" == "toolspr" ]; then
 
     echo -e "\nAction failed sending alert"
     pip install dbt-platform-helper

--- a/regression_tests/src/send_failure_alerts.sh
+++ b/regression_tests/src/send_failure_alerts.sh
@@ -2,7 +2,29 @@
 
 echo "TARGET_ENVIRONMENT: ${TARGET_ENVIRONMENT}"
 
-if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "1291-sort-out-alerts" && [ "${TARGET_ENVIRONMENT:-toolspr}" == "tony" ]; then
+function is_platform_tools_branch_main() {
+    git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "1291-sort-out-alerts"
+}
+
+function is_demodjango_deploy_branch_main() {
+    cd demodjango-deploy
+    git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main"
+    cd "$CODEBUILD_SRC_DIR"
+}
+
+function is_demodjango_branch_main() {
+    cd demodjango
+    git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main"
+    cd "$CODEBUILD_SRC_DIR"
+}
+
+#todo: Add terraform-platform-tools when we are targeting branches
+if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && \
+    is_platform_tools_branch_main && \
+    is_demodjango_deploy_branch_main && \
+    is_demodjango_branch_main && \
+    [ "${TARGET_ENVIRONMENT:-toolspr}" == "tony" ]; then
+
     echo -e "\nAction failed sending alert"
     pip install dbt-platform-helper
     MESSAGE=":alert: @here DBT Platform regression tests have failed in <https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/763451185160/projects/platform-tools-test/build/${CODEBUILD_BUILD_ID}/?region=eu-west-2|build ${CODEBUILD_BUILD_NUMBER}> :sob:"

--- a/regression_tests/src/send_failure_alerts.sh
+++ b/regression_tests/src/send_failure_alerts.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+env
+
+if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ] && git branch --contains $CODEBUILD_RESOLVED_SOURCE_VERSION | grep -q "main" && [ "${TARGET_ENVIRONMENT:-toolspr}" == "toolspr" ]; then
+    echo -e "\nAction failed sending alert"
+    pip install dbt-platform-helper
+    MESSAGE=":alert: @here DBT Platform regression tests have failed in <https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/763451185160/projects/platform-tools-test/build/${CODEBUILD_BUILD_ID}/?region=eu-west-2|build ${CODEBUILD_BUILD_NUMBER}> :sob:"
+    platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "" "${MESSAGE}"
+else
+    echo -e "\nAction succeeded, no alert sent"
+fi


### PR DESCRIPTION
Addresses [DBTP-1291](https://uktrade.atlassian.net/browse/DBTP-1291)

- Add checks for the targeted repositories being on the main branch before sending a Slack message to alert about any regression test failures.
- Extracted the Slack alert code out into a script.
- Removed `install` phase from buildspec because failures in the install phase do not result in a Slack message alert.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DBTP-1291]: https://uktrade.atlassian.net/browse/DBTP-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ