### PR TITLE
fix: DBTP-1387 Fix maintenance page offline command when specifiying a specific service

### DIFF
--- a/dbt_platform_helper/domain/maintenance_page.py
+++ b/dbt_platform_helper/domain/maintenance_page.py
@@ -154,7 +154,16 @@ def add_maintenance_page(
                     "Field": "path-pattern",
                     "PathPatternConfig": {"Values": ["/*"]},
                 },
-                *host_header_conditions,
+                {
+                    "Field": "host-header",
+                    "HostHeaderConfig": {
+                        "Values": [
+                            value
+                            for condition in host_header_conditions
+                            for value in condition["HostHeaderConfig"]["Values"]
+                        ]
+                    },
+                },
             ],
             Actions=[
                 {

--- a/dbt_platform_helper/domain/maintenance_page.py
+++ b/dbt_platform_helper/domain/maintenance_page.py
@@ -157,12 +157,14 @@ def add_maintenance_page(
                 {
                     "Field": "host-header",
                     "HostHeaderConfig": {
-                        "Values": list(
-                            {
-                                value
-                                for condition in host_header_conditions
-                                for value in condition["HostHeaderConfig"]["Values"]
-                            }
+                        "Values": sorted(
+                            list(
+                                {
+                                    value
+                                    for condition in host_header_conditions
+                                    for value in condition["HostHeaderConfig"]["Values"]
+                                }
+                            )
                         )
                     },
                 },

--- a/dbt_platform_helper/domain/maintenance_page.py
+++ b/dbt_platform_helper/domain/maintenance_page.py
@@ -90,7 +90,7 @@ def add_maintenance_page(
     app: str,
     env: str,
     services: List[Service],
-    allowed_ips: tuple,
+    allowed_ips: List[str],
     template: str = "default",
 ):
     lb_client = session.client("elbv2")

--- a/dbt_platform_helper/domain/maintenance_page.py
+++ b/dbt_platform_helper/domain/maintenance_page.py
@@ -107,7 +107,7 @@ def add_maintenance_page(
             if not target_group_arn:
                 continue
 
-            conditions = get_host_conditions(lb_client, listener_arn, target_group_arn)
+            conditions = get_host_header_conditions(lb_client, listener_arn, target_group_arn)
             host_header_conditions.extend(conditions)
 
             for ip in allowed_ips:
@@ -520,7 +520,9 @@ def create_source_ip_rule(
     )
 
 
-def get_host_conditions(lb_client: boto3.client, listener_arn: str, target_group_arn: str) -> list:
+def get_host_header_conditions(
+    lb_client: boto3.client, listener_arn: str, target_group_arn: str
+) -> list:
     rules = lb_client.describe_rules(ListenerArn=listener_arn)["Rules"]
 
     # Get current set of forwarding conditions for the target group

--- a/dbt_platform_helper/domain/maintenance_page.py
+++ b/dbt_platform_helper/domain/maintenance_page.py
@@ -157,11 +157,13 @@ def add_maintenance_page(
                 {
                     "Field": "host-header",
                     "HostHeaderConfig": {
-                        "Values": [
-                            value
-                            for condition in host_header_conditions
-                            for value in condition["HostHeaderConfig"]["Values"]
-                        ]
+                        "Values": list(
+                            {
+                                value
+                                for condition in host_header_conditions
+                                for value in condition["HostHeaderConfig"]["Values"]
+                            }
+                        )
                     },
                 },
             ],

--- a/dbt_platform_helper/domain/maintenance_page.py
+++ b/dbt_platform_helper/domain/maintenance_page.py
@@ -98,6 +98,7 @@ def add_maintenance_page(
     bypass_value = "".join(random.choices(string.ascii_lowercase + string.digits, k=12))
 
     rule_priority = itertools.count(start=1)
+    host_header_conditions = []
     try:
         for svc in services:
             target_group_arn = find_target_group(app, env, svc.name, session)
@@ -106,6 +107,7 @@ def add_maintenance_page(
             if not target_group_arn:
                 continue
 
+            # TODO get host header conditions here and pass in, update the list of host header conditions
             for ip in allowed_ips:
                 create_header_rule(
                     lb_client,
@@ -146,7 +148,9 @@ def add_maintenance_page(
                 {
                     "Field": "path-pattern",
                     "PathPatternConfig": {"Values": ["/*"]},
-                }
+                },
+                # TODO add host header for services
+                *host_header_conditions,
             ],
             Actions=[
                 {
@@ -446,6 +450,7 @@ def create_header_rule(
     rule_name: str,
     priority: int,
 ):
+    # TODO pass in conditions to reduce call count
     conditions = get_host_conditions(lb_client, listener_arn, target_group_arn)
 
     # add new condition to existing conditions

--- a/tests/platform_helper/domain/test_maintenance_page.py
+++ b/tests/platform_helper/domain/test_maintenance_page.py
@@ -265,7 +265,8 @@ class TestAddMaintenancePage:
                 {
                     "Field": "path-pattern",
                     "PathPatternConfig": {"Values": ["/*"]},
-                }
+                },
+                {"Field": "host-header", "HostHeaderConfig": {"Values": []}},
             ],
             Actions=[
                 {

--- a/tests/platform_helper/domain/test_maintenance_page.py
+++ b/tests/platform_helper/domain/test_maintenance_page.py
@@ -1040,7 +1040,6 @@ class TestCommandHelperMethods:
         }
         assert rules[1]["Priority"] == "501"
 
-        # check rule number 6 as it is the maintenance page Rule, validate that it has a host header for web but not web2
         assert rules[indices["maintenance_page_index"]]["Priority"] == indices["priority"]
         assert rules[indices["maintenance_page_index"]]["Conditions"] == [
             {"Field": "path-pattern", "PathPatternConfig": {"Values": ["/*"]}},

--- a/tests/platform_helper/domain/test_maintenance_page.py
+++ b/tests/platform_helper/domain/test_maintenance_page.py
@@ -1254,10 +1254,10 @@ class TestActivateMethod:
         ):
             provider.activate(env, services, template, vpc)
 
-            maintenance_mocks.get_https_listener_for_application.assert_not_called()
-            maintenance_mocks.get_maintenance_page_type.assert_not_called()
-            maintenance_mocks.remove_maintenance_page.assert_not_called()
-            maintenance_mocks.add_maintenance_page.assert_not_called()
+        maintenance_mocks.get_https_listener_for_application.assert_not_called()
+        maintenance_mocks.get_maintenance_page_type.assert_not_called()
+        maintenance_mocks.remove_maintenance_page.assert_not_called()
+        maintenance_mocks.add_maintenance_page.assert_not_called()
 
     def test_successful_activate_multiple_services(
         self,

--- a/tests/platform_helper/domain/test_maintenance_page.py
+++ b/tests/platform_helper/domain/test_maintenance_page.py
@@ -121,7 +121,7 @@ class TestAddMaintenancePage:
     @patch("dbt_platform_helper.domain.maintenance_page.create_source_ip_rule")
     @patch("dbt_platform_helper.domain.maintenance_page.create_header_rule")
     @patch(
-        "dbt_platform_helper.domain.maintenance_page.get_host_conditions",
+        "dbt_platform_helper.domain.maintenance_page.get_host_header_conditions",
         return_value=[{"Field": "host-header", "HostHeaderConfig": {"Values": ["/test-path"]}}],
     )
     @patch("dbt_platform_helper.domain.maintenance_page.find_target_group")
@@ -130,7 +130,7 @@ class TestAddMaintenancePage:
         self,
         get_maintenance_page_template,
         find_target_group,
-        get_host_conditions,
+        get_host_header_conditions,
         create_header_rule,
         create_source_ip,
         choices,
@@ -152,7 +152,7 @@ class TestAddMaintenancePage:
             template,
         )
 
-        get_host_conditions.assert_called_with(
+        get_host_header_conditions.assert_called_with(
             boto_mock.client(),
             "listener_arn",
             "target_group_arn",
@@ -227,14 +227,14 @@ class TestAddMaintenancePage:
     )
     @patch("dbt_platform_helper.domain.maintenance_page.create_source_ip_rule")
     @patch("dbt_platform_helper.domain.maintenance_page.create_header_rule")
-    @patch("dbt_platform_helper.domain.maintenance_page.get_host_conditions")
+    @patch("dbt_platform_helper.domain.maintenance_page.get_host_header_conditions")
     @patch("dbt_platform_helper.domain.maintenance_page.find_target_group")
     @patch("dbt_platform_helper.domain.maintenance_page.get_maintenance_page_template")
     def test_no_target_group(
         self,
         get_maintenance_page_template,
         find_target_group,
-        get_host_conditions,
+        get_host_header_conditions,
         create_header_rule,
         create_source_ip,
         choices,
@@ -254,7 +254,7 @@ class TestAddMaintenancePage:
             template,
         )
 
-        get_host_conditions.assert_not_called()
+        get_host_header_conditions.assert_not_called()
         create_header_rule.assert_not_called()
 
         create_source_ip.was_not_called()

--- a/tests/platform_helper/domain/test_maintenance_page.py
+++ b/tests/platform_helper/domain/test_maintenance_page.py
@@ -955,7 +955,7 @@ class TestCommandHelperMethods:
                 ["web", "web2"],
                 {
                     "Field": "host-header",
-                    "HostHeaderConfig": {"Values": ["/test-path-2", "/test-path"]},
+                    "HostHeaderConfig": {"Values": ["/test-path", "/test-path-2"]},
                 },
                 {"maintenance_page_index": 8, "expected_rules_length": 10, "priority": "7"},
             ),

--- a/tests/platform_helper/domain/test_maintenance_page.py
+++ b/tests/platform_helper/domain/test_maintenance_page.py
@@ -421,7 +421,6 @@ class TestCommandHelperMethods:
         from botocore.exceptions import ClientError
         from moto.elbv2.models import ELBv2Backend
 
-        # moto.mock_elbv2().start()
         original_create_rule = ELBv2Backend.create_rule
 
         def custom_create_rule(self, listener_arn, conditions, priority, actions, **kwargs):


### PR DESCRIPTION
Addresses [DBTP-1387](https://uktrade.atlassian.net/browse/DBTP-1387)

---

## What:
- fix to add host header for each service that is being taken offline
- reduces calls to get host header conditions from 3 to 1 for each service
- improves naming of the `get_host_conditions` to `get_host_header_conditions`
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- ~[ ] If the work includes user interface changes, before and after screenshots included in description~
- ~[ ] Includes any applicable changes to the documentation in this code base~
- ~[ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~
### Tasks:
- ~[ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing~
- e2e test will be added in https://uktrade.atlassian.net/browse/DBTP-1419
- Manually tested thourghly to confirm working well


[DBTP-1387]: https://uktrade.atlassian.net/browse/DBTP-1387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ