### PR TITLE
chore: Update README.md to add pull-request-end-to-end-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ For an optional manual check, install the package locally and test everything wo
 
 #### Merging to main
 
-- Merging to `main` will trigger the `pull-request-regression-tests` pipeline in the _platform-tools_ AWS account to run regression tests
+- Merging to `main` will trigger the `pull-request-end-to-end-tests` pipeline in the _platform-tools_ AWS account to run regression tests
 - We use the `release-please` GitHub action to create and update a _release PR_ when changes are merged to `main`
   - The _release PR_ will automatically update the _pyproject.toml_ version number and generate release notes based on the commits merged since the last release
   - Merging the _release PR_ will create a draft GitHub release for the next version with release notes
@@ -128,7 +128,7 @@ For an optional manual check, install the package locally and test everything wo
 
 Publishing a GitHub release should automatically:
 
-- Run the full `pull-request-regression-tests` pipeline
+- Run the full `pull-request-end-to-end-tests` pipeline
 - Trigger a CodeBuild project called `platform-tools-build` in the _platform-tools_ AWS account to run. This runs the _buildspec-pypi.yml_ file which contains the build steps to publish the new `platform-helper` package version to PyPI
 - Trigger a rebuild of the DBT Platform Documentation, so it includes the latest release documentation (currently WIP)
 - Push a notification to the development community via the #developers channel in Slack


### PR DESCRIPTION
Addresses: The fact we have changed the regression tests pipeline name to end-to-end tests
Please add any relevant context for you pull request here, or delete this if none needed.

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
