### PR TITLE
feat: DBTP-1215 Improve error message when AWS profile not set

### DIFF
--- a/dbt_platform_helper/utils/aws.py
+++ b/dbt_platform_helper/utils/aws.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 import boto3
 import botocore
+import botocore.exceptions
 import click
 import yaml
 from boto3 import Session
@@ -48,9 +49,10 @@ def get_aws_session_or_abort(aws_profile: str = None) -> boto3.session.Session:
         botocore.exceptions.UnauthorizedSSOTokenError,
         botocore.exceptions.TokenRetrievalError,
         botocore.exceptions.SSOTokenLoadError,
+        botocore.exceptions.NoCredentialsError,
     ):
         click.secho(
-            "The SSO session associated with this profile has expired or is otherwise invalid."
+            "The SSO session associated with this profile has expired, is not set or is otherwise invalid."
             "To refresh this SSO session run `aws sso login` with the corresponding profile",
             fg="red",
         )

--- a/dbt_platform_helper/utils/aws.py
+++ b/dbt_platform_helper/utils/aws.py
@@ -37,7 +37,7 @@ def get_aws_session_or_abort(aws_profile: str = None) -> boto3.session.Session:
         click.secho("Credentials are valid.", fg="green")
 
     except botocore.exceptions.ProfileNotFound:
-        _handle_error(f'AWS profile "{aws_profile}" is not configured.', "")
+        _handle_error(f'AWS profile "{aws_profile}" is not configured.')
     except botocore.exceptions.ClientError as e:
         if e.response["Error"]["Code"] == "ExpiredToken":
             _handle_error(
@@ -69,8 +69,9 @@ def get_aws_session_or_abort(aws_profile: str = None) -> boto3.session.Session:
     return session
 
 
-def _handle_error(message: str, refresh_token_message: str) -> None:
-    click.secho(message + refresh_token_message, fg="red")
+def _handle_error(message: str, refresh_token_message: str = None) -> None:
+    full_message = message + (" " + refresh_token_message if refresh_token_message else "")
+    click.secho(full_message, fg="red")
     exit(1)
 
 

--- a/dbt_platform_helper/utils/aws.py
+++ b/dbt_platform_helper/utils/aws.py
@@ -52,7 +52,7 @@ def get_aws_session_or_abort(aws_profile: str = None) -> boto3.session.Session:
         botocore.exceptions.NoCredentialsError,
     ):
         click.secho(
-            "The SSO session associated with this profile has expired, is not set or is otherwise invalid.."
+            "The SSO session associated with this profile has expired, is not set or is otherwise invalid."
             "To refresh this SSO session run `aws sso login` with the corresponding profile",
             fg="red",
         )

--- a/dbt_platform_helper/utils/aws.py
+++ b/dbt_platform_helper/utils/aws.py
@@ -18,12 +18,12 @@ from dbt_platform_helper.exceptions import ValidationException
 SSM_BASE_PATH = "/copilot/{app}/{env}/secrets/"
 SSM_PATH = "/copilot/{app}/{env}/secrets/{name}"
 AWS_SESSION_CACHE = {}
-REFRESH_TOKEN_MESSAGE = (
-    "To refresh this SSO session run `aws sso login` with the corresponding profile"
-)
 
 
 def get_aws_session_or_abort(aws_profile: str = None) -> boto3.session.Session:
+    REFRESH_TOKEN_MESSAGE = (
+        "To refresh this SSO session run `aws sso login` with the corresponding profile"
+    )
     aws_profile = aws_profile or os.getenv("AWS_PROFILE")
     if aws_profile in AWS_SESSION_CACHE:
         return AWS_SESSION_CACHE[aws_profile]

--- a/dbt_platform_helper/utils/aws.py
+++ b/dbt_platform_helper/utils/aws.py
@@ -45,12 +45,28 @@ def get_aws_session_or_abort(aws_profile: str = None) -> boto3.session.Session:
     try:
         account_id, user_id = get_account_details(sts)
         click.secho("Credentials are valid.", fg="green")
-    except (
-        botocore.exceptions.UnauthorizedSSOTokenError,
-        botocore.exceptions.TokenRetrievalError,
-        botocore.exceptions.SSOTokenLoadError,
-        botocore.exceptions.NoCredentialsError,
-    ):
+    except (botocore.exceptions.NoCredentialsError,):
+        click.secho(
+            "There are no credentials set for this session."
+            "To refresh this SSO session run `aws sso login` with the corresponding profile",
+            fg="red",
+        )
+        exit(1)
+    except (botocore.exceptions.UnauthorizedSSOTokenError,):
+        click.secho(
+            "The SSO Token used for this session is unauthorised."
+            "To refresh this SSO session run `aws sso login` with the corresponding profile",
+            fg="red",
+        )
+        exit(1)
+    except (botocore.exceptions.TokenRetrievalError,):
+        click.secho(
+            "Unable to retrieve the Token for this session."
+            "To refresh this SSO session run `aws sso login` with the corresponding profile",
+            fg="red",
+        )
+        exit(1)
+    except (botocore.exceptions.SSOTokenLoadError,):
         click.secho(
             "The SSO session associated with this profile has expired, is not set or is otherwise invalid."
             "To refresh this SSO session run `aws sso login` with the corresponding profile",

--- a/dbt_platform_helper/utils/aws.py
+++ b/dbt_platform_helper/utils/aws.py
@@ -52,7 +52,7 @@ def get_aws_session_or_abort(aws_profile: str = None) -> boto3.session.Session:
         botocore.exceptions.NoCredentialsError,
     ):
         click.secho(
-            "The SSO session associated with this profile has expired, is not set or is otherwise invalid."
+            "The SSO session associated with this profile has expired, is not set or is otherwise invalid.."
             "To refresh this SSO session run `aws sso login` with the corresponding profile",
             fg="red",
         )

--- a/tests/platform_helper/utils/test_aws.py
+++ b/tests/platform_helper/utils/test_aws.py
@@ -131,7 +131,7 @@ def test_get_ssm_secrets(mock_get_aws_session_or_abort):
 @patch("dbt_platform_helper.utils.aws.get_account_details")
 @patch("boto3.session.Session")
 @patch("click.secho")
-def test_get_aws_session_or_abort_erors(
+def test_get_aws_session_or_abort_errors(
     mock_secho,
     mock_session,
     mock_get_account_details,

--- a/tests/platform_helper/utils/test_aws.py
+++ b/tests/platform_helper/utils/test_aws.py
@@ -99,7 +99,7 @@ def test_get_aws_session_or_abort_with_invalid_credentials(
 ):
     aws_profile = "existing_profile"
     expected_error_message = (
-        "The SSO session associated with this profile has expired or is otherwise invalid."
+        "The SSO session associated with this profile has expired, is not set or is otherwise invalid."
         + "To refresh this SSO session run `aws sso login` with the corresponding profile"
     )
     mock_get_account_details.side_effect = botocore.exceptions.SSOTokenLoadError(

--- a/tests/platform_helper/utils/test_aws.py
+++ b/tests/platform_helper/utils/test_aws.py
@@ -37,6 +37,9 @@ ALPHANUMERIC_SERVICE_NAME = "alphanumericservicename123"
 COPILOT_IDENTIFIER = "c0PIlotiD3ntIF3r"
 CLUSTER_NAME_SUFFIX = f"Cluster-{COPILOT_IDENTIFIER}"
 SERVICE_NAME_SUFFIX = f"Service-{COPILOT_IDENTIFIER}"
+REFRESH_TOKEN_MESSAGE = (
+    "To refresh this SSO session run `aws sso login` with the corresponding profile"
+)
 
 
 def test_get_aws_session_or_abort_profile_not_configured(clear_session_cache, capsys):
@@ -99,32 +102,28 @@ def test_get_ssm_secrets(mock_get_aws_session_or_abort):
             botocore.exceptions.NoCredentialsError(
                 error_msg="There are no credentials set for this session."
             ),
-            "There are no credentials set for this session."
-            "To refresh this SSO session run `aws sso login` with the corresponding profile",
+            f"There are no credentials set for this session. {REFRESH_TOKEN_MESSAGE}",
         ),
         (
             "existing_profile",
             botocore.exceptions.UnauthorizedSSOTokenError(
                 error_msg="The SSO Token used for this session is unauthorised."
             ),
-            "The SSO Token used for this session is unauthorised."
-            "To refresh this SSO session run `aws sso login` with the corresponding profile",
+            f"The SSO Token used for this session is unauthorised. {REFRESH_TOKEN_MESSAGE}",
         ),
         (
             "existing_profile",
             botocore.exceptions.TokenRetrievalError(
                 error_msg="Unable to retrieve the Token for this session.", provider="sso"
             ),
-            "Unable to retrieve the Token for this session."
-            "To refresh this SSO session run `aws sso login` with the corresponding profile",
+            f"Unable to retrieve the Token for this session. {REFRESH_TOKEN_MESSAGE}",
         ),
         (
             "existing_profile",
             botocore.exceptions.SSOTokenLoadError(
                 error_msg="The SSO session associated with this profile has expired, is not set or is otherwise invalid."
             ),
-            "The SSO session associated with this profile has expired, is not set or is otherwise invalid."
-            "To refresh this SSO session run `aws sso login` with the corresponding profile",
+            f"The SSO session associated with this profile has expired, is not set or is otherwise invalid. {REFRESH_TOKEN_MESSAGE}",
         ),
     ],
 )


### PR DESCRIPTION
Addresses [DBTP-1215](https://uktrade.atlassian.net/browse/DBTP-1215)

We have quite a few errors which can be thrown when there's an issue with the aws_profile, so instead of adding yet another one to the pile I extracted them into a parametarised test and the errors are now clear in the implementation code, and most importantly they are all tested individually

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DBTP-1215]: https://uktrade.atlassian.net/browse/DBTP-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ