### PR TITLE
test: DBTP-1675 Update TestGenerateTerraform with happy path

### DIFF
--- a/tests/platform_helper/domain/test_terraform_environment.py
+++ b/tests/platform_helper/domain/test_terraform_environment.py
@@ -5,6 +5,7 @@ import pytest
 from dbt_platform_helper.domain.terraform_environment import TerraformEnvironment
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.config import ConfigProvider
+from dbt_platform_helper.providers.terraform_manifest import TerraformManifestProvider
 
 
 class TestGenerateTerraform:
@@ -37,3 +38,24 @@ class TestGenerateTerraform:
             match="cannot generate terraform for environment not-an-environment.  It does not exist in your configuration",
         ):
             terraform_environment.generate("not-an-environment")
+
+    def test_generate_success(self):
+        environment_name = "test"
+        tpm_default_version = "123"
+
+        mock_manifest_provider = Mock(spec=TerraformManifestProvider)
+
+        mock_config_provider = Mock(spec=ConfigProvider)
+        mock_config_provider.get_enriched_config.return_value = self.VALID_ENRICHED_CONFIG
+
+        terraform_environment = TerraformEnvironment(
+            config_provider=mock_config_provider,
+            manifest_provider=mock_manifest_provider,
+            io=Mock(),
+        )
+
+        terraform_environment.generate(environment_name, tpm_default_version)
+
+        mock_manifest_provider.generate_environment_config.assert_called_once_with(
+            self.VALID_ENRICHED_CONFIG, environment_name, tpm_default_version
+        )


### PR DESCRIPTION
Addresses [DBTP-1675](https://uktrade.atlassian.net/browse/DBTP-1675)

test_generate_success added to TestGenerateTerraform using new TerraformManifestProvider

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
~~- [ ] If the work includes user interface changes, before and after screenshots included in description~~
~~- [ ] Includes any applicable changes to the documentation in this code base~~
~~- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation]~~(https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
~~- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing~~


[DBTP-1675]: https://uktrade.atlassian.net/browse/DBTP-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ