### PR TITLE
fix: DBTP-1509 Correct link to maintenance pages instructions

### DIFF
--- a/dbt_platform_helper/domain/maintenance_page.py
+++ b/dbt_platform_helper/domain/maintenance_page.py
@@ -261,7 +261,7 @@ def add_maintenance_page(
         )
 
         click.secho(
-            f"\nUse a browser plugin to add `Bypass-Key` header with value {bypass_value} to your requests. For more detail, visit https://platform.readme.trade.gov.uk/activities/holding-and-maintenance-pages/",
+            f"\nUse a browser plugin to add `Bypass-Key` header with value {bypass_value} to your requests. For more detail, visit https://platform.readme.trade.gov.uk/next-steps/put-a-service-under-maintenance/",
             fg="green",
         )
 


### PR DESCRIPTION
Addresses [DBTP-1509](https://uktrade.atlassian.net/browse/DBTP-1509)

No tests, just a little text change.

End to end tests run would be pointless for this one.

https://github.com/uktrade/platform-documentation/pull/430 should be merged before this.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- ~[ ] If the work includes user interface changes, before and after screenshots included in description~
- ~[ ] Includes any applicable changes to the documentation in this code base~
- ~[ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~
### Tasks:
- ~[ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing~


[DBTP-1509]: https://uktrade.atlassian.net/browse/DBTP-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ