### PR TITLE
chore: Fix dependabot alert in test files

### DIFF
--- a/tests/platform_helper/utils/fixtures/pyproject.toml
+++ b/tests/platform_helper/utils/fixtures/pyproject.toml
@@ -17,7 +17,7 @@ packages = [
 platform-helper = "platform_helper:platform_helper"
 
 [tool.poetry.dependencies]
-Jinja2 = "3.1.4"
+Jinja2 = "3.1.5"
 PyYAML = "6.0.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/platform_helper/utils/fixtures/pyproject_malformed.toml
+++ b/tests/platform_helper/utils/fixtures/pyproject_malformed.toml
@@ -17,7 +17,7 @@ packages = [
 platform-helper = "platform_helper:platform_helper"
 
 [tool.poetry.dependencies]
-Jinja2 = "3.1.4"
+Jinja2 = "3.1.5"
 PyYAML = "6.0.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Fixes dependabot security alert for dependencies listed in test fixture files

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
