### PR TITLE
fix: DBTP-1645 - conduit out of memory when querying large data sets

### DIFF
--- a/dbt_platform_helper/providers/copilot.py
+++ b/dbt_platform_helper/providers/copilot.py
@@ -60,6 +60,7 @@ def create_addon_client_task(
 
     subprocess.call(
         f"copilot task run --app {application.name} --env {env} "
+        f"--cpu 2048 --memory 4096 "
         f"--task-group-name {task_name} "
         f"{execution_role}"
         f"--image {CONDUIT_DOCKER_IMAGE_LOCATION}:{addon_type} "

--- a/dbt_platform_helper/providers/copilot.py
+++ b/dbt_platform_helper/providers/copilot.py
@@ -95,6 +95,7 @@ def create_postgres_admin_task(
 
     subprocess.call(
         f"copilot task run --app {app.name} --env {env} "
+        f"--cpu 2048 --memory 4096 "
         f"--task-group-name {task_name} "
         f"--image {CONDUIT_DOCKER_IMAGE_LOCATION}:{addon_type} "
         f"--env-vars CONNECTION_SECRET='{connection_string}' "

--- a/dbt_platform_helper/providers/copilot.py
+++ b/dbt_platform_helper/providers/copilot.py
@@ -60,11 +60,11 @@ def create_addon_client_task(
 
     subprocess.call(
         f"copilot task run --app {application.name} --env {env} "
-        f"--cpu 2048 --memory 4096 "
         f"--task-group-name {task_name} "
         f"{execution_role}"
         f"--image {CONDUIT_DOCKER_IMAGE_LOCATION}:{addon_type} "
         f"--secrets CONNECTION_SECRET={_get_secrets_provider(application, env).get_connection_secret_arn(secret_name)} "
+        "--cpu 2048 --memory 4096 "
         "--platform-os linux "
         "--platform-arch arm64",
         shell=True,
@@ -96,10 +96,10 @@ def create_postgres_admin_task(
 
     subprocess.call(
         f"copilot task run --app {app.name} --env {env} "
-        f"--cpu 2048 --memory 4096 "
         f"--task-group-name {task_name} "
         f"--image {CONDUIT_DOCKER_IMAGE_LOCATION}:{addon_type} "
         f"--env-vars CONNECTION_SECRET='{connection_string}' "
+        "--cpu 2048 --memory 4096 "
         "--platform-os linux "
         "--platform-arch arm64",
         shell=True,

--- a/tests/platform_helper/providers/test_copilot.py
+++ b/tests/platform_helper/providers/test_copilot.py
@@ -116,6 +116,7 @@ def test_create_redis_or_opensearch_addon_client_task(
     mock_subprocess.call.assert_called()
     mock_subprocess.call.assert_called_once_with(
         f"copilot task run --app test-application --env {env} "
+        f"--cpu 2048 --memory 4096 "
         f"--task-group-name {task_name} "
         f"--execution-role {addon_name}-{mock_application.name}-{env}-conduitEcsTask "
         f"--image public.ecr.aws/uktrade/tunnel:{addon_type} "
@@ -169,6 +170,7 @@ def test_create_postgres_addon_client_task(
     mock_subprocess.call.assert_called()
     mock_subprocess.call.assert_called_once_with(
         f"copilot task run --app test-application --env {env} "
+        f"--cpu 2048 --memory 4096 "
         f"--task-group-name {task_name} "
         f"--execution-role {addon_name}-{mock_application.name}-{env}-conduitEcsTask "
         f"--image public.ecr.aws/uktrade/tunnel:{addon_type} "
@@ -258,6 +260,7 @@ def test_create_addon_client_task_does_not_add_execution_role_if_role_not_found(
 
     mock_subprocess.call.assert_called_once_with(
         f"copilot task run --app test-application --env {env} "
+        f"--cpu 2048 --memory 4096 "
         f"--task-group-name {task_name} "
         f"--image public.ecr.aws/uktrade/tunnel:{addon_type} "
         "--secrets CONNECTION_SECRET=test-arn "

--- a/tests/platform_helper/providers/test_copilot.py
+++ b/tests/platform_helper/providers/test_copilot.py
@@ -54,6 +54,7 @@ def test_create_postgres_admin_task(mock_update_parameter, mock_application):
 
     mock_subprocess.call.assert_called_once_with(
         f"copilot task run --app {mock_application.name} --env {env} "
+        f"--cpu 2048 --memory 4096 "
         f"--task-group-name test-task "
         "--image public.ecr.aws/uktrade/tunnel:postgres "
         "--env-vars CONNECTION_SECRET='\"connection string\"' "

--- a/tests/platform_helper/providers/test_copilot.py
+++ b/tests/platform_helper/providers/test_copilot.py
@@ -54,10 +54,10 @@ def test_create_postgres_admin_task(mock_update_parameter, mock_application):
 
     mock_subprocess.call.assert_called_once_with(
         f"copilot task run --app {mock_application.name} --env {env} "
-        f"--cpu 2048 --memory 4096 "
-        f"--task-group-name test-task "
+        "--task-group-name test-task "
         "--image public.ecr.aws/uktrade/tunnel:postgres "
         "--env-vars CONNECTION_SECRET='\"connection string\"' "
+        "--cpu 2048 --memory 4096 "
         "--platform-os linux "
         "--platform-arch arm64",
         shell=True,
@@ -117,11 +117,11 @@ def test_create_redis_or_opensearch_addon_client_task(
     mock_subprocess.call.assert_called()
     mock_subprocess.call.assert_called_once_with(
         f"copilot task run --app test-application --env {env} "
-        f"--cpu 2048 --memory 4096 "
         f"--task-group-name {task_name} "
         f"--execution-role {addon_name}-{mock_application.name}-{env}-conduitEcsTask "
         f"--image public.ecr.aws/uktrade/tunnel:{addon_type} "
         "--secrets CONNECTION_SECRET=test-arn "
+        "--cpu 2048 --memory 4096 "
         "--platform-os linux "
         "--platform-arch arm64",
         shell=True,
@@ -171,11 +171,11 @@ def test_create_postgres_addon_client_task(
     mock_subprocess.call.assert_called()
     mock_subprocess.call.assert_called_once_with(
         f"copilot task run --app test-application --env {env} "
-        f"--cpu 2048 --memory 4096 "
         f"--task-group-name {task_name} "
         f"--execution-role {addon_name}-{mock_application.name}-{env}-conduitEcsTask "
         f"--image public.ecr.aws/uktrade/tunnel:{addon_type} "
         "--secrets CONNECTION_SECRET=test-arn "
+        "--cpu 2048 --memory 4096 "
         "--platform-os linux "
         "--platform-arch arm64",
         shell=True,
@@ -261,10 +261,10 @@ def test_create_addon_client_task_does_not_add_execution_role_if_role_not_found(
 
     mock_subprocess.call.assert_called_once_with(
         f"copilot task run --app test-application --env {env} "
-        f"--cpu 2048 --memory 4096 "
         f"--task-group-name {task_name} "
         f"--image public.ecr.aws/uktrade/tunnel:{addon_type} "
         "--secrets CONNECTION_SECRET=test-arn "
+        "--cpu 2048 --memory 4096 "
         "--platform-os linux "
         "--platform-arch arm64",
         shell=True,


### PR DESCRIPTION
Addresses [DBTP-1645](https://uktrade.atlassian.net/browse/DBTP-1645)

---
## Checklist:

### Title:
- [ ] ~~Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)~~
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
    - The underlying issue is difficult to replicate in regression pipelines.
- [ ] ~~If the work includes user interface changes, before and after screenshots included in description~~
- [ ] ~~Includes any applicable changes to the documentation in this code base~~
- [ ] ~~Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~~
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing


[DBTP-1645]: https://uktrade.atlassian.net/browse/DBTP-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ