### PR TITLE
fix: Use fakefs in test to avoid message changing to 'overwritten' in subsequent test runs

### DIFF
--- a/tests/platform_helper/domain/test_copilot_environment.py
+++ b/tests/platform_helper/domain/test_copilot_environment.py
@@ -473,7 +473,7 @@ class TestCopilotTemplating:
             overwrite=True,
         )
 
-    def test_file_provider_default(self):
+    def test_file_provider_default(self, fakefs):
         result = CopilotTemplating().write_environment_manifest(
             "connors-environment",
             "test manifest contents",


### PR DESCRIPTION
Out of ticket - fixes an issue where re-running `test_file_provider_default` fails due to not mocking filesystem

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
