### PR TITLE
feat: DBTP-1635 Add additional S3 source bucket validation 

### DIFF
--- a/dbt_platform_helper/domain/config_validator.py
+++ b/dbt_platform_helper/domain/config_validator.py
@@ -23,6 +23,7 @@ class ConfigValidator:
             self.validate_codebase_pipelines,
             self.validate_environment_pipelines_triggers,
             self.validate_database_copy_section,
+            self.validate_database_migration_input_sources,
         ]
         self.io = io
 
@@ -238,6 +239,37 @@ class ConfigValidator:
                         errors.append(
                             f"Incorrect value for 'to_account' for environment '{to_env}'"
                         )
+
+        if errors:
+            abort_with_error("\n".join(errors))
+
+    def validate_database_migration_input_sources(self, config):
+        extensions = config.get("extensions", {})
+        if not extensions:
+            return
+
+        s3_extensions = {
+            key: ext for key, ext in extensions.items() if ext.get("type", None) == "s3"
+        }
+
+        if not s3_extensions:
+            return
+
+        errors = []
+
+        for extension_name, extension in s3_extensions.items():
+            for env, env_config in extension.get("environments", {}).items():
+                if "data_migration" not in env_config:
+                    continue
+                data_migration = env_config.get("data_migration", {})
+                if "import" in data_migration and "import_sources" in data_migration:
+                    errors.append(
+                        f"Error in '{extension_name}.environments.{env}.data_migration': only the 'import_sources' property is required - 'import' is deprecated."
+                    )
+                if "import" not in data_migration and "import_sources" not in data_migration:
+                    errors.append(
+                        f"Error in '{extension_name}.environments.{env}.data_migration': 'import_sources' property is missing."
+                    )
 
         if errors:
             abort_with_error("\n".join(errors))

--- a/dbt_platform_helper/providers/platform_config_schema.py
+++ b/dbt_platform_helper/providers/platform_config_schema.py
@@ -430,7 +430,7 @@ class PlatformConfigSchema:
         if errors:
             # Todo: Raise suitable PlatformException?
             raise SchemaError(
-                f"Bucket name '{name}' is invalid:\n{'\\n'.join(f'  {e}' for e in errors)}"
+                "Bucket name '{}' is invalid:\n{}".format(name, "\n".join(f"  {e}" for e in errors))
             )
 
         return True

--- a/dbt_platform_helper/providers/platform_config_schema.py
+++ b/dbt_platform_helper/providers/platform_config_schema.py
@@ -430,7 +430,7 @@ class PlatformConfigSchema:
         if errors:
             # Todo: Raise suitable PlatformException?
             raise SchemaError(
-                "Bucket name '{}' is invalid:\n{}".format(name, "\n".join(f"  {e}" for e in errors))
+                f"Bucket name '{name}' is invalid:\n{'\\n'.join(f'  {e}' for e in errors)}"
             )
 
         return True
@@ -451,6 +451,15 @@ class PlatformConfigSchema:
                 "source_bucket_arn": _valid_s3_bucket_arn("source_bucket_arn"),
                 "worker_role_arn": PlatformConfigSchema.__valid_iam_role_arn("worker_role_arn"),
             },
+            Optional("import_sources"): [
+                {
+                    Optional("source_kms_key_arn"): PlatformConfigSchema.__valid_kms_key_arn(
+                        "source_kms_key_arn"
+                    ),
+                    "source_bucket_arn": _valid_s3_bucket_arn("source_bucket_arn"),
+                    "worker_role_arn": PlatformConfigSchema.__valid_iam_role_arn("worker_role_arn"),
+                }
+            ],
         }
 
         _valid_s3_bucket_retention_policy = Or(

--- a/dbt_platform_helper/providers/platform_config_schema.py
+++ b/dbt_platform_helper/providers/platform_config_schema.py
@@ -443,23 +443,17 @@ class PlatformConfigSchema:
                 error=f"{key} must contain a valid ARN for an S3 bucket",
             )
 
+        _single_import_config = {
+            Optional("source_kms_key_arn"): PlatformConfigSchema.__valid_kms_key_arn(
+                "source_kms_key_arn"
+            ),
+            "source_bucket_arn": _valid_s3_bucket_arn("source_bucket_arn"),
+            "worker_role_arn": PlatformConfigSchema.__valid_iam_role_arn("worker_role_arn"),
+        }
+
         _valid_s3_data_migration = {
-            "import": {
-                Optional("source_kms_key_arn"): PlatformConfigSchema.__valid_kms_key_arn(
-                    "source_kms_key_arn"
-                ),
-                "source_bucket_arn": _valid_s3_bucket_arn("source_bucket_arn"),
-                "worker_role_arn": PlatformConfigSchema.__valid_iam_role_arn("worker_role_arn"),
-            },
-            Optional("import_sources"): [
-                {
-                    Optional("source_kms_key_arn"): PlatformConfigSchema.__valid_kms_key_arn(
-                        "source_kms_key_arn"
-                    ),
-                    "source_bucket_arn": _valid_s3_bucket_arn("source_bucket_arn"),
-                    "worker_role_arn": PlatformConfigSchema.__valid_iam_role_arn("worker_role_arn"),
-                }
-            ],
+            Optional("import"): _single_import_config,
+            Optional("import_sources"): [_single_import_config],
         }
 
         _valid_s3_bucket_retention_policy = Or(

--- a/tests/platform_helper/utils/fixtures/addons_files/s3_addons.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/s3_addons.yml
@@ -59,6 +59,22 @@ my-s3-bucket-with-data-migration:
           source_bucket_arn: arn:aws:s3:::test-app
           source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
           worker_role_arn: arn:aws:iam::123456789012:role/test-role
+          
+my-s3-bucket-with-data-migration-import-sources:
+  type: s3
+  environments:
+    dev:
+      bucket_name: s3-data-migration
+      versioning: false
+      data_migration:
+        import: 
+          source_bucket_arn: arn:aws:s3:::test-app
+          source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
+          worker_role_arn: arn:aws:iam::123456789012:role/test-role
+        import_sources:
+          - source_bucket_arn: arn:aws:s3:::valid-source-bucket-2
+            source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-2
+            worker_role_arn: arn:aws:iam::123456789012:role/test-role-2
 
 my-s3-bucket-with-external-access:
   type: s3

--- a/tests/platform_helper/utils/fixtures/addons_files/s3_addons.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/s3_addons.yml
@@ -67,10 +67,6 @@ my-s3-bucket-with-data-migration-import-sources:
       bucket_name: s3-data-migration
       versioning: false
       data_migration:
-        import: 
-          source_bucket_arn: arn:aws:s3:::test-app
-          source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
-          worker_role_arn: arn:aws:iam::123456789012:role/test-role
         import_sources:
           - source_bucket_arn: arn:aws:s3:::valid-source-bucket-2
             source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-2

--- a/tests/platform_helper/utils/fixtures/addons_files/s3_addons_bad_data.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/s3_addons_bad_data.yml
@@ -160,10 +160,6 @@ my-s3-bucket-data-migration-import-sources-source-bucket-2-invalid-arn:
     dev:
       bucket_name: mandatory
       data_migration:
-        import:
-          source_bucket_arn: arn:aws:s3:::test-app
-          source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
-          worker_role_arn: arn:aws:iam::123456789012:role/test-role 
         import_sources:
           - source_bucket_arn: 1234abc
             source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-2
@@ -172,6 +168,24 @@ my-s3-bucket-data-migration-import-sources-source-bucket-2-invalid-arn:
             source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-3
             worker_role_arn: arn:aws:iam::123456789012:role/test-role-3
             
+my-s3-bucket-data-migration-import-cannot-have-both-import-and-import-sources:
+  type: s3
+  environments:
+    dev:
+      bucket_name: mandatory
+      data_migration:
+        import:
+          source_bucket_arn: arn:aws:s3:::test-app
+          source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
+          worker_role_arn: arn:aws:iam::123456789012:role/test-role
+        import_sources:
+          - source_bucket_arn: 1234abc
+            source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-2
+            worker_role_arn: arn:aws:iam::123456789012:role/test-role-2
+          - source_bucket_arn: arn:aws:s3:::valid-source-bucket-2
+            source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-3
+            worker_role_arn: arn:aws:iam::123456789012:role/test-role-3
+
 my-s3-bucket-data-migration-import-sources-source-bucket-3-invalid-arn:
   type: s3
   environments:

--- a/tests/platform_helper/utils/fixtures/addons_files/s3_addons_bad_data.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/s3_addons_bad_data.yml
@@ -153,6 +153,112 @@ my-s3-bucket-data-migration-worker-role-invalid-arn:
           source_bucket_arn: arn:aws:s3:::test-app
           source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
           worker_role_arn: 1234abc
+          
+my-s3-bucket-data-migration-import-sources-source-bucket-2-invalid-arn:
+  type: s3
+  environments:
+    dev:
+      bucket_name: mandatory
+      data_migration:
+        import:
+          source_bucket_arn: arn:aws:s3:::test-app
+          source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
+          worker_role_arn: arn:aws:iam::123456789012:role/test-role 
+        import_sources:
+          - source_bucket_arn: 1234abc
+            source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-2
+            worker_role_arn: arn:aws:iam::123456789012:role/test-role-2
+          - source_bucket_arn: arn:aws:s3:::valid-source-bucket-2
+            source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-3
+            worker_role_arn: arn:aws:iam::123456789012:role/test-role-3
+            
+my-s3-bucket-data-migration-import-sources-source-bucket-3-invalid-arn:
+  type: s3
+  environments:
+    dev:
+      bucket_name: mandatory
+      data_migration:
+        import:
+          source_bucket_arn: arn:aws:s3:::test-app
+          source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
+          worker_role_arn: arn:aws:iam::123456789012:role/test-role 
+        import_sources:
+          - source_bucket_arn: arn:aws:s3:::valid-source-bucket-2
+            source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-2
+            worker_role_arn: arn:aws:iam::123456789012:role/test-role-2
+          - source_bucket_arn: 1234abc
+            source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-3
+            worker_role_arn: arn:aws:iam::123456789012:role/test-role-3
+
+my-s3-bucket-data-migration-import-sources-kms-key-invalid-arn:
+  type: s3
+  environments:
+    dev:
+      bucket_name: mandatory
+      data_migration:
+        import:
+          source_bucket_arn: arn:aws:s3:::test-app
+          source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
+          worker_role_arn: arn:aws:iam::123456789012:role/test-role 
+        import_sources:
+          - source_bucket_arn: arn:aws:s3:::test-app-2
+            source_kms_key_arn: 1234abc
+            worker_role_arn: arn:aws:iam::123456789012:role/test-role-2
+
+my-s3-bucket-data-migration-import-sources-worker-role-invalid-arn:
+  type: s3
+  environments:
+    dev:
+      bucket_name: mandatory
+      data_migration:
+        import:
+          source_bucket_arn: arn:aws:s3:::test-app
+          source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
+          worker_role_arn: arn:aws:iam::123456789012:role/test-role 
+        import_sources:
+          - source_bucket_arn: arn:aws:s3:::test-app-2
+            source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-2
+            worker_role_arn: 1234abc
+
+my-s3-bucket-data-migration-import-sources-empty:
+  type: s3
+  environments:
+    dev:
+      bucket_name: mandatory
+      data_migration:
+        import:
+          source_bucket_arn: arn:aws:s3:::test-app
+          source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
+          worker_role_arn: arn:aws:iam::123456789012:role/test-role 
+        import_sources: []
+
+my-s3-bucket-data-migration-import-sources-missing-bucket-arn:
+  type: s3
+  environments:
+    dev:
+      bucket_name: mandatory
+      data_migration:
+        import:
+          source_bucket_arn: arn:aws:s3:::test-app
+          source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
+          worker_role_arn: arn:aws:iam::123456789012:role/test-role 
+        import_sources:
+          - source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-2
+            worker_role_arn: arn:aws:iam::123456789012:role/test-role-2
+            
+my-s3-bucket-data-migration-import-sources-missing-worker-role-arn:
+  type: s3
+  environments:
+    dev:
+      bucket_name: mandatory
+      data_migration:
+        import:
+          source_bucket_arn: arn:aws:s3:::test-app
+          source_kms_key_arn: arn:aws:kms::123456789012:key/test-key
+          worker_role_arn: arn:aws:iam::123456789012:role/test-role 
+        import_sources:
+          - source_kms_key_arn: arn:aws:kms::123456789012:key/test-key-2
+            source_bucket_arn: arn:aws:s3:::test-app-2              
 
 my-s3-external-access-bucket-invalid-arn:
   type: s3


### PR DESCRIPTION
Addresses [DBTP-1635](https://uktrade.atlassian.net/browse/DBTP-1635)

- GREAT service has the requirement of pulling data from multiple S3 source buckets.
- Validation added to support this configuration in a service's `<application>-deploy/platform-config.yml` file

Docs PR: https://github.com/uktrade/platform-documentation/pull/457
---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [x] If the work includes user interface changes, before and after screenshots included in description
- [x] Includes any applicable changes to the documentation in this code base
- [x] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing


[DBTP-1635]: https://uktrade.atlassian.net/browse/DBTP-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ