### PR TITLE
fix: Initialise missing parameter provider for codebase commands (off-ticket)

### DIFF
--- a/dbt_platform_helper/commands/codebase.py
+++ b/dbt_platform_helper/commands/codebase.py
@@ -1,10 +1,14 @@
+import boto3
 import click
 
 from dbt_platform_helper.domain.codebase import Codebase
 from dbt_platform_helper.domain.versioning import PlatformHelperVersioning
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.io import ClickIOProvider
+from dbt_platform_helper.providers.parameter_store import ParameterStore
 from dbt_platform_helper.utils.click import ClickDocOptGroup
+
+parameter_provider = ParameterStore(boto3.client("ssm"))
 
 
 @click.group(chain=True, cls=ClickDocOptGroup)
@@ -17,7 +21,7 @@ def codebase():
 def prepare():
     """Sets up an application codebase for use within a DBT platform project."""
     try:
-        Codebase().prepare()
+        Codebase(parameter_provider).prepare()
     except PlatformException as err:
         ClickIOProvider().abort_with_error(str(err))
 
@@ -33,7 +37,7 @@ def prepare():
 def list(app, with_images):
     """List available codebases for the application."""
     try:
-        Codebase().list(app, with_images)
+        Codebase(parameter_provider).list(app, with_images)
     except PlatformException as err:
         ClickIOProvider().abort_with_error(str(err))
 
@@ -49,7 +53,7 @@ def list(app, with_images):
 def build(app, codebase, commit):
     """Trigger a CodePipeline pipeline based build."""
     try:
-        Codebase().build(app, codebase, commit)
+        Codebase(parameter_provider).build(app, codebase, commit)
     except PlatformException as err:
         ClickIOProvider().abort_with_error(str(err))
 
@@ -65,6 +69,6 @@ def build(app, codebase, commit):
 @click.option("--commit", help="GitHub commit hash", required=True)
 def deploy(app, env, codebase, commit):
     try:
-        Codebase().deploy(app, env, codebase, commit)
+        Codebase(parameter_provider).deploy(app, env, codebase, commit)
     except PlatformException as err:
         ClickIOProvider().abort_with_error(str(err))

--- a/dbt_platform_helper/commands/codebase.py
+++ b/dbt_platform_helper/commands/codebase.py
@@ -1,4 +1,3 @@
-import boto3
 import click
 
 from dbt_platform_helper.domain.codebase import Codebase
@@ -6,9 +5,8 @@ from dbt_platform_helper.domain.versioning import PlatformHelperVersioning
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.parameter_store import ParameterStore
+from dbt_platform_helper.utils.aws import get_aws_session_or_abort
 from dbt_platform_helper.utils.click import ClickDocOptGroup
-
-parameter_provider = ParameterStore(boto3.client("ssm"))
 
 
 @click.group(chain=True, cls=ClickDocOptGroup)
@@ -21,7 +19,7 @@ def codebase():
 def prepare():
     """Sets up an application codebase for use within a DBT platform project."""
     try:
-        Codebase(parameter_provider).prepare()
+        Codebase(ParameterStore(get_aws_session_or_abort().client("ssm"))).prepare()
     except PlatformException as err:
         ClickIOProvider().abort_with_error(str(err))
 
@@ -37,7 +35,7 @@ def prepare():
 def list(app, with_images):
     """List available codebases for the application."""
     try:
-        Codebase(parameter_provider).list(app, with_images)
+        Codebase(ParameterStore(get_aws_session_or_abort().client("ssm"))).list(app, with_images)
     except PlatformException as err:
         ClickIOProvider().abort_with_error(str(err))
 
@@ -53,7 +51,9 @@ def list(app, with_images):
 def build(app, codebase, commit):
     """Trigger a CodePipeline pipeline based build."""
     try:
-        Codebase(parameter_provider).build(app, codebase, commit)
+        Codebase(ParameterStore(get_aws_session_or_abort().client("ssm"))).build(
+            app, codebase, commit
+        )
     except PlatformException as err:
         ClickIOProvider().abort_with_error(str(err))
 
@@ -69,6 +69,8 @@ def build(app, codebase, commit):
 @click.option("--commit", help="GitHub commit hash", required=True)
 def deploy(app, env, codebase, commit):
     try:
-        Codebase(parameter_provider).deploy(app, env, codebase, commit)
+        Codebase(ParameterStore(get_aws_session_or_abort().client("ssm"))).deploy(
+            app, env, codebase, commit
+        )
     except PlatformException as err:
         ClickIOProvider().abort_with_error(str(err))

--- a/tests/platform_helper/test_command_codebase.py
+++ b/tests/platform_helper/test_command_codebase.py
@@ -1,5 +1,6 @@
 import os
 from unittest.mock import MagicMock
+from unittest.mock import Mock
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -28,12 +29,21 @@ def mock_aws_client(get_aws_session_or_abort):
 
 
 class TestCodebasePrepare:
+    @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
+    @patch("dbt_platform_helper.commands.codebase.ParameterStore")
     @patch("dbt_platform_helper.commands.codebase.Codebase")
-    def test_codebase_prepare_calls_codebase_prepare_method(self, mock_codebase_object):
-        mock_codebase_object_instance = mock_codebase_object.return_value
+    def test_codebase_prepare_calls_codebase_prepare_method(
+        self, mock_codebase_object, mock_parameter_provider, mock_session
+    ):
+        mock_ssm_client = Mock()
+        mock_session.return_value.client.return_value = mock_ssm_client
 
         result = CliRunner().invoke(prepare_command)
-        mock_codebase_object_instance.prepare.assert_called_once()
+
+        mock_session.return_value.client.assert_called_once_with("ssm")
+        mock_parameter_provider.assert_called_with(mock_ssm_client)
+        mock_codebase_object.assert_called_once_with(mock_parameter_provider.return_value)
+        mock_codebase_object.return_value.prepare.assert_called_once()
 
         assert result.exit_code == 0
 
@@ -50,6 +60,33 @@ class TestCodebasePrepare:
 
 
 class TestCodebaseBuild:
+    @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
+    @patch("dbt_platform_helper.commands.codebase.ParameterStore")
+    @patch("dbt_platform_helper.commands.codebase.Codebase")
+    def test_codebase_build_calls_codebase_build_method(
+        self, mock_codebase_object, mock_parameter_provider, mock_session
+    ):
+        mock_ssm_client = Mock()
+        mock_session.return_value.client.return_value = mock_ssm_client
+
+        result = CliRunner().invoke(
+            build,
+            [
+                "--app",
+                "test-application",
+                "--codebase",
+                "application",
+                "--commit",
+                "test-commit-hash",
+            ],
+        )
+        mock_session.return_value.client.assert_called_once_with("ssm")
+        mock_parameter_provider.assert_called_with(mock_ssm_client)
+        mock_codebase_object.assert_called_once_with(mock_parameter_provider.return_value)
+        mock_codebase_object.return_value.build.assert_called_once()
+
+        assert result.exit_code == 0
+
     @patch("dbt_platform_helper.commands.codebase.Codebase")
     @patch("click.secho")
     def test_codebase_build_does_not_trigger_build_without_an_application(
@@ -74,11 +111,16 @@ class TestCodebaseBuild:
 
         assert result.exit_code == 1
 
+    @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
+    @patch("dbt_platform_helper.commands.codebase.ParameterStore")
     @patch("dbt_platform_helper.commands.codebase.Codebase")
     @patch("click.secho")
     def test_codebase_build_aborts_with_a_nonexistent_commit_hash(
-        self, mock_click, mock_codebase_object
+        self, mock_click, mock_codebase_object, mock_parameter_provider, mock_session
     ):
+        mock_ssm_client = Mock()
+        mock_session.return_value.client.return_value = mock_ssm_client
+
         mock_codebase_object_instance = mock_codebase_object.return_value
         mock_codebase_object_instance.build.side_effect = CommitNotFoundException()
         os.environ["AWS_PROFILE"] = "foo"
@@ -95,6 +137,11 @@ class TestCodebaseBuild:
             ],
         )
 
+        mock_session.return_value.client.assert_called_once_with("ssm")
+        mock_parameter_provider.assert_called_with(mock_ssm_client)
+        mock_codebase_object.assert_called_once_with(mock_parameter_provider.return_value)
+        mock_codebase_object.return_value.build.assert_called_once()
+
         mock_codebase_object_instance.build.assert_called_once_with(
             "test-application", "application", "nonexistent-commit-hash"
         )
@@ -103,11 +150,45 @@ class TestCodebaseBuild:
 
 
 class TestCodebaseDeploy:
+    @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
+    @patch("dbt_platform_helper.commands.codebase.ParameterStore")
+    @patch("dbt_platform_helper.commands.codebase.Codebase")
+    def test_codebase_prepare_calls_codebase_prepare_method(
+        self, mock_codebase_object, mock_parameter_provider, mock_session
+    ):
+        mock_ssm_client = Mock()
+        mock_session.return_value.client.return_value = mock_ssm_client
+
+        result = CliRunner().invoke(
+            deploy,
+            [
+                "--app",
+                "test-application",
+                "--env",
+                "development",
+                "--codebase",
+                "application",
+                "--commit",
+                "ab1c23d",
+            ],
+        )
+        mock_session.return_value.client.assert_called_once_with("ssm")
+        mock_parameter_provider.assert_called_with(mock_ssm_client)
+        mock_codebase_object.assert_called_once_with(mock_parameter_provider.return_value)
+        mock_codebase_object.return_value.deploy.assert_called_once()
+
+        assert result.exit_code == 0
+
+    @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
+    @patch("dbt_platform_helper.commands.codebase.ParameterStore")
     @patch("dbt_platform_helper.commands.codebase.Codebase")
     def test_codebase_deploy_successfully_triggers_a_pipeline_based_deploy(
-        self, codebase_object_mock
+        self, mock_codebase_object, mock_parameter_provider, mock_session
     ):
-        mock_codebase_object_instance = codebase_object_mock.return_value
+        mock_codebase_object_instance = mock_codebase_object.return_value
+
+        mock_ssm_client = Mock()
+        mock_session.return_value.client.return_value = mock_ssm_client
 
         CliRunner().invoke(
             deploy,
@@ -124,16 +205,27 @@ class TestCodebaseDeploy:
             input="y\n",
         )
 
+        mock_session.return_value.client.assert_called_once_with("ssm")
+        mock_parameter_provider.assert_called_with(mock_ssm_client)
+        mock_codebase_object.assert_called_once_with(mock_parameter_provider.return_value)
+        mock_codebase_object.return_value.deploy.assert_called_once()
+
         mock_codebase_object_instance.deploy.assert_called_once_with(
             "test-application", "development", "application", "ab1c23d"
         )
 
+    @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
+    @patch("dbt_platform_helper.commands.codebase.ParameterStore")
     @patch("dbt_platform_helper.commands.codebase.Codebase")
     @patch("click.secho")
     def test_codebase_deploy_aborts_with_a_nonexistent_image_repository_or_image_tag(
-        self, mock_click, codebase_object_mock
+        self, mock_click, mock_codebase_object, mock_parameter_provider, mock_session
     ):
-        mock_codebase_object_instance = codebase_object_mock.return_value
+
+        mock_ssm_client = Mock()
+        mock_session.return_value.client.return_value = mock_ssm_client
+
+        mock_codebase_object_instance = mock_codebase_object.return_value
         mock_codebase_object_instance.deploy.side_effect = ImageNotFoundException
         result = CliRunner().invoke(
             deploy,
@@ -149,16 +241,27 @@ class TestCodebaseDeploy:
             ],
         )
 
+        mock_session.return_value.client.assert_called_once_with("ssm")
+        mock_parameter_provider.assert_called_with(mock_ssm_client)
+        mock_codebase_object.assert_called_once_with(mock_parameter_provider.return_value)
+        mock_codebase_object.return_value.deploy.assert_called_once()
+
         mock_codebase_object_instance.deploy.assert_called_once_with(
             "test-application", "development", "application", "nonexistent-commit-hash"
         )
         assert result.exit_code == 1
 
+    @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
+    @patch("dbt_platform_helper.commands.codebase.ParameterStore")
     @patch("dbt_platform_helper.commands.codebase.Codebase")
     @patch("click.secho")
     def test_codebase_deploy_does_not_trigger_build_without_an_application(
-        self, mock_click, mock_codebase_object
+        self, mock_click, mock_codebase_object, mock_parameter_provider, mock_session
     ):
+
+        mock_ssm_client = Mock()
+        mock_session.return_value.client.return_value = mock_ssm_client
+
         mock_codebase_object_instance = mock_codebase_object.return_value
         mock_codebase_object_instance.deploy.side_effect = ApplicationNotFoundException
         os.environ["AWS_PROFILE"] = "foo"
@@ -177,16 +280,26 @@ class TestCodebaseDeploy:
             ],
         )
 
+        mock_session.return_value.client.assert_called_once_with("ssm")
+        mock_parameter_provider.assert_called_with(mock_ssm_client)
+        mock_codebase_object.assert_called_once_with(mock_parameter_provider.return_value)
+        mock_codebase_object.return_value.deploy.assert_called_once()
+
         mock_codebase_object_instance.deploy.assert_called_once_with(
             "not-an-application", "dev", "application", "ab1c23d"
         )
         assert result.exit_code == 1
 
+    @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
+    @patch("dbt_platform_helper.commands.codebase.ParameterStore")
     @patch("dbt_platform_helper.commands.codebase.Codebase")
     @patch("click.secho")
     def test_codebase_deploy_does_not_trigger_build_with_missing_environment(
-        self, mock_click, mock_codebase_object
+        self, mock_click, mock_codebase_object, mock_parameter_provider, mock_session
     ):
+        mock_ssm_client = Mock()
+        mock_session.return_value.client.return_value = mock_ssm_client
+
         mock_codebase_object_instance = mock_codebase_object.return_value
         mock_codebase_object_instance.deploy.side_effect = ApplicationEnvironmentNotFoundException
         os.environ["AWS_PROFILE"] = "foo"
@@ -205,16 +318,26 @@ class TestCodebaseDeploy:
             ],
         )
 
+        mock_session.return_value.client.assert_called_once_with("ssm")
+        mock_parameter_provider.assert_called_with(mock_ssm_client)
+        mock_codebase_object.assert_called_once_with(mock_parameter_provider.return_value)
+        mock_codebase_object.return_value.deploy.assert_called_once()
+
         mock_codebase_object_instance.deploy.assert_called_once_with(
             "test-application", "not-an-environment", "application", "ab1c23d"
         )
         assert result.exit_code == 1
 
+    @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
+    @patch("dbt_platform_helper.commands.codebase.ParameterStore")
     @patch("dbt_platform_helper.commands.codebase.Codebase")
     @patch("click.secho")
     def test_codebase_deploy_does_not_trigger_build_with_missing_codebase(
-        self, mock_click, mock_codebase_object
+        self, mock_click, mock_codebase_object, mock_parameter_provider, mock_session
     ):
+        mock_ssm_client = Mock()
+        mock_session.return_value.client.return_value = mock_ssm_client
+
         mock_codebase_object_instance = mock_codebase_object.return_value
         mock_codebase_object_instance.deploy.side_effect = CopilotCodebaseNotFoundException
         os.environ["AWS_PROFILE"] = "foo"
@@ -233,6 +356,11 @@ class TestCodebaseDeploy:
             ],
         )
 
+        mock_session.return_value.client.assert_called_once_with("ssm")
+        mock_parameter_provider.assert_called_with(mock_ssm_client)
+        mock_codebase_object.assert_called_once_with(mock_parameter_provider.return_value)
+        mock_codebase_object.return_value.deploy.assert_called_once()
+
         mock_codebase_object_instance.deploy.assert_called_once_with(
             "test-application", "test-environment", "not-a-codebase", "ab1c23d"
         )
@@ -240,12 +368,24 @@ class TestCodebaseDeploy:
 
 
 class TestCodebaseList:
+    @patch("dbt_platform_helper.commands.codebase.get_aws_session_or_abort")
+    @patch("dbt_platform_helper.commands.codebase.ParameterStore")
     @patch("dbt_platform_helper.commands.codebase.Codebase")
-    def test_lists_codebases_successfully(self, mock_codebase_object):
+    def test_lists_codebases_successfully(
+        self, mock_codebase_object, mock_parameter_provider, mock_session
+    ):
+        mock_ssm_client = Mock()
+        mock_session.return_value.client.return_value = mock_ssm_client
+
         mock_codebase_object_instance = mock_codebase_object.return_value
         os.environ["AWS_PROFILE"] = "foo"
 
         result = CliRunner().invoke(list, ["--app", "test-application", "--with-images"])
+
+        mock_session.return_value.client.assert_called_once_with("ssm")
+        mock_parameter_provider.assert_called_with(mock_ssm_client)
+        mock_codebase_object.assert_called_once_with(mock_parameter_provider.return_value)
+        mock_codebase_object.return_value.list.assert_called_once()
 
         mock_codebase_object_instance.list.assert_called_once_with("test-application", True)
         assert result.exit_code == 0


### PR DESCRIPTION
Initialising ParameterStore for commands/codebase.py was missed out during [the refactor](https://github.com/uktrade/platform-tools/pull/793), Adding it here to avoid a breaking change.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
