### PR TITLE
feat: Fall back on profile_account_id when trying to match account id to profile name.

### DIFF
--- a/dbt_platform_helper/utils/aws.py
+++ b/dbt_platform_helper/utils/aws.py
@@ -97,7 +97,9 @@ def get_profile_name_from_account_id(account_id: str):
     aws_config = ConfigParser()
     aws_config.read(Path.home().joinpath(".aws/config"))
     for section in aws_config.sections():
-        found_account_id = aws_config[section].get("sso_account_id", None)
+        found_account_id = aws_config[section].get(
+            "sso_account_id", aws_config[section].get("profile_account_id", None)
+        )
         if account_id == found_account_id:
             return section.removeprefix("profile ")
 

--- a/tests/platform_helper/utils/test_aws.py
+++ b/tests/platform_helper/utils/test_aws.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import mock_open
@@ -442,6 +443,25 @@ def test_get_profile_name_from_account_id(fakefs):
     assert get_profile_name_from_account_id("000000000") == "development"
     assert get_profile_name_from_account_id("111111111") == "staging"
     assert get_profile_name_from_account_id("222222222") == "production"
+
+
+def test_get_profile_name_from_account_id_when_not_using_sso(fs):
+    fs.create_file(
+        Path.home().joinpath(".aws/config"),
+        contents="""
+[profile development]
+region = eu-west-2
+output = json
+profile_account_id = 123456789
+
+[profile staging]
+region = eu-west-2
+output = json
+profile_account_id = 987654321
+""",
+    )
+    assert get_profile_name_from_account_id("123456789") == "development"
+    assert get_profile_name_from_account_id("987654321") == "staging"
 
 
 def test_get_profile_name_from_account_id_with_no_matching_account(fakefs):


### PR DESCRIPTION
Addresses [DBTP-1109](https://uktrade.atlassian.net/browse/DBTP-1109)

This is required to run the database copy command from a pipeline. The way our code gets account id given a profile name is by looking in the users aws config and getting the sso_application_id value from there.

A pipeline will not be configured with SSO, but with assumed roles, so we do not have the sso_account_id. We cannot add that parameter to the aws config in a pipeline as boto sees it and tries to connect via SSO which of course fails.

This workaround allows us to add a new profile_account_id parameter to the aws config file (which is not used by boto and is ignored) from which the command can pick up the account id.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [x] If the work includes user interface changes, before and after screenshots included in description
- [x] Includes any applicable changes to the documentation in this code base
- [x] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DBTP-1109]: https://uktrade.atlassian.net/browse/DBTP-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ