### PR TITLE
refactor: DBTP-1700 Rationalise S3 policy schema to simplify documentation

### DIFF
--- a/dbt_platform_helper/providers/platform_config_schema.py
+++ b/dbt_platform_helper/providers/platform_config_schema.py
@@ -435,7 +435,7 @@ class PlatformConfigSchema:
         return True
 
     @staticmethod
-    def __valid_s3_base_definition() -> dict:
+    def __s3_bucket_schema() -> dict:
         def _valid_s3_bucket_arn(key):
             return Regex(
                 r"^arn:aws:s3::.*",
@@ -485,6 +485,10 @@ class PlatformConfigSchema:
 
         return dict(
             {
+                "type": "s3",
+                Optional("objects"): [
+                    {"key": str, Optional("body"): str, Optional("content_type"): str}
+                ],
                 Optional("readonly"): bool,
                 Optional("serve_static_content"): bool,
                 Optional("serve_static_param_name"): str,
@@ -519,17 +523,18 @@ class PlatformConfigSchema:
         )
 
     @staticmethod
-    def __s3_bucket_schema() -> dict:
-        return PlatformConfigSchema.__valid_s3_base_definition() | {
-            "type": "s3",
-            Optional("objects"): [
-                {"key": str, Optional("body"): str, Optional("content_type"): str}
-            ],
-        }
-
-    @staticmethod
     def __s3_bucket_policy_schema() -> dict:
-        return PlatformConfigSchema.__valid_s3_base_definition() | {"type": "s3-policy"}
+        return dict(
+            {
+                "type": "s3-policy",
+                Optional("services"): Or("__all__", [str]),
+                Optional("environments"): {
+                    PlatformConfigSchema.__valid_environment_name(): {
+                        "bucket_name": PlatformConfigSchema.valid_s3_bucket_name,
+                    },
+                },
+            }
+        )
 
     @staticmethod
     def string_matching_regex(regex_pattern: str) -> Callable:

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -495,7 +495,6 @@ extensions:
     environments:
       dev:
         bucket_name: test-app-policy-dev
-        versioning: false
   
   test-app-s3-bucket-data-migration:
     type: s3

--- a/tests/platform_helper/utils/fixtures/addons_files/s3_policy_addons.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/s3_policy_addons.yml
@@ -1,6 +1,5 @@
 my-s3-policy:
   type: s3-policy
-  readonly: true
 
   services:
     - "web"
@@ -9,4 +8,3 @@ my-s3-policy:
   environments:
     dev:
       bucket_name: my-bucket-dev
-      deletion_policy: Retain

--- a/tests/platform_helper/utils/fixtures/addons_files/s3_policy_addons_bad_data.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/s3_policy_addons_bad_data.yml
@@ -1,15 +1,3 @@
-my-s3-bucket-policy-readonly-should-be-bool:
-  type: s3-policy
-  readonly: 27 # Should be bool
-
-my-s3-bucket-policy-serve-static-content-should-be-bool:
-  type: s3-policy
-  serve_static_content: 27 # Should be bool
-
-my-s3-bucket-policy-serve-static-param-name-should-be-string:
-  type: s3-policy
-  serve_static_param_name: 27 # Should be string
-
 my-s3-bucket-policy-services-should-be-list:
   type: s3-policy
   services: 33 # Should be a list
@@ -24,13 +12,6 @@ my-s3-bucket-policy-bad-name-suffix:
   environments:
     dev:
       bucket_name: banana-s3alias # Can't end with -s3alias
-
-my-s3-bucket-policy-invalid-deletion-policy:
-  type: s3-policy
-  environments:
-    dev:
-      bucket_name: barney
-      deletion_policy: False # Should be a valid policy name.
 
 my-s3-bucket-policy-invalid-param:
   type: s3-policy

--- a/tests/platform_helper/utils/test_validation.py
+++ b/tests/platform_helper/utils/test_validation.py
@@ -107,13 +107,9 @@ def test_validate_addons_success(addons_file):
         (
             "s3_policy_addons_bad_data.yml",
             {
-                "my-s3-bucket-policy-readonly-should-be-bool": r"readonly.*should be instance of 'bool'",
-                "my-s3-bucket-policy-serve-static-content-should-be-bool": r"serve_static_content.*should be instance of 'bool'",
-                "my-s3-bucket-policy-serve-static-param-name-should-be-string": r"serve_static_param_name.*should be instance of 'str'",
                 "my-s3-bucket-policy-services-should-be-list": r"services.*should be instance of 'list'",
                 "my-s3-bucket-policy-service-should-be-string": r"services.*should be instance of 'str'",
                 "my-s3-bucket-policy-bad-name-suffix": r"Bucket name 'banana-s3alias' is invalid:\n  Names cannot be suffixed '-s3alias'",
-                "my-s3-bucket-policy-invalid-deletion-policy": r"environments.*dev.*deletion_policy.*does not match False",
                 "my-s3-bucket-policy-invalid-param": r"Wrong key 'unknown1'",
                 "my-s3-bucket-policy-invalid-object-param": r"Wrong key 'objects'",
                 "my-s3-bucket-policy-invalid-env-param": r"environments.*Wrong key 'unknown3'",


### PR DESCRIPTION
Contributes to [DBTP-1700](https://uktrade.atlassian.net/browse/DBTP-1700).

Because the version `platform-helper` branch specified is not actually used in the environment/codebase pipelines yet, I have run through the environment and codebase deploy commands manually against my environment to check it does not break anything.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] ~If the work includes user interface changes, before and after screenshots included in description~
- [ ] ~Includes any applicable changes to the documentation in this code base~
- [ ] ~Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~
### Tasks:
- [x] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing

[End to end test run](https://763451185160-2qjkzelg.eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/willg-end-to-end-tests/executions/4f7c3844-6616-4e77-bfc9-e5c51a3329e4/visualization?region=eu-west-2).


[DBTP-1700]: https://uktrade.atlassian.net/browse/DBTP-1700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ