### PR TITLE
fix: DBTP-1511 Upload code coverage AND test analysis results to Codecov

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,7 +34,14 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
 
-      - name: Upload test results to Codecov
+      - name: Upload code coverage results to Codecov
+        uses: codecov/codecov-action@v4
+        if: ${{ !cancelled() }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+
+      - name: Upload test analysis results to Codecov
         uses: codecov/test-results-action@v1
         if: ${{ !cancelled() }}
         with:


### PR DESCRIPTION
Continuation of the work for [DBTP-1511](https://uktrade.atlassian.net/browse/DBTP-1511)

I hadn't realised we need to use `codecov/codecov-action@v4` AND `codecov/test-results-action@v1`. I had thought the latter would still handle the code coverage part.

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- ~[ ] Includes tests (or an explanation for why it doesn't)~
- ~[ ] If the work includes user interface changes, before and after screenshots included in description~
- ~[ ] Includes any applicable changes to the documentation in this code base~
- ~[ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~
### Tasks:
- ~[ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing~
