### PR TITLE
fix: DBPT-1729 - Allows Vpc to be returned without security groups

### DIFF
--- a/dbt_platform_helper/domain/database_copy.py
+++ b/dbt_platform_helper/domain/database_copy.py
@@ -79,6 +79,9 @@ class DatabaseCopy:
         except VpcProviderException as ex:
             self.io.abort_with_error(str(ex))
 
+        if not vpc_config.security_groups:
+            self.io.abort_with_error(f"No security groups found in vpc '{vpc_name}'")
+
         database_identifier = f"{self.app}-{env}-{self.database}"
 
         try:
@@ -121,7 +124,7 @@ class DatabaseCopy:
         self,
         session: boto3.session.Session,
         env: str,
-        vpc_config: Vpc,
+        vpc: Vpc,
         is_dump: bool,
         db_connection_string: str,
         filename: str,
@@ -145,8 +148,8 @@ class DatabaseCopy:
             ],
             networkConfiguration={
                 "awsvpcConfiguration": {
-                    "subnets": vpc_config.private_subnets,
-                    "securityGroups": vpc_config.security_groups,
+                    "subnets": vpc.private_subnets,
+                    "securityGroups": vpc.security_groups,
                     "assignPublicIp": "DISABLED",
                 }
             },

--- a/dbt_platform_helper/providers/load_balancers.py
+++ b/dbt_platform_helper/providers/load_balancers.py
@@ -21,7 +21,9 @@ def get_load_balancer_for_application(session: boto3.Session, app: str, env: str
             load_balancer_arn = lb["ResourceArn"]
 
     if not load_balancer_arn:
-        raise LoadBalancerNotFoundException()
+        raise LoadBalancerNotFoundException(
+            f"No load balancer found for {app} in the {env} environment"
+        )
 
     return load_balancer_arn
 
@@ -39,7 +41,7 @@ def get_https_listener_for_application(session: boto3.Session, app: str, env: st
         pass
 
     if not listener_arn:
-        raise ListenerNotFoundException()
+        raise ListenerNotFoundException(f"No HTTPS listener for {app} in the {env} environment")
 
     return listener_arn
 

--- a/dbt_platform_helper/providers/vpc.py
+++ b/dbt_platform_helper/providers/vpc.py
@@ -98,9 +98,4 @@ class VpcProvider:
 
         sec_groups = self._get_security_groups(app, env, vpc_id)
 
-        if not sec_groups:
-            raise SecurityGroupNotFoundException(
-                f"No matching security groups found in vpc '{vpc_name}'"
-            )
-
         return Vpc(vpc_id, public_subnets, private_subnets, sec_groups)

--- a/tests/platform_helper/domain/test_database_copy.py
+++ b/tests/platform_helper/domain/test_database_copy.py
@@ -290,7 +290,7 @@ def test_database_dump_handles_env_name_errors(is_dump):
 
 @pytest.mark.parametrize("is_dump", (True, False))
 def test_database_dump_handles_missing_security_groups(is_dump):
-    vpc = Vpc("", ["public_subnet"], ["private_subnet"], [])
+    vpc = Vpc("123", ["public_subnet"], ["private_subnet"], [])
     mocks = DataCopyMocks(vpc=vpc)
 
     db_copy = DatabaseCopy("test-app", "test-db", **mocks.params())


### PR DESCRIPTION
Addresses [DBTP-1729](https://uktrade.atlassian.net/browse/DBTP-1729)

`environment generate` failed for new environments that don't yet have a copilot service deployed (no copilot security groups).  This change ensures the command works for a new environment without copilot SGs.

In the copilot generate command, the SG should not be needed on the Vpc.  Our `get_vpc` function threw an exception when no matching SGs were found.  This exception has been removed so that Vpc can be returned with security_groups = [].

Handling of the case with no security groups is moved to the database_copy command.  This is the only place where security groups are needed.

A follow up ticket [DBTP-1731](https://uktrade.atlassian.net/browse/DBTP-1731) will look at the VpcProvider and how to separate the `load` and `validate` functionality.

Manual testing:
I created a new environment from scratch and ran `platform-helper environment generate --name newenv` successfully

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing


[DBTP-1729]: https://uktrade.atlassian.net/browse/DBTP-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DBTP-1731]: https://uktrade.atlassian.net/browse/DBTP-1731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ