### PR TITLE
refactor: DBTP-1798 - move version domain code out of utils

### DIFF
--- a/dbt_platform_helper/commands/generate.py
+++ b/dbt_platform_helper/commands/generate.py
@@ -3,8 +3,8 @@ import click
 
 from dbt_platform_helper.commands.copilot import make_addons
 from dbt_platform_helper.commands.pipeline import generate as pipeline_generate
+from dbt_platform_helper.domain.versioning import RequiredVersion
 from dbt_platform_helper.utils.click import ClickDocOptCommand
-from dbt_platform_helper.utils.versioning import RequiredVersion
 
 
 @click.command(cls=ClickDocOptCommand)

--- a/dbt_platform_helper/commands/version.py
+++ b/dbt_platform_helper/commands/version.py
@@ -1,9 +1,9 @@
 import click
 
+from dbt_platform_helper.domain.versioning import RequiredVersion
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.utils.click import ClickDocOptGroup
-from dbt_platform_helper.utils.versioning import RequiredVersion
 
 
 @click.group(chain=True, cls=ClickDocOptGroup)

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -5,7 +5,7 @@ from dbt_platform_helper.providers.platform_helper_versioning import (
 )
 from dbt_platform_helper.providers.semantic_version import PlatformHelperVersionStatus
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
-from dbt_platform_helper.utils.versioning import running_as_installed_package
+from dbt_platform_helper.utils.files import running_as_installed_package
 
 
 class PlatformHelperVersionNotFoundException(PlatformException):

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -1,0 +1,67 @@
+from dbt_platform_helper.platform_exception import PlatformException
+from dbt_platform_helper.providers.io import ClickIOProvider
+from dbt_platform_helper.providers.platform_helper_versioning import (
+    PlatformHelperVersioning,
+)
+from dbt_platform_helper.providers.semantic_version import PlatformHelperVersionStatus
+from dbt_platform_helper.providers.semantic_version import SemanticVersion
+from dbt_platform_helper.utils.versioning import running_as_installed_package
+
+
+class PlatformHelperVersionNotFoundException(PlatformException):
+    def __init__(self):
+        super().__init__(f"""Platform helper version could not be resolved.""")
+
+
+class RequiredVersion:
+    def __init__(self, io=None, platform_helper_versioning=None):
+        self.io = io or ClickIOProvider()
+        self.platform_helper_versioning = platform_helper_versioning or PlatformHelperVersioning(
+            io=self.io
+        )
+
+    def get_required_platform_helper_version(
+        self, pipeline: str = None, version_status: PlatformHelperVersionStatus = None
+    ) -> str:
+        pipeline_version = version_status.pipeline_overrides.get(pipeline)
+        version_precedence = [
+            pipeline_version,
+            version_status.platform_config_default,
+            version_status.deprecated_version_file,
+        ]
+        non_null_version_precedence = [
+            f"{v}" if isinstance(v, SemanticVersion) else v for v in version_precedence if v
+        ]
+
+        out = non_null_version_precedence[0] if non_null_version_precedence else None
+
+        if not out:
+            raise PlatformHelperVersionNotFoundException
+
+        return out
+
+    def get_required_version(self, pipeline=None):
+        version_status = self.platform_helper_versioning.get_status()
+        self.io.process_messages(version_status.validate())
+        required_version = self.get_required_platform_helper_version(pipeline, version_status)
+        self.io.info(required_version)
+        return required_version
+
+    # Used in the generate command
+    def check_platform_helper_version_mismatch(self):
+        if not running_as_installed_package():
+            return
+
+        version_status = self.platform_helper_versioning.get_status()
+        self.io.process_messages(version_status.validate())
+
+        required_version = SemanticVersion.from_string(
+            self.get_required_platform_helper_version(version_status=version_status)
+        )
+
+        if not version_status.local == required_version:
+            message = (
+                f"WARNING: You are running platform-helper v{version_status.local} against "
+                f"v{required_version} specified for the project."
+            )
+            self.io.warn(message)

--- a/dbt_platform_helper/providers/platform_helper_versioning.py
+++ b/dbt_platform_helper/providers/platform_helper_versioning.py
@@ -18,6 +18,7 @@ from dbt_platform_helper.providers.version import LocalVersionProviderException
 from dbt_platform_helper.providers.version import PyPiVersionProvider
 from dbt_platform_helper.providers.yaml_file import FileProviderException
 from dbt_platform_helper.providers.yaml_file import YamlFileProvider
+from dbt_platform_helper.utils.files import running_as_installed_package
 
 
 class PlatformHelperVersioning:
@@ -104,8 +105,3 @@ class PlatformHelperVersioning:
             self.io.error(message)
         except IncompatibleMinorVersionException:
             self.io.warn(message)
-
-
-# TODO consolidate with the same function in versioning and given a home
-def running_as_installed_package():
-    return "site-packages" in __file__

--- a/dbt_platform_helper/providers/semantic_version.py
+++ b/dbt_platform_helper/providers/semantic_version.py
@@ -74,12 +74,10 @@ class SemanticVersion:
         return SemanticVersion(output_version[0], output_version[1], output_version[2])
 
 
+@dataclass
 class VersionStatus:
-    def __init__(
-        self, local_version: SemanticVersion = None, latest_release: SemanticVersion = None
-    ):
-        self.local = local_version
-        self.latest = latest_release
+    local: SemanticVersion = None
+    latest: SemanticVersion = None
 
     def __str__(self):
         attrs = {
@@ -95,7 +93,6 @@ class VersionStatus:
         pass
 
 
-# TODO remove dataclass, or make VersionStatus also a dataclass - align attribute names
 @dataclass
 class PlatformHelperVersionStatus(VersionStatus):
     local: Optional[SemanticVersion] = None

--- a/dbt_platform_helper/utils/files.py
+++ b/dbt_platform_helper/utils/files.py
@@ -51,3 +51,9 @@ def generate_override_files_from_template(base_path, overrides_path, output_dir,
 
     generate_files_for_dir("*")
     generate_files_for_dir("bin/*")
+
+
+# TODO: we've moved this from versioning utils and removed the duplication in platform_helper_versioning
+# Need to review if this is the correct place for this function to reside longer-term
+def running_as_installed_package():
+    return "site-packages" in __file__

--- a/dbt_platform_helper/utils/versioning.py
+++ b/dbt_platform_helper/utils/versioning.py
@@ -3,8 +3,6 @@ import subprocess
 from pathlib import Path
 
 from dbt_platform_helper.constants import DEFAULT_TERRAFORM_PLATFORM_MODULES_VERSION
-from dbt_platform_helper.platform_exception import PlatformException
-from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.platform_helper_versioning import (
     PlatformHelperVersioning,
 )
@@ -14,67 +12,6 @@ from dbt_platform_helper.providers.semantic_version import VersionStatus
 from dbt_platform_helper.providers.validation import ValidationException
 from dbt_platform_helper.providers.version import GithubVersionProvider
 from dbt_platform_helper.providers.yaml_file import YamlFileProvider
-
-
-# TODO to be moved into domain
-class PlatformHelperVersionNotFoundException(PlatformException):
-    def __init__(self):
-        super().__init__(f"""Platform helper version could not be resolved.""")
-
-
-# TODO to be moved into domain
-class RequiredVersion:
-    def __init__(self, io=None, platform_helper_versioning=None):
-        self.io = io or ClickIOProvider()
-        self.platform_helper_versioning = platform_helper_versioning or PlatformHelperVersioning(
-            io=self.io
-        )
-
-    def get_required_platform_helper_version(
-        self, pipeline: str = None, version_status: PlatformHelperVersionStatus = None
-    ) -> str:
-        pipeline_version = version_status.pipeline_overrides.get(pipeline)
-        version_precedence = [
-            pipeline_version,
-            version_status.platform_config_default,
-            version_status.deprecated_version_file,
-        ]
-        non_null_version_precedence = [
-            f"{v}" if isinstance(v, SemanticVersion) else v for v in version_precedence if v
-        ]
-
-        out = non_null_version_precedence[0] if non_null_version_precedence else None
-
-        if not out:
-            raise PlatformHelperVersionNotFoundException
-
-        return out
-
-    def get_required_version(self, pipeline=None):
-        version_status = self.platform_helper_versioning.get_status()
-        self.io.process_messages(version_status.validate())
-        required_version = self.get_required_platform_helper_version(pipeline, version_status)
-        self.io.info(required_version)
-        return required_version
-
-    # Used in the generate command
-    def check_platform_helper_version_mismatch(self):
-        if not running_as_installed_package():
-            return
-
-        version_status = self.platform_helper_versioning.get_status()
-        self.io.process_messages(version_status.validate())
-
-        required_version = SemanticVersion.from_string(
-            self.get_required_platform_helper_version(version_status=version_status)
-        )
-
-        if not version_status.local == required_version:
-            message = (
-                f"WARNING: You are running platform-helper v{version_status.local} against "
-                f"v{required_version} specified for the project."
-            )
-            self.io.warn(message)
 
 
 # TODO to be removed after config tests are updated - temporary wrapper mid-refactor

--- a/dbt_platform_helper/utils/versioning.py
+++ b/dbt_platform_helper/utils/versioning.py
@@ -24,11 +24,6 @@ def get_platform_helper_version_status(
     )
 
 
-# TODO duplicated in PlatformHelperVersion
-def running_as_installed_package():
-    return "site-packages" in __file__
-
-
 def get_required_terraform_platform_modules_version(
     cli_terraform_platform_modules_version, platform_config_terraform_modules_default_version
 ):

--- a/tests/platform_helper/domain/test_copilot.py
+++ b/tests/platform_helper/domain/test_copilot.py
@@ -88,7 +88,7 @@ class TestMakeAddonsCommand:
     )
     @freeze_time("2023-08-22 16:00:00")
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     @patch("dbt_platform_helper.jinja2_tags.version", new=Mock(return_value="v0.1-TEST"))
@@ -237,7 +237,7 @@ class TestMakeAddonsCommand:
     )
     @freeze_time("2023-08-22 16:00:00")
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     @patch("dbt_platform_helper.jinja2_tags.version", new=Mock(return_value="v0.1-TEST"))
@@ -340,7 +340,7 @@ class TestMakeAddonsCommand:
 
     @freeze_time("2023-08-22 16:00:00")
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     @patch("dbt_platform_helper.jinja2_tags.version", new=Mock(return_value="v0.1-TEST"))
@@ -412,7 +412,7 @@ class TestMakeAddonsCommand:
             assert not path.exists(), f"{path} should not exist"
 
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     def test_exit_if_no_config_file(self, fakefs):
@@ -425,7 +425,7 @@ class TestMakeAddonsCommand:
         )
 
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     @patch("dbt_platform_helper.commands.copilot.ConfigProvider", new=Mock())
@@ -440,7 +440,7 @@ class TestMakeAddonsCommand:
         assert "No services found in ./copilot/; exiting" in result.output
 
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     @patch("dbt_platform_helper.commands.copilot.ConfigProvider", new=Mock())
@@ -473,7 +473,7 @@ class TestMakeAddonsCommand:
         )
 
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     @mock_aws
@@ -506,7 +506,7 @@ class TestMakeAddonsCommand:
         )
 
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     @patch("dbt_platform_helper.commands.copilot.ConfigProvider", new=Mock())
@@ -559,7 +559,7 @@ class TestMakeAddonsCommand:
         )
 
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     @patch("dbt_platform_helper.commands.copilot.ConfigProvider", new=Mock())
@@ -607,7 +607,7 @@ class TestMakeAddonsCommand:
         assert "Names can only contain the characters 0-9, a-z, '.' and '-'." in result.output
 
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     def test_exit_if_services_key_invalid(self, fakefs):
@@ -645,7 +645,7 @@ class TestMakeAddonsCommand:
         assert "'this-is-not-valid' should be instance of 'list'" in result.output
 
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     @patch("dbt_platform_helper.commands.copilot.ConfigProvider", new=Mock())
@@ -667,7 +667,7 @@ class TestMakeAddonsCommand:
     )
     @patch("dbt_platform_helper.jinja2_tags.version", new=Mock(return_value="v0.1-TEST"))
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     @patch(
@@ -706,7 +706,7 @@ class TestMakeAddonsCommand:
             )
 
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     @patch("dbt_platform_helper.jinja2_tags.version", new=Mock(return_value="v0.1-TEST"))
@@ -747,7 +747,7 @@ class TestMakeAddonsCommand:
 
     @freeze_time("2023-08-22 16:00:00")
     @patch(
-        "dbt_platform_helper.utils.versioning.running_as_installed_package",
+        "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
     @patch("dbt_platform_helper.jinja2_tags.version", new=Mock(return_value="v0.1-TEST"))

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -20,10 +20,6 @@ from dbt_platform_helper.providers.semantic_version import SemanticVersion
     "dbt_platform_helper.domain.versioning.running_as_installed_package",
     new=Mock(return_value=True),
 )
-@patch(
-    "dbt_platform_helper.providers.platform_helper_versioning.running_as_installed_package",
-    new=Mock(return_value=True),
-)
 def test_check_platform_helper_version_shows_warning_when_different_than_file_spec():
     mock_io_provider = Mock()
     mock_platform_helper_version_provider = Mock()
@@ -42,9 +38,8 @@ def test_check_platform_helper_version_shows_warning_when_different_than_file_sp
     )
 
 
-@patch("dbt_platform_helper.utils.files.running_as_installed_package", new=Mock(return_value=True))
 @patch(
-    "dbt_platform_helper.providers.platform_helper_versioning.running_as_installed_package",
+    "dbt_platform_helper.domain.versioning.running_as_installed_package",
     new=Mock(return_value=True),
 )
 def test_check_platform_helper_version_shows_no_warning_when_same_as_file_spec():
@@ -64,10 +59,6 @@ def test_check_platform_helper_version_shows_no_warning_when_same_as_file_spec()
     mock_io_provider.error.assert_not_called
 
 
-@patch(
-    "dbt_platform_helper.providers.platform_helper_versioning.running_as_installed_package",
-    new=Mock(return_value=True),
-)
 @patch(
     "dbt_platform_helper.domain.versioning.running_as_installed_package",
     new=Mock(return_value=True),
@@ -150,8 +141,6 @@ def test_get_required_version_errors_if_version_is_not_specified(
     )
 
     mock_io_provider = Mock()
-
-    print("provider mock", mock_io_provider)
 
     expected_message = f"""Cannot get dbt-platform-helper version from '{PLATFORM_CONFIG_FILE}'.
 Create a section in the root of '{PLATFORM_CONFIG_FILE}':\n\ndefault_versions:\n  platform-helper: 1.2.3

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -1,0 +1,166 @@
+from pathlib import Path
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
+from dbt_platform_helper.domain.versioning import PlatformHelperVersionNotFoundException
+from dbt_platform_helper.domain.versioning import RequiredVersion
+from dbt_platform_helper.providers.platform_helper_versioning import (
+    PlatformHelperVersioning,
+)
+from dbt_platform_helper.providers.semantic_version import PlatformHelperVersionStatus
+from dbt_platform_helper.providers.semantic_version import SemanticVersion
+
+
+@patch(
+    "dbt_platform_helper.domain.versioning.running_as_installed_package",
+    new=Mock(return_value=True),
+)
+@patch(
+    "dbt_platform_helper.providers.platform_helper_versioning.running_as_installed_package",
+    new=Mock(return_value=True),
+)
+def test_check_platform_helper_version_shows_warning_when_different_than_file_spec():
+    mock_io_provider = Mock()
+    mock_platform_helper_version_provider = Mock()
+    mock_platform_helper_version_provider.get_status.return_value = PlatformHelperVersionStatus(
+        local=SemanticVersion(1, 0, 1),
+        deprecated_version_file=SemanticVersion(1, 0, 0),
+    )
+    required_version = RequiredVersion(
+        io=mock_io_provider, platform_helper_versioning=mock_platform_helper_version_provider
+    )
+
+    required_version.check_platform_helper_version_mismatch()
+
+    mock_io_provider.warn.assert_called_with(
+        f"WARNING: You are running platform-helper v1.0.1 against v1.0.0 specified for the project.",
+    )
+
+
+@patch(
+    "dbt_platform_helper.utils.versioning.running_as_installed_package", new=Mock(return_value=True)
+)
+@patch(
+    "dbt_platform_helper.providers.platform_helper_versioning.running_as_installed_package",
+    new=Mock(return_value=True),
+)
+def test_check_platform_helper_version_shows_no_warning_when_same_as_file_spec():
+    mock_io_provider = Mock()
+    mock_platform_helper_version_provider = Mock()
+    mock_platform_helper_version_provider.get_status.return_value = PlatformHelperVersionStatus(
+        local=SemanticVersion(1, 0, 1),
+        deprecated_version_file=SemanticVersion(1, 0, 0),
+    )
+    required_version = RequiredVersion(
+        io=mock_io_provider, platform_helper_versioning=mock_platform_helper_version_provider
+    )
+
+    required_version.check_platform_helper_version_mismatch()
+
+    mock_io_provider.warn.assert_not_called
+    mock_io_provider.error.assert_not_called
+
+
+@patch(
+    "dbt_platform_helper.providers.platform_helper_versioning.running_as_installed_package",
+    new=Mock(return_value=True),
+)
+@patch(
+    "dbt_platform_helper.domain.versioning.running_as_installed_package",
+    new=Mock(return_value=True),
+)
+def test_check_platform_helper_version_does_not_fall_over_if_platform_helper_version_file_not_present():
+    mock_platform_helper_version_provider = Mock()
+    mock_platform_helper_version_provider.get_status.return_value = PlatformHelperVersionStatus(
+        local=SemanticVersion(1, 0, 1),
+        deprecated_version_file=None,
+        platform_config_default=SemanticVersion(1, 0, 0),
+    )
+
+    mock_io_provider = Mock()
+
+    required_version = RequiredVersion(
+        platform_helper_versioning=mock_platform_helper_version_provider, io=mock_io_provider
+    )
+
+    required_version.check_platform_helper_version_mismatch()
+
+    mock_io_provider.warn.assert_called_with(
+        f"WARNING: You are running platform-helper v1.0.1 against v1.0.0 specified for the project.",
+    )
+
+
+@patch(
+    "dbt_platform_helper.providers.version.PyPiVersionProvider.get_latest_version",
+    return_value="10.9.9",
+)
+class TestVersionCommandWithInvalidConfig:
+    DEFAULT_VERSION = "1.2.3"
+    INVALID_CONFIG = {
+        "default_versions": {"platform-helper": DEFAULT_VERSION},
+        "a_bogus_field_that_invalidates_config": "foo",
+    }
+
+    def test_works_given_invalid_config(self, mock_latest_release, fakefs):
+        default_version = "1.2.3"
+        platform_config = self.INVALID_CONFIG
+        fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(platform_config))
+
+        result = RequiredVersion().get_required_platform_helper_version(
+            "bogus_pipeline", version_status=PlatformHelperVersioning().get_status()
+        )
+
+        assert result == default_version
+
+    def test_pipeline_override_given_invalid_config(self, mock_latest_release, fakefs):
+        pipeline_override_version = "1.1.1"
+        platform_config = self.INVALID_CONFIG
+        platform_config["environment_pipelines"] = {
+            "main": {
+                "versions": {"platform-helper": pipeline_override_version},
+            }
+        }
+        fakefs.create_file(Path(PLATFORM_CONFIG_FILE), contents=yaml.dump(platform_config))
+
+        result = RequiredVersion().get_required_platform_helper_version(
+            "main", version_status=PlatformHelperVersioning().get_status()
+        )
+
+        assert result == pipeline_override_version
+
+
+@patch("requests.get")
+@patch("dbt_platform_helper.providers.version.version")
+def test_get_required_version_errors_if_version_is_not_specified(
+    mock_version,
+    mock_get,
+    fakefs,
+):
+    mock_version.return_value = "1.2.3"
+    mock_get.return_value.json.return_value = {
+        "releases": {"1.2.3": None, "2.3.4": None, "0.1.0": None}
+    }
+
+    platform_config_without_default_version = {"application": "my-app"}
+    fakefs.create_file(
+        PLATFORM_CONFIG_FILE, contents=yaml.dump(platform_config_without_default_version)
+    )
+
+    mock_io_provider = Mock()
+
+    print("provider mock", mock_io_provider)
+
+    expected_message = f"""Cannot get dbt-platform-helper version from '{PLATFORM_CONFIG_FILE}'.
+Create a section in the root of '{PLATFORM_CONFIG_FILE}':\n\ndefault_versions:\n  platform-helper: 1.2.3
+"""
+
+    with pytest.raises(PlatformHelperVersionNotFoundException):
+        RequiredVersion(io=mock_io_provider).get_required_version()
+
+    mock_io_provider.process_messages.assert_called_with(
+        {"warnings": [], "errors": [expected_message]}
+    )

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -41,9 +41,7 @@ def test_check_platform_helper_version_shows_warning_when_different_than_file_sp
     )
 
 
-@patch(
-    "dbt_platform_helper.utils.versioning.running_as_installed_package", new=Mock(return_value=True)
-)
+@patch("dbt_platform_helper.utils.files.running_as_installed_package", new=Mock(return_value=True))
 @patch(
     "dbt_platform_helper.providers.platform_helper_versioning.running_as_installed_package",
     new=Mock(return_value=True),

--- a/tests/platform_helper/providers/test_semantic_version.py
+++ b/tests/platform_helper/providers/test_semantic_version.py
@@ -89,10 +89,7 @@ class TestVersionStatus:
     )
     def test_is_outdated(self, suite):
         local_version, latest_release, expected = suite
-        assert (
-            VersionStatus(local_version=local_version, latest_release=latest_release).is_outdated()
-            == expected
-        )
+        assert VersionStatus(local=local_version, latest=latest_release).is_outdated() == expected
 
     def test_to_string(self):
         result = f"{VersionStatus(SemanticVersion(1, 2, 0), SemanticVersion(1, 2, 3))}"

--- a/tests/platform_helper/test_command_generate.py
+++ b/tests/platform_helper/test_command_generate.py
@@ -37,7 +37,8 @@ def test_platform_helper_generate_creates_the_pipeline_configuration_and_addons(
     new=Mock(return_value=True),
 )
 @patch(
-    "dbt_platform_helper.utils.versioning.running_as_installed_package", new=Mock(return_value=True)
+    "dbt_platform_helper.domain.versioning.running_as_installed_package",
+    new=Mock(return_value=True),
 )
 @patch("dbt_platform_helper.commands.generate.make_addons", new=Mock(return_value=True))
 @patch("dbt_platform_helper.commands.generate.pipeline_generate", new=Mock(return_value=True))

--- a/tests/platform_helper/test_command_secrets.py
+++ b/tests/platform_helper/test_command_secrets.py
@@ -133,7 +133,7 @@ def test_copy_secrets_with_existing_secret(
 
 @mock_aws
 @patch(
-    "dbt_platform_helper.utils.versioning.running_as_installed_package",
+    "dbt_platform_helper.utils.files.running_as_installed_package",
     new=Mock(return_value=False),
 )
 def test_list():

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -146,10 +146,6 @@ def test_platform_helper_version_deprecation_warnings(
         mock_io_provider.process_messages.assert_called_with({})
 
 
-# TODO move to RequiredVersion domain tests
-# TODO mock config provider instead of fs
-
-
 # TODO Relocate when we refactor config command in DBTP-1538
 @patch("subprocess.run")
 @patch(

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -86,66 +86,6 @@ def test_check_platform_helper_version_skips_when_skip_environment_variable_is_s
     version_compatibility.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "version_in_phv_file, version_in_platform_config, expected_warnings",
-    (
-        (
-            True,
-            False,
-            [
-                f"Please delete '{PLATFORM_HELPER_VERSION_FILE}' as it is now deprecated.",
-                f"Create a section in the root of '{PLATFORM_CONFIG_FILE}':\n\ndefault_versions:\n  platform-helper: 3.3.3\n",
-            ],
-        ),
-        (
-            False,
-            True,
-            None,
-        ),
-        (
-            True,
-            True,
-            [f"Please delete '{PLATFORM_HELPER_VERSION_FILE}' as it is now deprecated."],
-        ),
-    ),
-)
-# TODO add coverage for the include_project_versions parameter in the PlatformHelperVersion tests
-# @pytest.mark.parametrize("include_project_versions", [False, True])
-@patch("requests.get")
-@patch("dbt_platform_helper.providers.version.version")
-def test_platform_helper_version_deprecation_warnings(
-    mock_version,
-    mock_get,
-    fakefs,
-    version_in_phv_file,
-    version_in_platform_config,
-    expected_warnings,
-):
-    mock_version.return_value = "1.2.3"
-    mock_get.return_value.json.return_value = {
-        "releases": {"1.2.3": None, "2.3.4": None, "0.1.0": None}
-    }
-    platform_config = {"application": "my-app"}
-    if version_in_platform_config:
-        platform_config["default_versions"] = {"platform-helper": "2.2.2"}
-
-    fakefs.create_file(PLATFORM_CONFIG_FILE, contents=yaml.dump(platform_config))
-
-    if version_in_phv_file:
-        fakefs.create_file(PLATFORM_HELPER_VERSION_FILE, contents="3.3.3")
-
-    mock_io_provider = Mock()
-
-    RequiredVersion(io=mock_io_provider).get_required_version()
-
-    if expected_warnings:
-        mock_io_provider.process_messages.assert_called_with(
-            {"warnings": expected_warnings, "errors": []}
-        )
-    else:
-        mock_io_provider.process_messages.assert_called_with({})
-
-
 # TODO Relocate when we refactor config command in DBTP-1538
 @patch("subprocess.run")
 @patch(
@@ -173,52 +113,6 @@ def test_get_aws_versions(mock_get_github_released_version, mock_run):
 
     assert versions.local == SemanticVersion(1, 0, 0)
     assert versions.latest == SemanticVersion(2, 0, 0)
-
-
-# TODO this is testing both get_required_platform_helper_version and
-# get_platform_helper_version_status.  We should instead unit test
-# PlatformHelperVersion.get_status thoroughly and then inject VersionStatus for this test.
-@pytest.mark.parametrize(
-    "platform_helper_version_file_version,platform_config_default_version,expected_version",
-    [
-        ("0.0.1", None, "0.0.1"),
-        ("0.0.1", "1.0.0", "1.0.0"),
-    ],
-)
-@patch("dbt_platform_helper.providers.version.version", return_value="0.0.0")
-@patch("requests.get")
-def test_get_required_platform_helper_version(
-    mock_get,
-    mock_version,
-    fakefs,
-    platform_helper_version_file_version,
-    platform_config_default_version,
-    expected_version,
-):
-    mock_get.return_value.json.return_value = {
-        "releases": {"1.2.3": None, "2.3.4": None, "0.1.0": None}
-    }
-    if platform_helper_version_file_version:
-        Path(PLATFORM_HELPER_VERSION_FILE).write_text("0.0.1")
-
-    platform_config = {
-        "application": "my-app",
-        "environments": {"dev": None},
-        "environment_pipelines": {
-            "main": {"slack_channel": "abc", "trigger_on_push": True, "environments": {"dev": None}}
-        },
-    }
-    if platform_config_default_version:
-        platform_config["default_versions"] = {"platform-helper": platform_config_default_version}
-
-    Path(PLATFORM_CONFIG_FILE).write_text(yaml.dump(platform_config))
-
-    version_status = PlatformHelperVersioning().get_status()
-    required_version = RequiredVersion()
-
-    result = required_version.get_required_platform_helper_version(version_status=version_status)
-
-    assert result == expected_version
 
 
 # TODO this is testing both get_required_platform_helper_version and

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -59,7 +59,7 @@ def test_validate_template_version(template_check: Tuple[str, Type[BaseException
 
 # TODO move to PlatformHelperVersion provider tests
 @patch(
-    "dbt_platform_helper.utils.versioning.running_as_installed_package",
+    "dbt_platform_helper.utils.files.running_as_installed_package",
     new=Mock(return_value=False),
 )
 @patch("dbt_platform_helper.utils.versioning.get_platform_helper_version_status")
@@ -72,7 +72,7 @@ def test_check_platform_helper_version_skips_when_running_local_version(version_
 # TODO move to PlatformHelperVersion provider tests and ensure it's testing the right thing
 # right now this always passes because the specific mock is never called
 @patch(
-    "dbt_platform_helper.utils.versioning.running_as_installed_package",
+    "dbt_platform_helper.utils.files.running_as_installed_package",
     new=Mock(return_value=True),
 )
 @patch("dbt_platform_helper.utils.versioning.get_platform_helper_version_status")

--- a/tests/platform_helper/utils/test_versioning.py
+++ b/tests/platform_helper/utils/test_versioning.py
@@ -11,6 +11,8 @@ import yaml
 from dbt_platform_helper.constants import DEFAULT_TERRAFORM_PLATFORM_MODULES_VERSION
 from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_FILE
+from dbt_platform_helper.domain.versioning import PlatformHelperVersionNotFoundException
+from dbt_platform_helper.domain.versioning import RequiredVersion
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.platform_helper_versioning import (
@@ -25,8 +27,6 @@ from dbt_platform_helper.providers.semantic_version import (
 from dbt_platform_helper.providers.semantic_version import PlatformHelperVersionStatus
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.validation import ValidationException
-from dbt_platform_helper.utils.versioning import PlatformHelperVersionNotFoundException
-from dbt_platform_helper.utils.versioning import RequiredVersion
 from dbt_platform_helper.utils.versioning import get_aws_versions
 from dbt_platform_helper.utils.versioning import get_copilot_versions
 from dbt_platform_helper.utils.versioning import (
@@ -72,7 +72,8 @@ def test_check_platform_helper_version_skips_when_running_local_version(version_
 
 # TODO move to RequiredVersion domain
 @patch(
-    "dbt_platform_helper.utils.versioning.running_as_installed_package", new=Mock(return_value=True)
+    "dbt_platform_helper.domain.versioning.running_as_installed_package",
+    new=Mock(return_value=True),
 )
 @patch(
     "dbt_platform_helper.providers.platform_helper_versioning.running_as_installed_package",
@@ -127,7 +128,8 @@ def test_check_platform_helper_version_shows_no_warning_when_same_as_file_spec()
     new=Mock(return_value=True),
 )
 @patch(
-    "dbt_platform_helper.utils.versioning.running_as_installed_package", new=Mock(return_value=True)
+    "dbt_platform_helper.domain.versioning.running_as_installed_package",
+    new=Mock(return_value=True),
 )
 def test_check_platform_helper_version_does_not_fall_over_if_platform_helper_version_file_not_present():
     mock_platform_helper_version_provider = Mock()


### PR DESCRIPTION
Addresses [DBTP-1798](https://uktrade.atlassian.net/browse/DBTP-1798)

* Extracted `RequiredVersion` and associated tests from versioning utilities file into its own domain/domain test class
* Updated imports and patch paths
* Convert `VersionStatus` to data class
* Remove duplicated `running_as_installed_package` function and consolidate in `files` utility file

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing


[DBTP-1798]: https://uktrade.atlassian.net/browse/DBTP-1798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ