### PR TITLE
fix: DBTP-1789 - Default pipelines config to empty list

### DIFF
--- a/copilot/environments/connors-environment/manifest.yml
+++ b/copilot/environments/connors-environment/manifest.yml
@@ -1,1 +1,0 @@
-test manifest contents

--- a/dbt_platform_helper/providers/platform_config_schema.py
+++ b/dbt_platform_helper/providers/platform_config_schema.py
@@ -134,7 +134,7 @@ class PlatformConfigSchema:
                 Optional("additional_ecr_repository"): str,
                 Optional("deploy_repository_branch"): str,
                 "services": [{str: [str]}],
-                "pipelines": [
+                Optional("pipelines"): [
                     Or(
                         {
                             "name": str,

--- a/dbt_platform_helper/providers/terraform_manifest.py
+++ b/dbt_platform_helper/providers/terraform_manifest.py
@@ -123,7 +123,7 @@ class TerraformManifestProvider:
                 "codebase": "${each.key}",
                 "repository": "${each.value.repository}",
                 "additional_ecr_repository": '${lookup(each.value, "additional_ecr_repository", null)}',
-                "pipelines": "${each.value.pipelines}",
+                "pipelines": '${lookup(each.value, "pipelines", [])}',
                 "services": "${each.value.services}",
                 "requires_image_build": '${lookup(each.value, "requires_image_build", true)}',
                 "slack_channel": '${lookup(each.value, "slack_channel", "/codebuild/slack_oauth_channel")}',

--- a/tests/platform_helper/providers/test_terraform_manifest.py
+++ b/tests/platform_helper/providers/test_terraform_manifest.py
@@ -87,7 +87,7 @@ def test_generate_codebase_pipeline_config_creates_file(
         module["additional_ecr_repository"]
         == '${lookup(each.value, "additional_ecr_repository", null)}'
     )
-    assert module["pipelines"] == "${each.value.pipelines}"
+    assert module["pipelines"] == '${lookup(each.value, "pipelines", [])}'
     assert module["services"] == "${each.value.services}"
     assert module["requires_image_build"] == '${lookup(each.value, "requires_image_build", true)}'
     assert (


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1789

If no pipeline config is specified use an empty list.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [x] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
