### PR TITLE
chore: Automate labelling pull requests with "dbt-platform"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add 'dbt-platform' label to any pull-request that is opened against the `main` branch
+dbt-platform:
+  - base-branch: 'main'

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -3,11 +3,12 @@ name: "Label Pull Requests"
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   labeler:
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,0 +1,13 @@
+name: "Label Pull Requests"
+
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
So that we can all bookmark a [Pull Requests I should 👀 Search](https://github.com/pulls?q=is%3Aopen+is%3Apr+draft%3Afalse+label%3Adbt-platform+-author%3A%40me).