### PR TITLE
fix: DBTP-1498 - Add option for database dump filename

### DIFF
--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -765,6 +765,7 @@ platform-helper database (dump|load|copy)
 ```
 platform-helper database dump --from <from_env> --database <database> 
                               [--app <application>] [--from-vpc <from_vpc>] 
+                              [--filename <filename>] 
 ```
 
 ## Options
@@ -777,6 +778,8 @@ platform-helper database dump --from <from_env> --database <database>
   - The name of the database you are dumping data from
 - `--from-vpc <text>`
   - The vpc the specified environment is running in. Required unless you are running the command from your deploy repo
+- `--filename <text>`
+  - Specify a name for the database dump file. Recommended if the same dump database is being used for multiple load environments
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.
 
@@ -791,7 +794,7 @@ platform-helper database dump --from <from_env> --database <database>
 ```
 platform-helper database load --to <to_env> --database <database> 
                               [--app <application>] [--to-vpc <to_vpc>] 
-                              [--auto-approve] 
+                              [--filename <filename>] [--auto-approve] 
 ```
 
 ## Options
@@ -806,6 +809,8 @@ platform-helper database load --to <to_env> --database <database>
   - The vpc the specified environment is running in. Required unless you are running the command from your deploy repo
 - `--auto-approve <boolean>` _Defaults to False._
 
+- `--filename <text>`
+  - Specify a name for the database dump file. Recommended if the same dump database is being used for multiple load environments
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.
 

--- a/dbt_platform_helper/commands/database.py
+++ b/dbt_platform_helper/commands/database.py
@@ -31,10 +31,15 @@ def database():
     type=str,
     help="The vpc the specified environment is running in. Required unless you are running the command from your deploy repo",
 )
-def dump(app, from_env, database, from_vpc):
+@click.option(
+    "--filename",
+    type=str,
+    help="Specify a name for the database dump file. Recommended if the same dump database is being used for multiple load environments",
+)
+def dump(app, from_env, database, from_vpc, filename):
     """Dump a database into an S3 bucket."""
     data_copy = DatabaseCopy(app, database)
-    data_copy.dump(from_env, from_vpc)
+    data_copy.dump(from_env, from_vpc, filename)
     # Todo: Catch expected errors and output message
 
 
@@ -56,10 +61,15 @@ def dump(app, from_env, database, from_vpc):
     help="The vpc the specified environment is running in. Required unless you are running the command from your deploy repo",
 )
 @click.option("--auto-approve/--no-auto-approve", default=False)
-def load(app, to_env, database, to_vpc, auto_approve):
+@click.option(
+    "--filename",
+    type=str,
+    help="Specify a name for the database dump file. Recommended if the same dump database is being used for multiple load environments",
+)
+def load(app, to_env, database, to_vpc, auto_approve, filename):
     """Load a database from an S3 bucket."""
     data_copy = DatabaseCopy(app, database, auto_approve)
-    data_copy.load(to_env, to_vpc)
+    data_copy.load(to_env, to_vpc, filename)
     # Todo: Catch expected errors and output message
 
 

--- a/dbt_platform_helper/domain/database_copy.py
+++ b/dbt_platform_helper/domain/database_copy.py
@@ -61,7 +61,7 @@ class DatabaseCopy:
         except ApplicationNotFoundException:
             abort(f"No such application '{app}'.")
 
-    def _execute_operation(self, is_dump: bool, env: str, vpc_name: str, to_env: str):
+    def _execute_operation(self, is_dump: bool, env: str, vpc_name: str, filename: str):
         vpc_name = self.enrich_vpc_name(env, vpc_name)
 
         environments = self.application.environments
@@ -89,7 +89,7 @@ class DatabaseCopy:
 
         try:
             task_arn = self.run_database_copy_task(
-                env_session, env, vpc_config, is_dump, db_connection_string, to_env
+                env_session, env, vpc_config, is_dump, db_connection_string, filename
             )
         except Exception as exc:
             self.abort(f"{exc} (Account id: {self.account_id(env)})")
@@ -122,14 +122,15 @@ class DatabaseCopy:
         vpc_config: Vpc,
         is_dump: bool,
         db_connection_string: str,
-        to_env: str,
+        filename: str,
     ) -> str:
         client = session.client("ecs")
         action = "dump" if is_dump else "load"
+        dump_file_name = filename if filename else "data_dump"
         env_vars = [
             {"name": "DATA_COPY_OPERATION", "value": action.upper()},
             {"name": "DB_CONNECTION_STRING", "value": db_connection_string},
-            {"name": "TO_ENVIRONMENT", "value": to_env},
+            {"name": "DUMP_FILE_NAME", "value": dump_file_name},
         ]
         if not is_dump:
             env_vars.append({"name": "ECS_CLUSTER", "value": f"{self.app}-{env}"})
@@ -159,12 +160,12 @@ class DatabaseCopy:
 
         return response.get("tasks", [{}])[0].get("taskArn")
 
-    def dump(self, env: str, vpc_name: str, to_env: str):
-        self._execute_operation(True, env, vpc_name, to_env)
+    def dump(self, env: str, vpc_name: str, filename: str = None):
+        self._execute_operation(True, env, vpc_name, filename)
 
-    def load(self, env: str, vpc_name: str):
+    def load(self, env: str, vpc_name: str, filename: str = None):
         if self.is_confirmed_ready_to_load(env):
-            self._execute_operation(False, env, vpc_name, to_env=env)
+            self._execute_operation(False, env, vpc_name, filename)
 
     def copy(
         self,
@@ -180,7 +181,7 @@ class DatabaseCopy:
         if not no_maintenance_page:
             self.maintenance_page_provider.activate(self.app, to_env, services, template, to_vpc)
         self.dump(from_env, from_vpc, to_env)
-        self.load(to_env, to_vpc)
+        self.load(to_env, to_vpc, to_env)
         if not no_maintenance_page:
             self.maintenance_page_provider.deactivate(self.app, to_env)
 

--- a/dbt_platform_helper/domain/database_copy.py
+++ b/dbt_platform_helper/domain/database_copy.py
@@ -180,8 +180,8 @@ class DatabaseCopy:
         to_vpc = self.enrich_vpc_name(to_env, to_vpc)
         if not no_maintenance_page:
             self.maintenance_page_provider.activate(self.app, to_env, services, template, to_vpc)
-        self.dump(from_env, from_vpc, to_env)
-        self.load(to_env, to_vpc, to_env)
+        self.dump(from_env, from_vpc, f"data_dump_{to_env}")
+        self.load(to_env, to_vpc, f"data_dump_{to_env}")
         if not no_maintenance_page:
             self.maintenance_page_provider.deactivate(self.app, to_env)
 

--- a/images/tools/database-copy/entrypoint.sh
+++ b/images/tools/database-copy/entrypoint.sh
@@ -2,9 +2,9 @@
 
 clean_up(){
   echo "Cleaning up dump file"
-  rm "data_dump_${TO_ENVIRONMENT}.sql"
+  rm "${DUMP_FILE_NAME}.sql"
   echo "Removing dump file from S3"
-  aws s3 rm s3://${S3_BUCKET_NAME}/"data_dump_${TO_ENVIRONMENT}.sql"
+  aws s3 rm s3://${S3_BUCKET_NAME}/"${DUMP_FILE_NAME}.sql"
   exit_code=$?
   if [ ${exit_code} -ne 0 ]
   then
@@ -27,7 +27,7 @@ handle_errors(){
 if [ "${DATA_COPY_OPERATION:-DUMP}" != "LOAD" ]
 then
   echo "Starting data dump"
-  pg_dump --no-owner --no-acl --format c "${DB_CONNECTION_STRING}" > "data_dump_${TO_ENVIRONMENT}.sql"
+  pg_dump --no-owner --no-acl --format c "${DB_CONNECTION_STRING}" > "${DUMP_FILE_NAME}.sql"
   exit_code=$?
 
   if [ ${exit_code} -ne 0 ]
@@ -36,7 +36,7 @@ then
     exit $exit_code
   fi
 
-  aws s3 cp "data_dump_${TO_ENVIRONMENT}.sql" s3://${S3_BUCKET_NAME}/
+  aws s3 cp "${DUMP_FILE_NAME}.sql" s3://${S3_BUCKET_NAME}/
   exit_code=$?
 
   if [ ${exit_code} -ne 0 ]
@@ -50,7 +50,7 @@ else
   echo "Starting data load"
 
   echo "Copying data dump from S3"
-  aws s3 cp s3://${S3_BUCKET_NAME}/"data_dump_${TO_ENVIRONMENT}.sql" "data_dump_${TO_ENVIRONMENT}.sql"
+  aws s3 cp s3://${S3_BUCKET_NAME}/"${DUMP_FILE_NAME}.sql" "${DUMP_FILE_NAME}.sql"
   
   handle_errors $? "Copy failed"
 
@@ -82,7 +82,7 @@ else
   handle_errors $? "Clear down failed"
   
   echo "Restoring data from dump file"
-  pg_restore --format c --dbname "${DB_CONNECTION_STRING}" "data_dump_${TO_ENVIRONMENT}.sql"
+  pg_restore --format c --dbname "${DB_CONNECTION_STRING}" "${DUMP_FILE_NAME}.sql"
   
   handle_errors $? "Restore failed"
   for service in ${SERVICES}

--- a/tests/platform_helper/domain/test_database_copy.py
+++ b/tests/platform_helper/domain/test_database_copy.py
@@ -363,8 +363,10 @@ def test_copy_command(services, template):
     mocks.maintenance_page_provider.activate.assert_called_once_with(
         "test-app", "test-to-env", services, template, "test-vpc-override"
     )
-    db_copy.dump.assert_called_once_with("test-from-env", "test-from-vpc", "test-to-env")
-    db_copy.load.assert_called_once_with("test-to-env", "test-vpc-override", "test-to-env")
+    db_copy.dump.assert_called_once_with("test-from-env", "test-from-vpc", "data_dump_test-to-env")
+    db_copy.load.assert_called_once_with(
+        "test-to-env", "test-vpc-override", "data_dump_test-to-env"
+    )
     mocks.maintenance_page_provider.deactivate.assert_called_once_with("test-app", "test-to-env")
 
 

--- a/tests/platform_helper/domain/test_database_copy.py
+++ b/tests/platform_helper/domain/test_database_copy.py
@@ -58,7 +58,7 @@ def test_run_database_copy_task(is_dump, exp_operation):
     mock_client.run_task.return_value = {"tasks": [{"taskArn": "arn:aws:ecs:test-task-arn"}]}
 
     actual_task_arn = db_copy.run_database_copy_task(
-        mock_session, "test-env", vpc, is_dump, db_connection_string, "test-env"
+        mock_session, "test-env", vpc, is_dump, db_connection_string, "test-dump-file"
     )
 
     assert actual_task_arn == "arn:aws:ecs:test-task-arn"
@@ -67,7 +67,7 @@ def test_run_database_copy_task(is_dump, exp_operation):
     expected_env_vars = [
         {"name": "DATA_COPY_OPERATION", "value": exp_operation.upper()},
         {"name": "DB_CONNECTION_STRING", "value": "connection_string"},
-        {"name": "TO_ENVIRONMENT", "value": "test-env"},
+        {"name": "DUMP_FILE_NAME", "value": "test-dump-file"},
     ]
     if not is_dump:
         expected_env_vars.append(
@@ -117,7 +117,7 @@ def test_database_dump():
     db_copy.enrich_vpc_name = Mock()
     db_copy.enrich_vpc_name.return_value = "test-vpc-override"
 
-    db_copy.dump(env, vpc_name, "test-env")
+    db_copy.dump(env, vpc_name)
 
     mocks.load_application.assert_called_once()
     mocks.vpc_config.assert_called_once_with(
@@ -127,7 +127,7 @@ def test_database_dump():
         mocks.environment.session, app, env, "test-app-test-env-test-db"
     )
     mock_run_database_copy_task.assert_called_once_with(
-        mocks.environment.session, env, mocks.vpc, True, "test-db-connection-string", "test-env"
+        mocks.environment.session, env, mocks.vpc, True, "test-db-connection-string", None
     )
     mocks.input.assert_not_called()
     mocks.echo.assert_has_calls(
@@ -170,7 +170,7 @@ def test_database_load_with_response_of_yes():
     )
 
     mock_run_database_copy_task.assert_called_once_with(
-        mocks.environment.session, env, mocks.vpc, False, "test-db-connection-string", "test-env"
+        mocks.environment.session, env, mocks.vpc, False, "test-db-connection-string", None
     )
 
     mocks.input.assert_called_once_with(
@@ -247,7 +247,7 @@ def test_database_dump_handles_db_name_errors(is_dump):
 
     with pytest.raises(SystemExit) as exc:
         if is_dump:
-            db_copy.dump("test-env", "vpc-name", "test-env")
+            db_copy.dump("test-env", "vpc-name")
         else:
             db_copy.load("test-env", "vpc-name")
 
@@ -263,7 +263,7 @@ def test_database_dump_handles_env_name_errors(is_dump):
 
     with pytest.raises(SystemExit) as exc:
         if is_dump:
-            db_copy.dump("bad-env", "vpc-name", "test-env")
+            db_copy.dump("bad-env", "vpc-name")
         else:
             db_copy.load("bad-env", "vpc-name")
 
@@ -284,7 +284,7 @@ def test_database_dump_handles_account_id_errors(is_dump):
 
     with pytest.raises(SystemExit) as exc:
         if is_dump:
-            db_copy.dump("test-env", "vpc-name", "test-env")
+            db_copy.dump("test-env", "vpc-name")
         else:
             db_copy.load("test-env", "vpc-name")
 
@@ -364,7 +364,7 @@ def test_copy_command(services, template):
         "test-app", "test-to-env", services, template, "test-vpc-override"
     )
     db_copy.dump.assert_called_once_with("test-from-env", "test-from-vpc", "test-to-env")
-    db_copy.load.assert_called_once_with("test-to-env", "test-vpc-override")
+    db_copy.load.assert_called_once_with("test-to-env", "test-vpc-override", "test-to-env")
     mocks.maintenance_page_provider.deactivate.assert_called_once_with("test-app", "test-to-env")
 
 

--- a/tests/platform_helper/test_command_database.py
+++ b/tests/platform_helper/test_command_database.py
@@ -28,7 +28,33 @@ def test_command_dump_success(mock_database_copy_object):
 
     assert result.exit_code == 0
     mock_database_copy_object.assert_called_once_with("my_app", "my_postgres")
-    mock_database_copy_instance.dump.assert_called_once_with("my_env", "my_vpc")
+    mock_database_copy_instance.dump.assert_called_once_with("my_env", "my_vpc", None)
+
+
+@patch("dbt_platform_helper.commands.database.DatabaseCopy")
+def test_command_dump_success_with_filename(mock_database_copy_object):
+    mock_database_copy_instance = mock_database_copy_object.return_value
+
+    runner = CliRunner()
+    result = runner.invoke(
+        dump,
+        [
+            "--app",
+            "my_app",
+            "--from",
+            "my_env",
+            "--database",
+            "my_postgres",
+            "--from-vpc",
+            "my_vpc",
+            "--filename",
+            "my_dump_file",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_database_copy_object.assert_called_once_with("my_app", "my_postgres")
+    mock_database_copy_instance.dump.assert_called_once_with("my_env", "my_vpc", "my_dump_file")
 
 
 @patch("dbt_platform_helper.commands.database.DatabaseCopy")
@@ -51,7 +77,7 @@ def test_command_load_success(mock_database_copy_object):
 
     assert result.exit_code == 0
     mock_database_copy_object.assert_called_once_with("my_app", "my_postgres", False)
-    mock_database_copy_instance.load.assert_called_once_with("my_env", "my_vpc")
+    mock_database_copy_instance.load.assert_called_once_with("my_env", "my_vpc", None)
 
 
 @patch("dbt_platform_helper.commands.database.DatabaseCopy")
@@ -75,7 +101,32 @@ def test_command_load_success_with_auto_approve(mock_database_copy_object):
 
     assert result.exit_code == 0
     mock_database_copy_object.assert_called_once_with("my_app", "my_postgres", True)
-    mock_database_copy_instance.load.assert_called_once_with("my_env", "my_vpc")
+    mock_database_copy_instance.load.assert_called_once_with("my_env", "my_vpc", None)
+
+
+@patch("dbt_platform_helper.commands.database.DatabaseCopy")
+def test_command_load_success_with_filename(mock_database_copy_object):
+    mock_database_copy_instance = mock_database_copy_object.return_value
+    runner = CliRunner()
+    result = runner.invoke(
+        load,
+        [
+            "--app",
+            "my_app",
+            "--to",
+            "my_env",
+            "--database",
+            "my_postgres",
+            "--to-vpc",
+            "my_vpc",
+            "--filename",
+            "my_dump_file",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_database_copy_object.assert_called_once_with("my_app", "my_postgres", False)
+    mock_database_copy_instance.load.assert_called_once_with("my_env", "my_vpc", "my_dump_file")
 
 
 @patch("dbt_platform_helper.commands.database.DatabaseCopy")


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1498

Add option on database dump and load commands to specify the filename of the database dump file.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
