### PR TITLE
fix: DBTP-1792 Set FileProvider default in CopilotTemplating

### DIFF
--- a/dbt_platform_helper/domain/copilot_environment.py
+++ b/dbt_platform_helper/domain/copilot_environment.py
@@ -132,7 +132,7 @@ class CopilotEnvironment:
 class CopilotTemplating:
     def __init__(
         self,
-        file_provider: FileProvider = None,
+        file_provider: FileProvider = FileProvider(),
         io: ClickIOProvider = ClickIOProvider(),
         # TODO file_provider can be moved up a layer.  File writing can be the responsibility of CopilotEnvironment generate
         # Or we align with PlatformTerraformManifestGenerator and rename from Templating to reflect the file writing responsibility

--- a/tests/platform_helper/domain/test_copilot_environment.py
+++ b/tests/platform_helper/domain/test_copilot_environment.py
@@ -473,6 +473,14 @@ class TestCopilotTemplating:
             overwrite=True,
         )
 
+    def test_file_provider_default(self):
+        result = CopilotTemplating().write_environment_manifest(
+            "connors-environment",
+            "test manifest contents",
+        )
+
+        assert result == "ive written to a file!"
+
 
 class TestCopilotGenerate:
 

--- a/tests/platform_helper/domain/test_copilot_environment.py
+++ b/tests/platform_helper/domain/test_copilot_environment.py
@@ -479,7 +479,7 @@ class TestCopilotTemplating:
             "test manifest contents",
         )
 
-        assert result == "ive written to a file!"
+        assert result == "File copilot/environments/connors-environment/manifest.yml created"
 
 
 class TestCopilotGenerate:


### PR DESCRIPTION
Addresses [DBTP-1792](https://uktrade.atlassian.net/browse/DBTP-1792)

---
## What:
when running the `platform-helper copilot make-addons` command you will get a `None` type error when trying to call `mkfile` in the `FileProvider`.
 
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- ~[ ] If the work includes user interface changes, before and after screenshots included in description~
- ~[ ] Includes any applicable changes to the documentation in this code base~
- ~[ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~
### Tasks:
- [x] Manually tested to confirm bug doesn't occur
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing


[DBTP-1792]: https://uktrade.atlassian.net/browse/DBTP-1792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ