### PR TITLE
feat: DBTP-1434 - CDN cache policy

### DIFF
--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -365,11 +365,11 @@ CACHE_POLICY_DEFINITION = {
 }
 
 PATHS_DEFINITION = {
-    "default": {
+    Optional("default"): {
         "cache": str,
         "request": str,
     },
-    "additional": list[
+    Optional("additional"): list[
         {
             "path": str,
             "cache": str,

--- a/dbt_platform_helper/utils/validation.py
+++ b/dbt_platform_helper/utils/validation.py
@@ -352,6 +352,32 @@ OPENSEARCH_DEFINITION = {
     },
 }
 
+CACHE_POLICY_DEFINITION = {
+    "min_ttl": int,
+    "max_ttl": int,
+    "default_ttl": int,
+    "cookies_config": Or("none", "whitelist", "allExcept", "all"),
+    "header": Or("none", "whitelist"),
+    "query_string_behavior": Or("none", "whitelist", "allExcept", "all"),
+    Optional("cookie_list"): list,
+    Optional("headers_list"): list,
+    Optional("cache_policy_query_strings"): list,
+}
+
+PATHS_DEFINITION = {
+    "default": {
+        "cache": str,
+        "request": str,
+    },
+    "additional": list[
+        {
+            "path": str,
+            "cache": str,
+            "request": str,
+        }
+    ],
+}
+
 ALB_DEFINITION = {
     "type": "alb",
     Optional("environments"): {
@@ -379,6 +405,9 @@ ALB_DEFINITION = {
                 Optional("viewer_certificate_minimum_protocol_version"): str,
                 Optional("viewer_certificate_ssl_support_method"): str,
                 Optional("viewer_protocol_policy"): str,
+                Optional("cache_policy"): dict({str: CACHE_POLICY_DEFINITION}),
+                Optional("origin_request_policy"): dict({str: {}}),
+                Optional("paths"): dict({str: PATHS_DEFINITION}),
             },
             None,
         )
@@ -521,7 +550,6 @@ def validate_platform_config(config):
 def _validate_extension_supported_versions(
     config, extension_type, version_key, get_supported_versions_fn
 ):
-
     extensions = config.get("extensions", {})
     if not extensions:
         return

--- a/images/copilot-bootstrap/default.conf.template
+++ b/images/copilot-bootstrap/default.conf.template
@@ -7,6 +7,10 @@ server {
         index  index.html index.htm;
     }
 
+    location /secondary-service {
+        alias /usr/share/nginx/html;
+    }
+
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html

--- a/tests/platform_helper/utils/fixtures/addons_files/alb_addons.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/alb_addons.yml
@@ -2,6 +2,41 @@ my-alb:
   type: alb
   environments:
     dev:
+        cache_policy:
+            "test-policy":
+                min_ttl: 3600
+                max_ttl: 31536000
+                default_ttl: 14400
+                cookies_config: "whitelist"
+                cookie_list: [ "x-csrf-token" ]
+                header: "whitelist"
+                headers_list: [ "CloudFront-Viewer-Country" ]
+                query_string_behavior: "whitelist"
+                cache_policy_query_strings: [ "q", "market" ]
+            "test-policy-2":
+                min_ttl: 3600
+                max_ttl: 31536000
+                default_ttl: 14400
+                cookies_config: "all"
+                cookie_list: [ ]
+                header: "none"
+                headers_list: [ ]
+                query_string_behavior: "all"
+                cache_policy_query_strings: [ ]
+        origin_request_policy:
+            "test-origin-request": { }
+        paths:
+            dev.application.uktrade.digital:
+                default:
+                    cache: "test-policy"
+                    request: "test-origin-request"
+                additional:
+                    - path: "/static"
+                      cache: "test-policy"
+                      request: "test-origin-request"
+                    - path: "/images"
+                      cache: "test-policy-2"
+                      request: "test-origin-request"
         additional_address_list: ["internal.api"]
         allowed_methods: ["GET", "POST", "OPTIONS"]
         cached_methods: ["GET", "HEAD"]

--- a/tests/platform_helper/utils/fixtures/addons_files/alb_addons_bad_data.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/alb_addons_bad_data.yml
@@ -71,7 +71,7 @@ my-alb-default-waf-should-be-a-string:
   type: alb
   environments:
     dev:
-      default_waf: [] # Should be a string
+      default_waf: [ ] # Should be a string
 
 
 my-alb-enable-logging-should-be-a-bool:
@@ -134,4 +134,109 @@ my-alb-view-protocol-policy-should-be-a-string:
   type: alb
   environments:
     dev:
-      viewer_protocol_policy: [] # Should be a string
+      viewer_protocol_policy: [ ] # Should be a string
+
+my-alb-cache-policy-min-ttl-should-be-a-int:
+  type: alb
+  environments:
+    dev:
+      cache_policy:
+        "test-policy":
+          min_ttl: "four hundred"
+
+my-alb-cache-policy-max-ttl-should-be-a-int:
+  type: alb
+  environments:
+    dev:
+      cache_policy:
+        "test-policy":
+          max_ttl: "three hundred"
+
+my-alb-cache-policy-default-ttl-should-be-a-int:
+  type: alb
+  environments:
+    dev:
+      cache_policy:
+        "test-policy":
+          default_ttl: "two hundred"
+
+my-alb-cache-policy-cookies-config-should-be-a-string:
+  type: alb
+  environments:
+    dev:
+      cache_policy:
+        "test-policy":
+          cookies_config: 44321
+
+my-alb-cache-policy-cookies-list-should-be-a-list:
+  type: alb
+  environments:
+    dev:
+      cache_policy:
+        "test-policy":
+          cookie_list: 123
+
+my-alb-cache-policy-header-should-be-a-string:
+  type: alb
+  environments:
+    dev:
+      cache_policy:
+        "test-policy":
+          header: 999
+
+my-alb-cache-policy-headers-list-should-be-a-list:
+  type: alb
+  environments:
+    dev:
+      cache_policy:
+        "test-policy":
+          headers_list: true
+
+my-alb-cache-policy-query-string-behavior-should-be-a-string:
+  type: alb
+  environments:
+    dev:
+      cache_policy:
+        "test-policy":
+          query_string_behavior: [ ]
+
+my-alb-cache-policy-cache-policy-query-strings-should-be-a-list:
+  type: alb
+  environments:
+    dev:
+      cache_policy:
+        "test-policy":
+          cache_policy_query_strings: 765
+
+my-alb-origin-request-policy-should-be-a-dict:
+  type: alb
+  environments:
+    dev:
+      origin_request_policy:
+        "test-origin-request": [ ]
+
+my-alb-paths-default-cache-should-be-a-string:
+  type: alb
+  environments:
+    dev:
+      paths:
+        dev.application.uktrade.digital:
+          default:
+            cache: 12345
+
+my-alb-paths-default-request-should-be-a-string:
+  type: alb
+  environments:
+    dev:
+      paths:
+        dev.application.uktrade.digital:
+          default:
+            request: { }
+
+my-alb-paths-additional-should-be-a-list:
+  type: alb
+  environments:
+    dev:
+      paths:
+        dev.application.uktrade.digital:
+          additional: false

--- a/tests/platform_helper/utils/test_validation.py
+++ b/tests/platform_helper/utils/test_validation.py
@@ -10,6 +10,7 @@ from schema import SchemaError
 from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_FILE
 from dbt_platform_helper.utils.validation import S3_BUCKET_NAME_ERROR_TEMPLATE
+from dbt_platform_helper.utils.validation import _validate_extension_supported_versions
 from dbt_platform_helper.utils.validation import config_file_check
 from dbt_platform_helper.utils.validation import float_between_with_halfstep
 from dbt_platform_helper.utils.validation import int_between
@@ -20,7 +21,6 @@ from dbt_platform_helper.utils.validation import validate_database_copy_section
 from dbt_platform_helper.utils.validation import validate_platform_config
 from dbt_platform_helper.utils.validation import validate_s3_bucket_name
 from dbt_platform_helper.utils.validation import validate_string
-from dbt_platform_helper.utils.validation import _validate_extension_supported_versions
 from tests.platform_helper.conftest import FIXTURES_DIR
 from tests.platform_helper.conftest import UTILS_FIXTURES_DIR
 
@@ -227,6 +227,19 @@ def test_validate_addons_success(addons_file):
                 "my-alb-viewer-certificate-minimum-protocol-version-should-be-a-string": r"environments.*dev.*should be instance of 'str'",
                 "my-alb-viewer-certificate-ssl-support-method-should-be-a-string": r"environments.*dev.*should be instance of 'str'",
                 "my-alb-view-protocol-policy-should-be-a-string": r"environments.*dev.*should be instance of 'str'",
+                "my-alb-cache-policy-min-ttl-should-be-a-int": r"environments.*dev.*should be instance of 'int'",
+                "my-alb-cache-policy-max-ttl-should-be-a-int": r"environments.*dev.*should be instance of 'int'",
+                "my-alb-cache-policy-default-ttl-should-be-a-int": r"environments.*dev.*should be instance of 'int'",
+                "my-alb-cache-policy-cookies-config-should-be-a-string": r"environments.*dev.*did not validate",
+                "my-alb-cache-policy-cookies-list-should-be-a-list": r"environments.*dev.*should be instance of 'list'",
+                "my-alb-cache-policy-header-should-be-a-string": r"environments.*dev.*did not validate",
+                "my-alb-cache-policy-headers-list-should-be-a-list": r"environments.*dev.*should be instance of 'list'",
+                "my-alb-cache-policy-query-string-behavior-should-be-a-string": r"environments.*dev.*did not validate",
+                "my-alb-cache-policy-cache-policy-query-strings-should-be-a-list": r"environments.*dev.*should be instance of 'list'",
+                "my-alb-origin-request-policy-should-be-a-dict": r"environments.*dev.*should be instance of 'dict'",
+                "my-alb-paths-default-cache-should-be-a-string": r"environments.*dev.*should be instance of 'str'",
+                "my-alb-paths-default-request-should-be-a-string": r"environments.*dev.*should be instance of 'str'",
+                "my-alb-paths-additional-should-be-a-list": r"environments.*dev.*raised TypeError",
             },
         ),
     ],


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1434

Add validation for CDN cache policies in `platform-config.yml`

Related PRs

- https://github.com/uktrade/demodjango-deploy/pull/249
- https://github.com/uktrade/platform-end-to-end-tests/pull/36

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
