### PR TITLE
ci: Remove tests/platform_helper/utils/test_aws.py from .trufflehogignore

### DIFF
--- a/.trufflehogignore
+++ b/.trufflehogignore
@@ -3,6 +3,3 @@
 node_modules
 poetry.lock
 venv
-
-# See https://github.com/trufflesecurity/trufflehog/issues/3602
-tests/platform_helper/utils/test_aws.py

--- a/tests/platform_helper/utils/test_aws.py
+++ b/tests/platform_helper/utils/test_aws.py
@@ -19,14 +19,14 @@ from dbt_platform_helper.utils.aws import get_aws_session_or_abort
 from dbt_platform_helper.utils.aws import get_codestar_connection_arn
 from dbt_platform_helper.utils.aws import get_connection_string
 from dbt_platform_helper.utils.aws import get_load_balancer_domain_and_configuration
-from dbt_platform_helper.utils.aws import get_supported_opensearch_versions
 from dbt_platform_helper.utils.aws import (
     get_postgres_connection_data_updated_with_master_secret,
 )
 from dbt_platform_helper.utils.aws import get_profile_name_from_account_id
 from dbt_platform_helper.utils.aws import get_public_repository_arn
-from dbt_platform_helper.utils.aws import get_supported_redis_versions
 from dbt_platform_helper.utils.aws import get_ssm_secrets
+from dbt_platform_helper.utils.aws import get_supported_opensearch_versions
+from dbt_platform_helper.utils.aws import get_supported_redis_versions
 from dbt_platform_helper.utils.aws import get_vpc_info_by_name
 from dbt_platform_helper.utils.aws import set_ssm_param
 from tests.platform_helper.conftest import mock_aws_client
@@ -705,7 +705,6 @@ def test_get_connection_string():
     mock_connection_data.assert_called_once_with(
         session, f"/copilot/my_app/my_env/secrets/MY_POSTGRES_READ_ONLY_USER", master_secret_arn
     )
-    # Ignoring this does not work, see https://github.com/trufflesecurity/trufflehog/issues/3602
     assert (
         connection_string
         == "postgres://master_user:master_password@hostname:1234/main"  # trufflehog:ignore


### PR DESCRIPTION
The fix for [this bug](https://github.com/trufflesecurity/trufflehog/issues/3602) has been released in [Trufflehog 3.83.7](https://github.com/trufflesecurity/trufflehog/releases/tag/v3.83.7).

No actual code changes, so not end to end test run etc.

**Everyone will need to update Trufflehog to avoid annoying and confusing Trufflehog failures.**

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- ~[ ] Ticket reference included (unless it's a quick out of ticket thing)~
### Description:
- ~[ ] Link to ticket included (unless it's a quick out of ticket thing)~
- ~[ ] Includes tests (or an explanation for why it doesn't)~
- ~[ ] If the work includes user interface changes, before and after screenshots included in description~
- ~[ ] Includes any applicable changes to the documentation in this code base~
- ~[ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~
### Tasks:
- ~[ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing~
