### PR TITLE
fix: use get_rules_tag_descriptions method to get descriptions

### DIFF
--- a/dbt_platform_helper/domain/maintenance_page.py
+++ b/dbt_platform_helper/domain/maintenance_page.py
@@ -144,9 +144,7 @@ def remove_maintenance_page(session: boto3.Session, listener_arn: str):
     lb_client = session.client("elbv2")
 
     rules = lb_client.describe_rules(ListenerArn=listener_arn)["Rules"]
-    tag_descriptions = lb_client.describe_tags(ResourceArns=[r["RuleArn"] for r in rules])[
-        "TagDescriptions"
-    ]
+    tag_descriptions = get_rules_tag_descriptions(rules, lb_client)
 
     for name in ["MaintenancePage", "AllowedIps", "BypassIpFilter", "AllowedSourceIps"]:
         deleted = delete_listener_rule(tag_descriptions, name, lb_client)


### PR DESCRIPTION
Addresses [DBTP-1697](https://uktrade.atlassian.net/browse/DBTP-1697)

No need for an additional test

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't) 
~- [ ] If the work includes user interface changes, before and after screenshots included in description~
~- [ ] Includes any applicable changes to the documentation in this code base~
~- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing

Haven't ran e2e tests but have tested the script on lite prod using a local version of platform helper with these changes (bug does not happen in demo django anyway)


[DBTP-1697]: https://uktrade.atlassian.net/browse/DBTP-1697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ