### PR TITLE
fix: DBTP-1784: Passing a full path as the first mkfile parameter causes a file not found error

### DIFF
--- a/dbt_platform_helper/providers/files.py
+++ b/dbt_platform_helper/providers/files.py
@@ -1,4 +1,3 @@
-from os import makedirs
 from pathlib import Path
 
 
@@ -8,26 +7,21 @@ class FileProvider:
         pass
 
     @staticmethod
-    def mkfile(base_path: str, file_path: str, contents: str, overwrite=False) -> str:
-        file_path = Path(file_path)
-        file = Path(base_path).joinpath(file_path)
-        file_exists = file.exists()
-
-        if not file_path.parent.exists():
-            makedirs(file_path.parent)
-
+    def mkfile(base_path: str, file_name: str, contents: str, overwrite=False) -> str:
+        file_path = Path(base_path).joinpath(file_name)
+        file_exists = file_path.exists()
         if file_exists and not overwrite:
             return f"File {file_path} exists; doing nothing"
 
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(contents)
+
         action = "overwritten" if file_exists and overwrite else "created"
-
-        file.write_text(contents)
-
-        return f"File {file_path} {action}"
+        return f"File {file_name} {action}"
 
     @staticmethod
-    def delete_file(base_path: str, file: str):
-        file_path = Path(base_path) / file
+    def delete_file(base_path: str, file_name: str):
+        file_path = Path(base_path) / file_name
         if file_path.exists():
             file_path.unlink()
             return f"{str(file_path)} has been deleted"

--- a/tests/platform_helper/providers/test_files.py
+++ b/tests/platform_helper/providers/test_files.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 from dbt_platform_helper.providers.files import FileProvider
@@ -37,23 +35,39 @@ def test_mkfile_does_nothing_if_file_already_exists_but_override_is_false(tmp_pa
         str(tmp_path), filename, contents="does not matter", overwrite=False
     )
 
-    assert message == f"File {filename} exists; doing nothing"
+    assert message == f"File {file_path} exists; doing nothing"
 
 
-@pytest.mark.parametrize(
-    "file_exists, expected_message",
-    [(True, "a_folder/some_file.txt has been deleted"), (False, None)],
-)
-def test_delete_file_deletes_the_file(fs, file_exists, expected_message):
-    filename = "some_file.txt"
+def test_mkfile_can_write_to_a_file_in_a_non_existent_directory(tmp_path):
+    path = tmp_path / "test_dir/test_subdir"
+    filename = "test_file.txt"
+
+    message = FileProvider().mkfile(str(path), filename, contents="does not matter")
+
+    assert message == "File test_file.txt created"
+
+
+def test_delete_file_deletes_the_file(tmp_path):
     folder = "a_folder"
-    folder_path = Path(folder)
+    filename = "some_file.txt"
+    folder_path = tmp_path / folder
     file_path = folder_path / filename
-    if file_exists:
-        folder_path.mkdir(parents=True)
-        file_path.touch()
+    folder_path.mkdir(parents=True)
+    file_path.touch()
 
-    message = FileProvider().delete_file(folder, filename)
+    message = FileProvider().delete_file(str(folder_path), filename)
 
     assert not file_path.exists()
-    assert message == expected_message
+    assert message == f"{file_path} has been deleted"
+
+
+def test_delete_file_does_nothing_if_file_didnt_exist(tmp_path):
+    folder = "a_folder"
+    filename = "some_file.txt"
+    folder_path = tmp_path / folder
+    file_path = folder_path / filename
+
+    message = FileProvider().delete_file(str(folder_path), filename)
+
+    assert not file_path.exists()
+    assert message is None

--- a/tests/platform_helper/providers/test_files.py
+++ b/tests/platform_helper/providers/test_files.py
@@ -44,6 +44,8 @@ def test_mkfile_can_write_to_a_file_in_a_non_existent_directory(tmp_path):
 
     message = FileProvider().mkfile(str(path), filename, contents="does not matter")
 
+    file_path = path / filename
+    assert file_path.exists()
     assert message == "File test_file.txt created"
 
 


### PR DESCRIPTION
Addresses [DBTP-1784](https://uktrade.atlassian.net/browse/DBTP-1784)

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [x] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing


[DBTP-1739]: https://uktrade.atlassian.net/browse/DBTP-1739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DBTP-1784]: https://uktrade.atlassian.net/browse/DBTP-1784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ