### PR TITLE
chore: DBTP-1630 - remove _fn suffix and variable typo

### DIFF
--- a/dbt_platform_helper/domain/terraform_environment.py
+++ b/dbt_platform_helper/domain/terraform_environment.py
@@ -56,9 +56,9 @@ class TerraformEnvironment:
         self,
         config_provider,
         manifest_generator: PlatformTerraformManifestGenerator = None,
-        echo_fn=click.echo,
+        echo=click.echo,
     ):
-        self.echo = echo_fn
+        self.echo = echo
         self.config_provider = config_provider
         self.manifest_generator = manifest_generator or PlatformTerraformManifestGenerator(
             FileProvider()

--- a/tests/platform_helper/domain/test_terraform_environment.py
+++ b/tests/platform_helper/domain/test_terraform_environment.py
@@ -33,7 +33,7 @@ class TestGenerateTerraform:
         terraform_environment = TerraformEnvironment(
             config_provider=mock_config_provider,
             manifest_generator=Mock(),
-            echo_fn=Mock(),
+            echo=Mock(),
         )
         with pytest.raises(
             PlatformException,
@@ -56,7 +56,7 @@ class TestGenerateTerraform:
         terraform_environment = TerraformEnvironment(
             config_provider=mock_config_provider,
             manifest_generator=mock_generator,
-            echo_fn=mock_echo_fn,
+            echo=mock_echo_fn,
         )
 
         terraform_environment.generate("test")

--- a/tests/platform_helper/providers/test_config.py
+++ b/tests/platform_helper/providers/test_config.py
@@ -266,7 +266,7 @@ def test_get_enriched_config_returns_config_with_environment_defaults_applied():
         },
     }
 
-    expected_enriched_config_config = {
+    expected_enriched_config = {
         "application": "test-app",
         "environments": {
             "test": {
@@ -283,7 +283,7 @@ def test_get_enriched_config_returns_config_with_environment_defaults_applied():
     mock_config_validator = Mock()
 
     result = ConfigProvider(mock_config_validator, mock_file_provider).get_enriched_config()
-    assert result == expected_enriched_config_config
+    assert result == expected_enriched_config
 
 
 def test_validation_fails_if_invalid_default_version_keys_present(


### PR DESCRIPTION
Addresses [DBTP-1630](https://uktrade.atlassian.net/browse/DBTP-1630)

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing


[DBTP-1630]: https://uktrade.atlassian.net/browse/DBTP-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ