### PR TITLE
fix: mock aws session in copilot tests

### DIFF
--- a/tests/platform_helper/domain/test_copilot.py
+++ b/tests/platform_helper/domain/test_copilot.py
@@ -355,6 +355,7 @@ class TestMakeAddonsCommand:
     @patch("dbt_platform_helper.domain.copilot.get_aws_session_or_abort")
     @patch("dbt_platform_helper.commands.copilot.ConfigProvider", new=Mock())
     @patch("dbt_platform_helper.commands.copilot.KMSProvider", new=Mock())
+    @mock_aws
     def test_make_addons_removes_old_addons_files(
         self,
         mock_get_session,
@@ -418,6 +419,7 @@ class TestMakeAddonsCommand:
         "dbt_platform_helper.utils.files.running_as_installed_package",
         new=Mock(return_value=False),
     )
+    @mock_aws
     def test_exit_if_no_config_file(self, fakefs):
         result = CliRunner().invoke(copilot, ["make-addons"])
 
@@ -432,6 +434,7 @@ class TestMakeAddonsCommand:
         new=Mock(return_value=False),
     )
     @patch("dbt_platform_helper.commands.copilot.ConfigProvider", new=Mock())
+    @mock_aws
     def test_exit_if_no_local_copilot_services(self, fakefs):
         fakefs.create_file(PLATFORM_CONFIG_FILE)
 


### PR DESCRIPTION
Ensures the aws session is mocked for the copilot tests since a call to `get_aws_session_or_abort()` is made at the beginning of the command

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
