### PR TITLE
fix: Delete old manifest before creating json one

### DIFF
--- a/dbt_platform_helper/providers/files.py
+++ b/dbt_platform_helper/providers/files.py
@@ -24,3 +24,8 @@ class FileProvider:
         file.write_text(contents)
 
         return f"File {file_path} {action}"
+
+    @staticmethod
+    def delete_file_if_present(base_path: str, file_path: str | Path):
+        file_path = Path(base_path) / file_path
+        file_path.unlink(missing_ok=True)

--- a/dbt_platform_helper/providers/files.py
+++ b/dbt_platform_helper/providers/files.py
@@ -26,7 +26,7 @@ class FileProvider:
         return f"File {file_path} {action}"
 
     @staticmethod
-    def delete_file(base_path: str, file: str | Path):
+    def delete_file(base_path: str, file: str):
         file_path = Path(base_path) / file
         if file_path.exists():
             file_path.unlink()

--- a/dbt_platform_helper/providers/files.py
+++ b/dbt_platform_helper/providers/files.py
@@ -26,6 +26,8 @@ class FileProvider:
         return f"File {file_path} {action}"
 
     @staticmethod
-    def delete_file_if_present(base_path: str, file_path: str | Path):
-        file_path = Path(base_path) / file_path
-        file_path.unlink(missing_ok=True)
+    def delete_file(base_path: str, file: str | Path):
+        file_path = Path(base_path) / file
+        if file_path.exists():
+            file_path.unlink()
+            return f"{str(file_path)} has been deleted"

--- a/dbt_platform_helper/providers/terraform_manifest.py
+++ b/dbt_platform_helper/providers/terraform_manifest.py
@@ -54,7 +54,7 @@ class TerraformManifestProvider:
         self._add_backend(terraform, platform_config, account, state_key_suffix)
         self._add_extensions_module(terraform, terraform_platform_modules_version, env)
         self._add_moved(terraform, platform_config)
-        self._cleanup_old_manifests(env_dir)
+        self._ensure_no_hcl_manifest_file(env_dir)
         self._write_terraform_json(terraform, env_dir)
 
     @staticmethod
@@ -205,5 +205,7 @@ class TerraformManifestProvider:
         )
         self.io.info(message)
 
-    def _cleanup_old_manifests(self, env_dir):
-        self.file_provider.delete_file_if_present(env_dir, "main.tf")
+    def _ensure_no_hcl_manifest_file(self, env_dir):
+        message = self.file_provider.delete_file(env_dir, "main.tf")
+        if message:
+            self.io.info(f"Manifest has moved to main.tf.json. {message}")

--- a/dbt_platform_helper/providers/terraform_manifest.py
+++ b/dbt_platform_helper/providers/terraform_manifest.py
@@ -33,7 +33,7 @@ class TerraformManifestProvider:
         self._add_backend(terraform, platform_config, default_account, state_key_suffix)
         self._add_codebase_pipeline_module(terraform, terraform_platform_modules_version)
         self._add_imports(terraform, ecr_imports)
-        self._write_terraform_json(terraform, "terraform/codebase-pipelines/main.tf.json")
+        self._write_terraform_json(terraform, "terraform/codebase-pipelines")
 
     def generate_environment_config(
         self,
@@ -46,6 +46,7 @@ class TerraformManifestProvider:
 
         application_name = platform_config["application"]
         state_key_suffix = f"{platform_config['application']}-{env}"
+        env_dir = f"terraform/environments/{env}"
 
         terraform = {}
         self._add_header(terraform)
@@ -53,7 +54,8 @@ class TerraformManifestProvider:
         self._add_backend(terraform, platform_config, account, state_key_suffix)
         self._add_extensions_module(terraform, terraform_platform_modules_version, env)
         self._add_moved(terraform, platform_config)
-        self._write_terraform_json(terraform, f"terraform/environments/{env}/main.tf.json")
+        self._cleanup_old_manifests(env_dir)
+        self._write_terraform_json(terraform, env_dir)
 
     @staticmethod
     def _get_account_for_env(env, platform_config):
@@ -194,11 +196,14 @@ class TerraformManifestProvider:
                     }
                 )
 
-    def _write_terraform_json(self, terraform, tf_json):
+    def _write_terraform_json(self, terraform: dict, env_dir: str):
         message = self.file_provider.mkfile(
-            str(Path(".").absolute()),
-            tf_json,
+            str(Path(env_dir).absolute()),
+            "main.tf.json",
             json.dumps(terraform, indent=2),
             True,
         )
         self.io.info(message)
+
+    def _cleanup_old_manifests(self, env_dir):
+        self.file_provider.delete_file_if_present(env_dir, "main.tf")

--- a/tests/platform_helper/providers/test_files.py
+++ b/tests/platform_helper/providers/test_files.py
@@ -19,7 +19,7 @@ def test_mkfile_creates_or_overrides_the_file(tmp_path, file_exists, overwrite, 
 
     contents = "The content"
 
-    message = FileProvider().mkfile(tmp_path, filename, contents, overwrite)
+    message = FileProvider().mkfile(str(tmp_path), filename, contents, overwrite)
 
     assert file_path.exists()
     assert file_path.read_text() == contents
@@ -31,6 +31,20 @@ def test_mkfile_does_nothing_if_file_already_exists_but_override_is_false(tmp_pa
     file_path = tmp_path / filename
     file_path.touch()
 
-    message = FileProvider().mkfile(tmp_path, filename, contents="does not matter", overwrite=False)
+    message = FileProvider().mkfile(
+        str(tmp_path), filename, contents="does not matter", overwrite=False
+    )
 
     assert message == f"File {filename} exists; doing nothing"
+
+
+@pytest.mark.parametrize("file_exists", [True, False])
+def test_delete_file_deletes_the_file(tmp_path, file_exists):
+    filename = "some-file.txt"
+    file_path = tmp_path / filename
+    if file_exists:
+        file_path.touch()
+
+    FileProvider().delete_file_if_present(str(tmp_path), filename)
+
+    assert not file_path.exists()

--- a/tests/platform_helper/providers/test_files.py
+++ b/tests/platform_helper/providers/test_files.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from dbt_platform_helper.providers.files import FileProvider
@@ -38,13 +40,20 @@ def test_mkfile_does_nothing_if_file_already_exists_but_override_is_false(tmp_pa
     assert message == f"File {filename} exists; doing nothing"
 
 
-@pytest.mark.parametrize("file_exists", [True, False])
-def test_delete_file_deletes_the_file(tmp_path, file_exists):
-    filename = "some-file.txt"
-    file_path = tmp_path / filename
+@pytest.mark.parametrize(
+    "file_exists, expected_message",
+    [(True, "a_folder/some_file.txt has been deleted"), (False, None)],
+)
+def test_delete_file_deletes_the_file(fs, file_exists, expected_message):
+    filename = "some_file.txt"
+    folder = "a_folder"
+    folder_path = Path(folder)
+    file_path = folder_path / filename
     if file_exists:
+        folder_path.mkdir(parents=True)
         file_path.touch()
 
-    FileProvider().delete_file_if_present(str(tmp_path), filename)
+    message = FileProvider().delete_file(folder, filename)
 
     assert not file_path.exists()
+    assert message == expected_message

--- a/tests/platform_helper/providers/test_terraform_manifest.py
+++ b/tests/platform_helper/providers/test_terraform_manifest.py
@@ -37,8 +37,8 @@ def test_generate_codebase_pipeline_config_creates_file(
 
     mock_io.info.assert_called_once_with("File created")
 
-    assert base_path == str(Path(".").absolute())
-    assert file_path == "terraform/codebase-pipelines/main.tf.json"
+    assert base_path == str(Path("terraform/codebase-pipelines").absolute())
+    assert file_path == "main.tf.json"
     assert overwrite
 
     json_content = json.loads(contents)
@@ -176,9 +176,12 @@ def test_generate_environment_config_creates_file(
     base_path, file_path, contents, overwrite = mock_file_provider.mkfile.call_args.args
 
     mock_io.info.assert_called_once_with("File created")
+    mock_file_provider.delete_file_if_present.assert_called_with(
+        f"terraform/environments/{env}", "main.tf"
+    )
 
-    assert base_path == str(Path(".").absolute())
-    assert file_path == f"terraform/environments/{env}/main.tf.json"
+    assert base_path == str(Path(f"terraform/environments/{env}").absolute())
+    assert file_path == "main.tf.json"
     assert overwrite
 
     json_content = json.loads(contents)


### PR DESCRIPTION
Addresses [DBTP-1602](https://uktrade.atlassian.net/browse/DBTP-1602)

Realised during manual testing that because we are moving to JSON formatted env manifests, if a team has an old `main.tf` file either in git or just locally, they will end up with 2 manifests trying to provision the same stuff in their env dir, so terraform apply will fall over. This PR cleans up that file first. 

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing


[DBTP-1602]: https://uktrade.atlassian.net/browse/DBTP-1602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ