### PR TITLE
fix: config validate command - wrong provider injected into PlatformHelperVersioning

### DIFF
--- a/dbt_platform_helper/providers/semantic_version.py
+++ b/dbt_platform_helper/providers/semantic_version.py
@@ -35,6 +35,9 @@ class SemanticVersion:
             return "unknown"
         return ".".join([str(s) for s in [self.major, self.minor, self.patch]])
 
+    def __repr__(self) -> str:
+        return str(self)
+
     def __lt__(self, other) -> bool:
         return (self.major, self.minor, self.patch) < (other.major, other.minor, other.patch)
 

--- a/dbt_platform_helper/utils/tool_versioning.py
+++ b/dbt_platform_helper/utils/tool_versioning.py
@@ -8,6 +8,7 @@ from dbt_platform_helper.providers.semantic_version import PlatformHelperVersion
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.semantic_version import VersionStatus
 from dbt_platform_helper.providers.validation import ValidationException
+from dbt_platform_helper.providers.version import DeprecatedVersionFileVersionProvider
 from dbt_platform_helper.providers.version import GithubVersionProvider
 from dbt_platform_helper.providers.yaml_file import YamlFileProvider
 
@@ -18,7 +19,7 @@ def get_platform_helper_version_status(
     yaml_provider=YamlFileProvider,
 ) -> PlatformHelperVersionStatus:
     return PlatformHelperVersioning(
-        version_file_version_provider=yaml_provider
+        version_file_version_provider=DeprecatedVersionFileVersionProvider(yaml_provider)
     )._get_version_status(include_project_versions=include_project_versions)
 
 

--- a/dbt_platform_helper/utils/tool_versioning.py
+++ b/dbt_platform_helper/utils/tool_versioning.py
@@ -4,12 +4,15 @@ from pathlib import Path
 
 from dbt_platform_helper.constants import DEFAULT_TERRAFORM_PLATFORM_MODULES_VERSION
 from dbt_platform_helper.domain.versioning import PlatformHelperVersioning
+from dbt_platform_helper.providers.config import ConfigProvider
 from dbt_platform_helper.providers.semantic_version import PlatformHelperVersionStatus
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.semantic_version import VersionStatus
 from dbt_platform_helper.providers.validation import ValidationException
 from dbt_platform_helper.providers.version import DeprecatedVersionFileVersionProvider
 from dbt_platform_helper.providers.version import GithubVersionProvider
+from dbt_platform_helper.providers.version import InstalledVersionProvider
+from dbt_platform_helper.providers.version import PyPiVersionProvider
 from dbt_platform_helper.providers.yaml_file import YamlFileProvider
 
 
@@ -19,7 +22,10 @@ def get_platform_helper_version_status(
     yaml_provider=YamlFileProvider,
 ) -> PlatformHelperVersionStatus:
     return PlatformHelperVersioning(
-        version_file_version_provider=DeprecatedVersionFileVersionProvider(yaml_provider)
+        pypi_provider=PyPiVersionProvider,
+        installed_version_provider=InstalledVersionProvider(),
+        version_file_version_provider=DeprecatedVersionFileVersionProvider(yaml_provider),
+        config_provider=ConfigProvider(),
     )._get_version_status(include_project_versions=include_project_versions)
 
 


### PR DESCRIPTION
yaml file provider should have been injected into deprecated version file version provider, not directly into PlatformHelperVersioning

I have tested the `config` commands manually however they don't appear in E2E tests, so we will add a test in the next PR.


---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
