### PR TITLE
refactor: Improve definition of version classes (DBTP-1895)

### DIFF
--- a/dbt_platform_helper/domain/config.py
+++ b/dbt_platform_helper/domain/config.py
@@ -172,7 +172,7 @@ class Config:
 
     def _check_tool_versions(
         self,
-        platform_helper_versions: PlatformHelperVersionStatus,
+        platform_helper_version_status: PlatformHelperVersionStatus,
         aws_version_status: VersionStatus,
         copilot_version_status: VersionStatus,
     ):
@@ -180,9 +180,7 @@ class Config:
 
         recommendations = {}
 
-        local_copilot_version = copilot_version_status.installed
-        copilot_latest_release = copilot_version_status.latest
-        if local_copilot_version is None:
+        if copilot_version_status.installed is None:
             recommendations["install-copilot"] = RECOMMENDATIONS["install-copilot"]
 
         if aws_version_status.installed is None:
@@ -216,9 +214,9 @@ class Config:
         tool_versions_table.add_row(
             [
                 "dbt-platform-helper",
-                str(platform_helper_versions.installed),
-                str(platform_helper_versions.latest),
-                no if platform_helper_versions.is_outdated() else yes,
+                str(platform_helper_version_status.installed),
+                str(platform_helper_version_status.latest),
+                no if platform_helper_version_status.is_outdated() else yes,
             ]
         )
 
@@ -233,13 +231,13 @@ class Config:
         if copilot_version_status.is_outdated() and "install-copilot" not in recommendations:
             recommendations["copilot-upgrade"] = RECOMMENDATIONS["generic-tool-upgrade"].format(
                 tool="AWS Copilot",
-                version=str(copilot_latest_release),
+                version=str(copilot_version_status.latest),
             )
 
-        if platform_helper_versions.is_outdated():
+        if platform_helper_version_status.is_outdated():
             recommendations["dbt-platform-helper-upgrade"] = RECOMMENDATIONS[
                 "dbt-platform-helper-upgrade"
-            ].format(version=str(platform_helper_versions.latest))
+            ].format(version=str(platform_helper_version_status.latest))
             recommendations["dbt-platform-helper-upgrade-note"] = RECOMMENDATIONS[
                 "dbt-platform-helper-upgrade-note"
             ]

--- a/dbt_platform_helper/domain/config.py
+++ b/dbt_platform_helper/domain/config.py
@@ -170,6 +170,18 @@ class Config:
         )
         return accounts_list
 
+    def _add_version_status_row(
+        self, table: PrettyTable, header: str, version_status: VersionStatus
+    ):
+        table.add_row(
+            [
+                header,
+                str(version_status.installed),
+                str(version_status.latest),
+                no if version_status.is_outdated() else yes,
+            ]
+        )
+
     def _check_tool_versions(
         self,
         platform_helper_version_status: PlatformHelperVersionStatus,
@@ -195,29 +207,10 @@ class Config:
         ]
         tool_versions_table.align["Tool"] = "l"
 
-        tool_versions_table.add_row(
-            [
-                "aws",
-                str(aws_version_status.installed),
-                str(aws_version_status.latest),
-                no if aws_version_status.is_outdated() else yes,
-            ]
-        )
-        tool_versions_table.add_row(
-            [
-                "copilot",
-                str(copilot_version_status.installed),
-                str(copilot_version_status.latest),
-                no if copilot_version_status.is_outdated() else yes,
-            ]
-        )
-        tool_versions_table.add_row(
-            [
-                "dbt-platform-helper",
-                str(platform_helper_version_status.installed),
-                str(platform_helper_version_status.latest),
-                no if platform_helper_version_status.is_outdated() else yes,
-            ]
+        self._add_version_status_row(tool_versions_table, "aws", aws_version_status)
+        self._add_version_status_row(tool_versions_table, "copilot", copilot_version_status)
+        self._add_version_status_row(
+            tool_versions_table, "dbt-platform-helper", platform_helper_version_status
         )
 
         self.io.info(tool_versions_table)

--- a/dbt_platform_helper/domain/config.py
+++ b/dbt_platform_helper/domain/config.py
@@ -76,7 +76,7 @@ class Config:
         self,
         io: ClickIOProvider = ClickIOProvider(),
         platform_helper_versioning_domain: PlatformHelperVersioning = PlatformHelperVersioning(),
-        aws_versions: AWSVersioning = AWSVersioning,
+        aws_versions: AWSVersioning = AWSVersioning(),
         copilot_versions: CopilotVersioning = CopilotVersioning,
         sso: SSOAuthProvider = None,
     ):

--- a/dbt_platform_helper/domain/config.py
+++ b/dbt_platform_helper/domain/config.py
@@ -16,10 +16,10 @@ from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.semantic_version import (
     IncompatibleMajorVersionException,
 )
-from dbt_platform_helper.providers.semantic_version import PlatformHelperVersionStatus
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
-from dbt_platform_helper.providers.semantic_version import VersionStatus
 from dbt_platform_helper.providers.validation import ValidationException
+from dbt_platform_helper.providers.version_status import PlatformHelperVersionStatus
+from dbt_platform_helper.providers.version_status import VersionStatus
 
 yes = "\033[92m✔\033[0m"
 no = "\033[91m✖\033[0m"

--- a/dbt_platform_helper/domain/config.py
+++ b/dbt_platform_helper/domain/config.py
@@ -19,7 +19,7 @@ from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.semantic_version import VersionStatus
 from dbt_platform_helper.providers.validation import ValidationException
 from dbt_platform_helper.providers.version import AWSVersioning
-from dbt_platform_helper.providers.version import CopilotVersionProvider
+from dbt_platform_helper.providers.version import CopilotVersioning
 
 yes = "\033[92m✔\033[0m"
 no = "\033[91m✖\033[0m"
@@ -77,7 +77,7 @@ class Config:
         io: ClickIOProvider = ClickIOProvider(),
         platform_helper_versioning_domain: PlatformHelperVersioning = PlatformHelperVersioning(),
         aws_versions: AWSVersioning = AWSVersioning,
-        copilot_versions: CopilotVersionProvider = CopilotVersionProvider,
+        copilot_versions: CopilotVersioning = CopilotVersioning,
         sso: SSOAuthProvider = None,
     ):
         self.oidc_app = None

--- a/dbt_platform_helper/domain/config.py
+++ b/dbt_platform_helper/domain/config.py
@@ -76,8 +76,8 @@ class Config:
         self,
         io: ClickIOProvider = ClickIOProvider(),
         platform_helper_versioning_domain: PlatformHelperVersioning = PlatformHelperVersioning(),
-        aws_versions: AWSVersioning = AWSVersioning(),
-        copilot_versions: CopilotVersioning = CopilotVersioning(),
+        aws_versioning: AWSVersioning = AWSVersioning(),
+        copilot_versioning: CopilotVersioning = CopilotVersioning(),
         sso: SSOAuthProvider = None,
     ):
         self.oidc_app = None

--- a/dbt_platform_helper/domain/config.py
+++ b/dbt_platform_helper/domain/config.py
@@ -77,7 +77,7 @@ class Config:
         io: ClickIOProvider = ClickIOProvider(),
         platform_helper_versioning_domain: PlatformHelperVersioning = PlatformHelperVersioning(),
         aws_versions: AWSVersioning = AWSVersioning(),
-        copilot_versions: CopilotVersioning = CopilotVersioning,
+        copilot_versions: CopilotVersioning = CopilotVersioning(),
         sso: SSOAuthProvider = None,
     ):
         self.oidc_app = None

--- a/dbt_platform_helper/domain/config.py
+++ b/dbt_platform_helper/domain/config.py
@@ -7,6 +7,8 @@ from typing import Dict
 from prettytable import PrettyTable
 
 from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
+from dbt_platform_helper.domain.versioning import AWSVersioning
+from dbt_platform_helper.domain.versioning import CopilotVersioning
 from dbt_platform_helper.domain.versioning import PlatformHelperVersioning
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.aws.sso_auth import SSOAuthProvider
@@ -18,8 +20,6 @@ from dbt_platform_helper.providers.semantic_version import PlatformHelperVersion
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.semantic_version import VersionStatus
 from dbt_platform_helper.providers.validation import ValidationException
-from dbt_platform_helper.providers.version import AWSVersioning
-from dbt_platform_helper.providers.version import CopilotVersioning
 
 yes = "\033[92m✔\033[0m"
 no = "\033[91m✖\033[0m"

--- a/dbt_platform_helper/domain/config.py
+++ b/dbt_platform_helper/domain/config.py
@@ -18,7 +18,7 @@ from dbt_platform_helper.providers.semantic_version import PlatformHelperVersion
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.semantic_version import VersionStatus
 from dbt_platform_helper.providers.validation import ValidationException
-from dbt_platform_helper.providers.version import AWSVersionProvider
+from dbt_platform_helper.providers.version import AWSVersioning
 from dbt_platform_helper.providers.version import CopilotVersionProvider
 
 yes = "\033[92m✔\033[0m"
@@ -76,7 +76,7 @@ class Config:
         self,
         io: ClickIOProvider = ClickIOProvider(),
         platform_helper_versioning_domain: PlatformHelperVersioning = PlatformHelperVersioning(),
-        aws_versions: AWSVersionProvider = AWSVersionProvider,
+        aws_versions: AWSVersioning = AWSVersioning,
         copilot_versions: CopilotVersionProvider = CopilotVersionProvider,
         sso: SSOAuthProvider = None,
     ):

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -167,16 +167,17 @@ class AWSVersioning:
         self.latest_version_provider = latest_version_provider or GithubLatestVersionProvider
 
     def get_version_status(self) -> VersionStatus:
-        aws_version = None
+        installed_aws_version = None
         try:
             response = subprocess.run("aws --version", capture_output=True, shell=True)
             matched = re.match(r"aws-cli/([0-9.]+)", response.stdout.decode("utf8"))
-            aws_version = SemanticVersion.from_string(matched.group(1))
+            installed_aws_version = SemanticVersion.from_string(matched.group(1))
         except ValueError:
             pass
 
         return VersionStatus(
-            aws_version, self.latest_version_provider.get_semantic_version("aws/aws-cli", True)
+            installed_aws_version,
+            self.latest_version_provider.get_semantic_version("aws/aws-cli", True),
         )
 
 

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -38,14 +38,14 @@ class PlatformHelperVersioning:
             YamlFileProvider
         ),
         config_provider: ConfigProvider = ConfigProvider(),
-        pypi_provider: PyPiLatestVersionProvider = PyPiLatestVersionProvider,
+        latest_version_provider: PyPiLatestVersionProvider = PyPiLatestVersionProvider,
         installed_version_provider: InstalledVersionProvider = InstalledVersionProvider(),
         skip_versioning_checks: bool = None,
     ):
         self.io = io
         self.version_file_version_provider = version_file_version_provider
         self.config_provider = config_provider
-        self.pypi_provider = pypi_provider
+        self.latest_version_provider = latest_version_provider
         self.installed_version_provider = installed_version_provider
         self.skip_versioning_checks = (
             skip_versioning_checks if skip_versioning_checks is not None else skip_version_checks()
@@ -104,7 +104,7 @@ class PlatformHelperVersioning:
             "dbt-platform-helper"
         )
 
-        latest_release = self.pypi_provider.get_semantic_version("dbt-platform-helper")
+        latest_release = self.latest_version_provider.get_semantic_version("dbt-platform-helper")
 
         if not include_project_versions:
             return PlatformHelperVersionStatus(

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -13,7 +13,7 @@ from dbt_platform_helper.providers.semantic_version import PlatformHelperVersion
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.version import DeprecatedVersionFileVersionProvider
 from dbt_platform_helper.providers.version import InstalledVersionProvider
-from dbt_platform_helper.providers.version import PyPiVersionProvider
+from dbt_platform_helper.providers.version import PyPiLatestVersionProvider
 from dbt_platform_helper.providers.yaml_file import YamlFileProvider
 
 
@@ -38,7 +38,7 @@ class PlatformHelperVersioning:
             YamlFileProvider
         ),
         config_provider: ConfigProvider = ConfigProvider(),
-        pypi_provider: PyPiVersionProvider = PyPiVersionProvider,
+        pypi_provider: PyPiLatestVersionProvider = PyPiLatestVersionProvider,
         installed_version_provider: InstalledVersionProvider = InstalledVersionProvider(),
         skip_versioning_checks: bool = None,
     ):

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -100,7 +100,7 @@ class PlatformHelperVersioning:
         self,
         include_project_versions: bool = True,
     ) -> PlatformHelperVersionStatus:
-        locally_installed_version = self.installed_version_provider.get_installed_tool_version(
+        locally_installed_version = self.installed_version_provider.get_semantic_version(
             "dbt-platform-helper"
         )
 

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -104,7 +104,7 @@ class PlatformHelperVersioning:
             "dbt-platform-helper"
         )
 
-        latest_release = self.pypi_provider.get_latest_version("dbt-platform-helper")
+        latest_release = self.pypi_provider.get_semantic_version("dbt-platform-helper")
 
         if not include_project_versions:
             return PlatformHelperVersionStatus(

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -185,7 +185,7 @@ class CopilotVersioning:
     def __init__(self, latest_version_provider: VersionProvider = None):
         self.latest_version_provider = latest_version_provider or GithubLatestVersionProvider
 
-    def get_version_status(self) -> VersionStatus:
+    def get_semantic_version(self):
         copilot_version = None
 
         try:
@@ -194,7 +194,10 @@ class CopilotVersioning:
         except ValueError:
             pass
 
+        return SemanticVersion.from_string(copilot_version)
+
+    def get_version_status(self) -> VersionStatus:
         return VersionStatus(
-            SemanticVersion.from_string(copilot_version),
+            self.get_semantic_version(),
             self.latest_version_provider.get_semantic_version("aws/copilot-cli"),
         )

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -11,14 +11,14 @@ from dbt_platform_helper.providers.semantic_version import (
 from dbt_platform_helper.providers.semantic_version import (
     IncompatibleMinorVersionException,
 )
-from dbt_platform_helper.providers.semantic_version import PlatformHelperVersionStatus
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
-from dbt_platform_helper.providers.semantic_version import VersionStatus
 from dbt_platform_helper.providers.version import DeprecatedVersionFileVersionProvider
 from dbt_platform_helper.providers.version import GithubLatestVersionProvider
 from dbt_platform_helper.providers.version import InstalledVersionProvider
 from dbt_platform_helper.providers.version import PyPiLatestVersionProvider
 from dbt_platform_helper.providers.version import VersionProvider
+from dbt_platform_helper.providers.version_status import PlatformHelperVersionStatus
+from dbt_platform_helper.providers.version_status import VersionStatus
 from dbt_platform_helper.providers.yaml_file import YamlFileProvider
 
 

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -129,7 +129,7 @@ class PlatformHelperVersioning:
         out = PlatformHelperVersionStatus(
             installed=locally_installed_version,
             latest=latest_release,
-            deprecated_version_file=self.version_file_version_provider.get_required_version(),
+            deprecated_version_file=self.version_file_version_provider.get_semantic_version(),
             platform_config_default=platform_config_default,
             pipeline_overrides=pipeline_overrides,
         )

--- a/dbt_platform_helper/providers/semantic_version.py
+++ b/dbt_platform_helper/providers/semantic_version.py
@@ -1,12 +1,6 @@
 import re
-from dataclasses import dataclass
-from dataclasses import field
-from typing import Dict
-from typing import Optional
 from typing import Union
 
-from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
-from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_FILE
 from dbt_platform_helper.providers.validation import ValidationException
 
 
@@ -79,75 +73,3 @@ class SemanticVersion:
                 output_version[index] = -1
 
         return SemanticVersion(output_version[0], output_version[1], output_version[2])
-
-
-@dataclass
-class VersionStatus:
-    installed: SemanticVersion = None
-    latest: SemanticVersion = None
-
-    def __str__(self):
-        attrs = {
-            key: value for key, value in vars(self).items() if isinstance(value, SemanticVersion)
-        }
-        attrs_str = ", ".join(f"{key}: {value}" for key, value in attrs.items())
-        return f"{self.__class__.__name__}: {attrs_str}"
-
-    def is_outdated(self):
-        return self.installed != self.latest
-
-    def validate(self):
-        pass
-
-
-@dataclass
-class PlatformHelperVersionStatus(VersionStatus):
-    installed: Optional[SemanticVersion] = None
-    latest: Optional[SemanticVersion] = None
-    deprecated_version_file: Optional[SemanticVersion] = None
-    platform_config_default: Optional[SemanticVersion] = None
-    pipeline_overrides: Optional[Dict[str, str]] = field(default_factory=dict)
-
-    def __str__(self):
-        semantic_version_attrs = {
-            key: value for key, value in vars(self).items() if isinstance(value, SemanticVersion)
-        }
-
-        class_str = ", ".join(f"{key}: {value}" for key, value in semantic_version_attrs.items())
-
-        if self.pipeline_overrides.items():
-            pipeline_overrides_str = "pipeline_overrides: " + ", ".join(
-                f"{key}: {value}" for key, value in self.pipeline_overrides.items()
-            )
-            class_str = ", ".join([class_str, pipeline_overrides_str])
-
-        return f"{self.__class__.__name__}: {class_str}"
-
-    def validate(self) -> dict:
-        if self.platform_config_default and not self.deprecated_version_file:
-            return {}
-
-        warnings = []
-        errors = []
-
-        missing_default_version_message = f"Create a section in the root of '{PLATFORM_CONFIG_FILE}':\n\ndefault_versions:\n  platform-helper: "
-        deprecation_message = (
-            f"Please delete '{PLATFORM_HELPER_VERSION_FILE}' as it is now deprecated."
-        )
-
-        if self.platform_config_default and self.deprecated_version_file:
-            warnings.append(deprecation_message)
-
-        if not self.platform_config_default and self.deprecated_version_file:
-            warnings.append(deprecation_message)
-            warnings.append(f"{missing_default_version_message}{self.deprecated_version_file}\n")
-
-        if not self.platform_config_default and not self.deprecated_version_file:
-            message = f"Cannot get dbt-platform-helper version from '{PLATFORM_CONFIG_FILE}'.\n"
-            message += f"{missing_default_version_message}{self.installed}\n"
-            errors.append(message)
-
-        return {
-            "warnings": warnings,
-            "errors": errors,
-        }

--- a/dbt_platform_helper/providers/semantic_version.py
+++ b/dbt_platform_helper/providers/semantic_version.py
@@ -54,6 +54,13 @@ class SemanticVersion:
         if self.minor != other.minor:
             raise IncompatibleMinorVersionException(str(self), str(other))
 
+    @staticmethod
+    def _cast_to_int_with_fallback(input, fallback=-1):
+        try:
+            return int(input)
+        except ValueError:
+            return fallback
+
     @classmethod
     def from_string(self, version_string: Union[str, None]):
         if version_string is None:
@@ -64,11 +71,6 @@ class SemanticVersion:
         if len(version_segments) != 3:
             return None
 
-        output_version = [0, 0, 0]
-        for index, segment in enumerate(version_segments):
-            try:
-                output_version[index] = int(segment)
-            except ValueError:
-                output_version[index] = -1
+        major, minor, patch = [self._cast_to_int_with_fallback(s) for s in version_segments]
 
-        return SemanticVersion(output_version[0], output_version[1], output_version[2])
+        return SemanticVersion(major, minor, patch)

--- a/dbt_platform_helper/providers/semantic_version.py
+++ b/dbt_platform_helper/providers/semantic_version.py
@@ -54,8 +54,8 @@ class SemanticVersion:
         if self.minor != other.minor:
             raise IncompatibleMinorVersionException(str(self), str(other))
 
-    @staticmethod
-    def from_string(version_string: Union[str, None]):
+    @classmethod
+    def from_string(self, version_string: Union[str, None]):
         if version_string is None:
             return None
 

--- a/dbt_platform_helper/providers/semantic_version.py
+++ b/dbt_platform_helper/providers/semantic_version.py
@@ -59,8 +59,7 @@ class SemanticVersion:
         if version_string is None:
             return None
 
-        version_plain = version_string.replace("v", "")
-        version_segments = re.split(r"[.\-]", version_plain)
+        version_segments = re.split(r"[.\-]", version_string.replace("v", ""))
 
         if len(version_segments) != 3:
             return None

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -28,12 +28,13 @@ class InstalledToolNotFoundException(InstalledVersionProviderException):
 
 
 class VersionProvider(ABC):
-    pass
+    def get_semantic_version() -> SemanticVersion:
+        pass
 
 
 class InstalledVersionProvider:
     @staticmethod
-    def get_installed_tool_version(tool_name: str) -> SemanticVersion:
+    def get_semantic_version(tool_name: str) -> SemanticVersion:
         try:
             return SemanticVersion.from_string(version(tool_name))
         except PackageNotFoundError:

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -1,6 +1,7 @@
 import re
 import subprocess
 from abc import ABC
+from abc import abstractmethod
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version
 from pathlib import Path
@@ -27,6 +28,7 @@ class InstalledToolNotFoundException(InstalledVersionProviderException):
 
 
 class VersionProvider(ABC):
+    @abstractmethod
     def get_semantic_version() -> SemanticVersion:
         raise NotImplementedError("Must be implemented in subclasses")
 

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -83,8 +83,8 @@ class DeprecatedVersionFileVersionProvider(VersionProvider):
 
 
 class AWSVersioning:
-    def __init__(self, latest_version_strategy: VersionProvider = None):
-        self.latest_version_strategy = latest_version_strategy or GithubLatestVersionProvider
+    def __init__(self, latest_version_provider: VersionProvider = None):
+        self.latest_version_provider = latest_version_provider or GithubLatestVersionProvider
 
     def get_version_status(self) -> VersionStatus:
         aws_version = None
@@ -96,13 +96,13 @@ class AWSVersioning:
             pass
 
         return VersionStatus(
-            aws_version, self.latest_version_strategy.get_semantic_version("aws/aws-cli", True)
+            aws_version, self.latest_version_provider.get_semantic_version("aws/aws-cli", True)
         )
 
 
 class CopilotVersioning:
-    def __init__(self, latest_version_strategy: VersionProvider = None):
-        self.latest_version_strategy = latest_version_strategy or GithubLatestVersionProvider
+    def __init__(self, latest_version_provider: VersionProvider = None):
+        self.latest_version_provider = latest_version_provider or GithubLatestVersionProvider
 
     def get_version_status(self) -> VersionStatus:
         copilot_version = None
@@ -115,5 +115,5 @@ class CopilotVersioning:
 
         return VersionStatus(
             SemanticVersion.from_string(copilot_version),
-            self.latest_version_strategy.get_semantic_version("aws/copilot-cli"),
+            self.latest_version_provider.get_semantic_version("aws/copilot-cli"),
         )

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -96,7 +96,7 @@ class AWSVersioning(VersionProvider):
         return VersionStatus(aws_version, github_version.get_semantic_version("aws/aws-cli", True))
 
 
-class CopilotVersionProvider(VersionProvider):
+class CopilotVersioning(VersionProvider):
     @staticmethod
     def get_version_status(github_version=GithubLatestVersionProvider) -> VersionStatus:
         copilot_version = None

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -72,7 +72,7 @@ class DeprecatedVersionFileVersionProvider(VersionProvider):
     def __init__(self, file_provider: YamlFileProvider):
         self.file_provider = file_provider or YamlFileProvider
 
-    def get_required_version(self) -> SemanticVersion:
+    def get_semantic_version(self) -> SemanticVersion:
         deprecated_version_file = Path(PLATFORM_HELPER_VERSION_FILE)
         try:
             loaded_version = self.file_provider.load(deprecated_version_file)

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -101,8 +101,10 @@ class AWSVersioning:
 
 
 class CopilotVersioning:
-    @staticmethod
-    def get_version_status(github_version=GithubLatestVersionProvider) -> VersionStatus:
+    def __init__(self, latest_version_strategy: VersionProvider = None):
+        self.latest_version_strategy = latest_version_strategy or GithubLatestVersionProvider
+
+    def get_version_status(self) -> VersionStatus:
         copilot_version = None
 
         try:
@@ -113,5 +115,5 @@ class CopilotVersioning:
 
         return VersionStatus(
             SemanticVersion.from_string(copilot_version),
-            github_version.get_semantic_version("aws/copilot-cli"),
+            self.latest_version_strategy.get_semantic_version("aws/copilot-cli"),
         )

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -43,7 +43,7 @@ class InstalledVersionProvider:
 
 # TODO add timeouts and exception handling for requests
 # TODO Alternatively use the gitpython package?
-class GithubVersionProvider(VersionProvider):
+class GithubLatestVersionProvider(VersionProvider):
     @staticmethod
     def get_latest_version(repo_name: str, tags: bool = False) -> SemanticVersion:
         if tags:
@@ -84,7 +84,7 @@ class DeprecatedVersionFileVersionProvider(VersionProvider):
 
 class AWSVersionProvider(VersionProvider):
     @staticmethod
-    def get_version_status(github_version=GithubVersionProvider) -> VersionStatus:
+    def get_version_status(github_version=GithubLatestVersionProvider) -> VersionStatus:
         aws_version = None
         try:
             response = subprocess.run("aws --version", capture_output=True, shell=True)
@@ -98,7 +98,7 @@ class AWSVersionProvider(VersionProvider):
 
 class CopilotVersionProvider(VersionProvider):
     @staticmethod
-    def get_version_status(github_version=GithubVersionProvider) -> VersionStatus:
+    def get_version_status(github_version=GithubLatestVersionProvider) -> VersionStatus:
         copilot_version = None
 
         try:

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -82,9 +82,11 @@ class DeprecatedVersionFileVersionProvider(VersionProvider):
         return version_from_file
 
 
-class AWSVersioning(VersionProvider):
-    @staticmethod
-    def get_version_status(github_version=GithubLatestVersionProvider) -> VersionStatus:
+class AWSVersioning:
+    def __init__(self, latest_version_strategy: VersionProvider = None):
+        self.latest_version_strategy = latest_version_strategy or GithubLatestVersionProvider
+
+    def get_version_status(self) -> VersionStatus:
         aws_version = None
         try:
             response = subprocess.run("aws --version", capture_output=True, shell=True)
@@ -93,10 +95,12 @@ class AWSVersioning(VersionProvider):
         except ValueError:
             pass
 
-        return VersionStatus(aws_version, github_version.get_semantic_version("aws/aws-cli", True))
+        return VersionStatus(
+            aws_version, self.latest_version_strategy.get_semantic_version("aws/aws-cli", True)
+        )
 
 
-class CopilotVersioning(VersionProvider):
+class CopilotVersioning:
     @staticmethod
     def get_version_status(github_version=GithubLatestVersionProvider) -> VersionStatus:
         copilot_version = None

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -82,7 +82,7 @@ class DeprecatedVersionFileVersionProvider(VersionProvider):
         return version_from_file
 
 
-class AWSVersionProvider(VersionProvider):
+class AWSVersioning(VersionProvider):
     @staticmethod
     def get_version_status(github_version=GithubLatestVersionProvider) -> VersionStatus:
         aws_version = None

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -58,7 +58,7 @@ class GithubLatestVersionProvider(VersionProvider):
         return SemanticVersion.from_string(package_info["tag_name"])
 
 
-class PyPiVersionProvider(VersionProvider):
+class PyPiLatestVersionProvider(VersionProvider):
     @staticmethod
     def get_semantic_version(project_name: str) -> SemanticVersion:
         package_info = requests.get(f"https://pypi.org/pypi/{project_name}/json").json()

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -28,7 +28,7 @@ class InstalledToolNotFoundException(InstalledVersionProviderException):
 
 class VersionProvider(ABC):
     def get_semantic_version() -> SemanticVersion:
-        pass
+        raise NotImplementedError("Must be implemented in subclasses")
 
 
 class InstalledVersionProvider:

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -45,7 +45,7 @@ class InstalledVersionProvider:
 # TODO Alternatively use the gitpython package?
 class GithubLatestVersionProvider(VersionProvider):
     @staticmethod
-    def get_latest_version(repo_name: str, tags: bool = False) -> SemanticVersion:
+    def get_semantic_version(repo_name: str, tags: bool = False) -> SemanticVersion:
         if tags:
             tags_list = requests.get(f"https://api.github.com/repos/{repo_name}/tags").json()
             versions = [SemanticVersion.from_string(v["name"]) for v in tags_list]
@@ -60,7 +60,7 @@ class GithubLatestVersionProvider(VersionProvider):
 
 class PyPiVersionProvider(VersionProvider):
     @staticmethod
-    def get_latest_version(project_name: str) -> SemanticVersion:
+    def get_semantic_version(project_name: str) -> SemanticVersion:
         package_info = requests.get(f"https://pypi.org/pypi/{project_name}/json").json()
         released_versions = package_info["releases"].keys()
         parsed_released_versions = [SemanticVersion.from_string(v) for v in released_versions]
@@ -93,7 +93,7 @@ class AWSVersionProvider(VersionProvider):
         except ValueError:
             pass
 
-        return VersionStatus(aws_version, github_version.get_latest_version("aws/aws-cli", True))
+        return VersionStatus(aws_version, github_version.get_semantic_version("aws/aws-cli", True))
 
 
 class CopilotVersionProvider(VersionProvider):
@@ -109,5 +109,5 @@ class CopilotVersionProvider(VersionProvider):
 
         return VersionStatus(
             SemanticVersion.from_string(copilot_version),
-            github_version.get_latest_version("aws/copilot-cli"),
+            github_version.get_semantic_version("aws/copilot-cli"),
         )

--- a/dbt_platform_helper/providers/version_status.py
+++ b/dbt_platform_helper/providers/version_status.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Dict
+from typing import Optional
+
+from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
+from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_FILE
+from dbt_platform_helper.providers.semantic_version import SemanticVersion
+
+
+@dataclass
+class VersionStatus:
+    installed: SemanticVersion = None
+    latest: SemanticVersion = None
+
+    def __str__(self):
+        attrs = {
+            key: value for key, value in vars(self).items() if isinstance(value, SemanticVersion)
+        }
+        attrs_str = ", ".join(f"{key}: {value}" for key, value in attrs.items())
+        return f"{self.__class__.__name__}: {attrs_str}"
+
+    def is_outdated(self):
+        return self.installed != self.latest
+
+    def validate(self):
+        pass
+
+
+@dataclass
+class PlatformHelperVersionStatus(VersionStatus):
+    installed: Optional[SemanticVersion] = None
+    latest: Optional[SemanticVersion] = None
+    deprecated_version_file: Optional[SemanticVersion] = None
+    platform_config_default: Optional[SemanticVersion] = None
+    pipeline_overrides: Optional[Dict[str, str]] = field(default_factory=dict)
+
+    def __str__(self):
+        semantic_version_attrs = {
+            key: value for key, value in vars(self).items() if isinstance(value, SemanticVersion)
+        }
+
+        class_str = ", ".join(f"{key}: {value}" for key, value in semantic_version_attrs.items())
+
+        if self.pipeline_overrides.items():
+            pipeline_overrides_str = "pipeline_overrides: " + ", ".join(
+                f"{key}: {value}" for key, value in self.pipeline_overrides.items()
+            )
+            class_str = ", ".join([class_str, pipeline_overrides_str])
+
+        return f"{self.__class__.__name__}: {class_str}"
+
+    def validate(self) -> dict:
+        if self.platform_config_default and not self.deprecated_version_file:
+            return {}
+
+        warnings = []
+        errors = []
+
+        missing_default_version_message = f"Create a section in the root of '{PLATFORM_CONFIG_FILE}':\n\ndefault_versions:\n  platform-helper: "
+        deprecation_message = (
+            f"Please delete '{PLATFORM_HELPER_VERSION_FILE}' as it is now deprecated."
+        )
+
+        if self.platform_config_default and self.deprecated_version_file:
+            warnings.append(deprecation_message)
+
+        if not self.platform_config_default and self.deprecated_version_file:
+            warnings.append(deprecation_message)
+            warnings.append(f"{missing_default_version_message}{self.deprecated_version_file}\n")
+
+        if not self.platform_config_default and not self.deprecated_version_file:
+            message = f"Cannot get dbt-platform-helper version from '{PLATFORM_CONFIG_FILE}'.\n"
+            message += f"{missing_default_version_message}{self.installed}\n"
+            errors.append(message)
+
+        return {
+            "warnings": warnings,
+            "errors": errors,
+        }

--- a/tests/platform_helper/domain/test_config.py
+++ b/tests/platform_helper/domain/test_config.py
@@ -14,14 +14,14 @@ from prettytable import PrettyTable
 from dbt_platform_helper.domain.config import Config
 from dbt_platform_helper.domain.config import NoDeploymentRepoConfigException
 from dbt_platform_helper.domain.config import NoPlatformConfigException
+from dbt_platform_helper.domain.versioning import AWSVersioning
+from dbt_platform_helper.domain.versioning import CopilotVersioning
 from dbt_platform_helper.domain.versioning import PlatformHelperVersioning
 from dbt_platform_helper.providers.aws.sso_auth import SSOAuthProvider
 from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.semantic_version import PlatformHelperVersionStatus
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.semantic_version import VersionStatus
-from dbt_platform_helper.providers.version import AWSVersioning
-from dbt_platform_helper.providers.version import CopilotVersioning
 
 START_URL = "https://uktrade.awsapps.com/start"
 

--- a/tests/platform_helper/domain/test_config.py
+++ b/tests/platform_helper/domain/test_config.py
@@ -19,9 +19,9 @@ from dbt_platform_helper.domain.versioning import CopilotVersioning
 from dbt_platform_helper.domain.versioning import PlatformHelperVersioning
 from dbt_platform_helper.providers.aws.sso_auth import SSOAuthProvider
 from dbt_platform_helper.providers.io import ClickIOProvider
-from dbt_platform_helper.providers.semantic_version import PlatformHelperVersionStatus
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
-from dbt_platform_helper.providers.semantic_version import VersionStatus
+from dbt_platform_helper.providers.version_status import PlatformHelperVersionStatus
+from dbt_platform_helper.providers.version_status import VersionStatus
 
 START_URL = "https://uktrade.awsapps.com/start"
 

--- a/tests/platform_helper/domain/test_config.py
+++ b/tests/platform_helper/domain/test_config.py
@@ -20,7 +20,7 @@ from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.semantic_version import PlatformHelperVersionStatus
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.semantic_version import VersionStatus
-from dbt_platform_helper.providers.version import AWSVersionProvider
+from dbt_platform_helper.providers.version import AWSVersioning
 from dbt_platform_helper.providers.version import CopilotVersionProvider
 
 START_URL = "https://uktrade.awsapps.com/start"
@@ -58,7 +58,7 @@ class ConfigMocks:
         self.copilot_version = kwargs.get(
             "copilot_version", VersionStatus(SemanticVersion(1, 0, 0), SemanticVersion(1, 0, 0))
         )
-        self.aws_versions = kwargs.get("aws_versions", Mock(spec=AWSVersionProvider))
+        self.aws_versions = kwargs.get("aws_versions", Mock(spec=AWSVersioning))
         self.aws_versions.get_version_status.return_value = self.aws_version
 
         self.copilot_versions = kwargs.get("copilot_versions", Mock(spec=CopilotVersionProvider))

--- a/tests/platform_helper/domain/test_config.py
+++ b/tests/platform_helper/domain/test_config.py
@@ -21,7 +21,7 @@ from dbt_platform_helper.providers.semantic_version import PlatformHelperVersion
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.semantic_version import VersionStatus
 from dbt_platform_helper.providers.version import AWSVersioning
-from dbt_platform_helper.providers.version import CopilotVersionProvider
+from dbt_platform_helper.providers.version import CopilotVersioning
 
 START_URL = "https://uktrade.awsapps.com/start"
 
@@ -61,7 +61,7 @@ class ConfigMocks:
         self.aws_versions = kwargs.get("aws_versions", Mock(spec=AWSVersioning))
         self.aws_versions.get_version_status.return_value = self.aws_version
 
-        self.copilot_versions = kwargs.get("copilot_versions", Mock(spec=CopilotVersionProvider))
+        self.copilot_versions = kwargs.get("copilot_versions", Mock(spec=CopilotVersioning))
         self.copilot_versions.get_version_status.return_value = self.copilot_version
 
     def params(self):

--- a/tests/platform_helper/domain/test_config.py
+++ b/tests/platform_helper/domain/test_config.py
@@ -72,8 +72,6 @@ class ConfigMocks:
             "platform_helper_versioning": self.platform_helper_versioning,
             "aws_versioning": self.aws_versioning,
             "copilot_versioning": self.copilot_versioning,
-            # "get_template_generated_with_version": self.get_template_generated_with_version,
-            # "validate_template_version": self.validate_template_version,
         }
 
 

--- a/tests/platform_helper/domain/test_config.py
+++ b/tests/platform_helper/domain/test_config.py
@@ -39,38 +39,39 @@ maybe = "\033[93m?\033[0m"
 class ConfigMocks:
     def __init__(self, *args, **kwargs):
         self.io = kwargs.get("io", Mock(spec=ClickIOProvider))
-        self.platform_helper_versioning_domain = kwargs.get(
-            "platform_helper_versioning_domain", MagicMock(spec=PlatformHelperVersioning)
+        self.platform_helper_versioning = kwargs.get(
+            "platform_helper_versioning", MagicMock(spec=PlatformHelperVersioning)
         )
         self.platform_helper_version_status = kwargs.get(
             "platform_helper_version_status",
             (PlatformHelperVersionStatus(SemanticVersion(1, 0, 0), SemanticVersion(1, 0, 0))),
         )
-        self.platform_helper_versioning_domain._get_version_status.return_value = (
+        self.platform_helper_versioning._get_version_status.return_value = (
             self.platform_helper_version_status
         )
 
         self.sso = kwargs.get("sso", Mock(spec=SSOAuthProvider))
 
-        self.aws_version = kwargs.get(
-            "aws_version", VersionStatus(SemanticVersion(1, 0, 0), SemanticVersion(1, 0, 0))
+        self.aws_version_status = kwargs.get(
+            "aws_version_status", VersionStatus(SemanticVersion(1, 0, 0), SemanticVersion(1, 0, 0))
         )
-        self.copilot_version = kwargs.get(
-            "copilot_version", VersionStatus(SemanticVersion(1, 0, 0), SemanticVersion(1, 0, 0))
+        self.copilot_version_status = kwargs.get(
+            "copilot_version_status",
+            VersionStatus(SemanticVersion(1, 0, 0), SemanticVersion(1, 0, 0)),
         )
-        self.aws_versions = kwargs.get("aws_versions", Mock(spec=AWSVersioning))
-        self.aws_versions.get_version_status.return_value = self.aws_version
+        self.aws_versioning = kwargs.get("aws_versioning", Mock(spec=AWSVersioning))
+        self.aws_versioning.get_version_status.return_value = self.aws_version_status
 
-        self.copilot_versions = kwargs.get("copilot_versions", Mock(spec=CopilotVersioning))
-        self.copilot_versions.get_version_status.return_value = self.copilot_version
+        self.copilot_versioning = kwargs.get("copilot_versioning", Mock(spec=CopilotVersioning))
+        self.copilot_versioning.get_version_status.return_value = self.copilot_version_status
 
     def params(self):
         return {
             "io": self.io,
             "sso": self.sso,
-            "platform_helper_versioning_domain": self.platform_helper_versioning_domain,
-            "aws_versions": self.aws_versions,
-            "copilot_versions": self.copilot_versions,
+            "platform_helper_versioning": self.platform_helper_versioning,
+            "aws_versioning": self.aws_versioning,
+            "copilot_versioning": self.copilot_versioning,
             # "get_template_generated_with_version": self.get_template_generated_with_version,
             # "validate_template_version": self.validate_template_version,
         }
@@ -176,13 +177,13 @@ class TestConfigValidate:
             ],
         )
 
-        config_mocks.platform_helper_versioning_domain._get_version_status.assert_called_with(
+        config_mocks.platform_helper_versioning._get_version_status.assert_called_with(
             include_project_versions=True
         )
 
         config_mocks.io.process_messages.assert_called_with({})
-        config_mocks.aws_versions.get_version_status.assert_called()
-        config_mocks.copilot_versions.get_version_status.assert_called()
+        config_mocks.aws_versioning.get_version_status.assert_called()
+        config_mocks.copilot_versioning.get_version_status.assert_called()
 
     def test_validate_not_installed(self, fakefs):
         fakefs.create_file("platform-config.yml")
@@ -192,8 +193,8 @@ class TestConfigValidate:
         )
 
         config_mocks = ConfigMocks(
-            aws_version=VersionStatus(None, SemanticVersion(2, 0, 0)),
-            copilot_version=VersionStatus(None, SemanticVersion(3, 0, 0)),
+            aws_version_status=VersionStatus(None, SemanticVersion(2, 0, 0)),
+            copilot_version_status=VersionStatus(None, SemanticVersion(3, 0, 0)),
         )
 
         config_domain = Config(**config_mocks.params())
@@ -292,7 +293,7 @@ class TestConfigValidate:
             ],
         )
 
-        config_mocks.platform_helper_versioning_domain._get_version_status.assert_called_with(
+        config_mocks.platform_helper_versioning._get_version_status.assert_called_with(
             include_project_versions=True
         )
 
@@ -304,8 +305,8 @@ class TestConfigValidate:
                 ],
             }
         )
-        config_mocks.aws_versions.get_version_status.assert_called()
-        config_mocks.copilot_versions.get_version_status.assert_called()
+        config_mocks.aws_versioning.get_version_status.assert_called()
+        config_mocks.copilot_versioning.get_version_status.assert_called()
 
     def test_validate_outdated(self, fakefs):
         fakefs.create_file("platform-config.yml")
@@ -318,8 +319,10 @@ class TestConfigValidate:
             platform_helper_version_status=PlatformHelperVersionStatus(
                 SemanticVersion(1, 0, 0), SemanticVersion(2, 0, 0)
             ),
-            aws_version=VersionStatus(SemanticVersion(0, 2, 0), SemanticVersion(2, 0, 0)),
-            copilot_version=VersionStatus(SemanticVersion(0, 3, 0), SemanticVersion(3, 0, 0)),
+            aws_version_status=VersionStatus(SemanticVersion(0, 2, 0), SemanticVersion(2, 0, 0)),
+            copilot_version_status=VersionStatus(
+                SemanticVersion(0, 3, 0), SemanticVersion(3, 0, 0)
+            ),
         )
         config_domain = Config(**config_mocks.params())
 
@@ -424,7 +427,7 @@ class TestConfigValidate:
             ],
         )
 
-        config_mocks.platform_helper_versioning_domain._get_version_status.assert_called_with(
+        config_mocks.platform_helper_versioning._get_version_status.assert_called_with(
             include_project_versions=True
         )
 
@@ -436,8 +439,8 @@ class TestConfigValidate:
                 ],
             }
         )
-        config_mocks.aws_versions.get_version_status.assert_called()
-        config_mocks.copilot_versions.get_version_status.assert_called()
+        config_mocks.aws_versioning.get_version_status.assert_called()
+        config_mocks.copilot_versioning.get_version_status.assert_called()
 
     def test_no_platform_config(self, fakefs):
         fakefs.create_file(

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -14,7 +14,7 @@ from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.version import DeprecatedVersionFileVersionProvider
 from dbt_platform_helper.providers.version import InstalledVersionProvider
-from dbt_platform_helper.providers.version import PyPiVersionProvider
+from dbt_platform_helper.providers.version import PyPiLatestVersionProvider
 
 
 class PlatformHelperVersioningMocks:
@@ -25,7 +25,7 @@ class PlatformHelperVersioningMocks:
         self.version_file_version_provider = kwargs.get(
             "version_file_version_provider", Mock(spec=DeprecatedVersionFileVersionProvider)
         )
-        self.pypi_provider = kwargs.get("pypi_provider", Mock(spec=PyPiVersionProvider))
+        self.pypi_provider = kwargs.get("pypi_provider", Mock(spec=PyPiLatestVersionProvider))
         self.installed_version_provider = kwargs.get(
             "installed_version_provider", Mock(spec=InstalledVersionProvider)
         )

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -357,24 +357,24 @@ class TestPlatformHelperVersioningCheckIfNeedsUpdate:
 
 class TestAWSVersioning:
     @patch("subprocess.run")
-    def test_get_aws_versions(self, mock_run):
+    def test_get_aws_versioning(self, mock_run):
         mock_run.return_value.stdout = b"aws-cli/1.0.0"
         github_version_provider = Mock()
         github_version_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
-        versions = AWSVersioning(github_version_provider).get_version_status()
+        version_status = AWSVersioning(github_version_provider).get_version_status()
 
-        assert versions.installed == SemanticVersion(1, 0, 0)
-        assert versions.latest == SemanticVersion(2, 0, 0)
+        assert version_status.installed == SemanticVersion(1, 0, 0)
+        assert version_status.latest == SemanticVersion(2, 0, 0)
 
 
 class TestCopilotVersioning:
     @patch("subprocess.run")
-    def test_copilot_versions(self, mock_run):
+    def test_copilot_versioning(self, mock_run):
         mock_run.return_value.stdout = b"1.0.0"
 
         github_version_provider = Mock()
         github_version_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
-        versions = CopilotVersioning(github_version_provider).get_version_status()
+        version_status = CopilotVersioning(github_version_provider).get_version_status()
 
-        assert versions.installed == SemanticVersion(1, 0, 0)
-        assert versions.latest == SemanticVersion(2, 0, 0)
+        assert version_status.installed == SemanticVersion(1, 0, 0)
+        assert version_status.latest == SemanticVersion(2, 0, 0)

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -356,25 +356,32 @@ class TestPlatformHelperVersioningCheckIfNeedsUpdate:
 
 
 class TestAWSVersioning:
-    @patch("subprocess.run")
-    def test_get_aws_versioning(self, mock_run):
-        mock_run.return_value.stdout = b"aws-cli/1.0.0"
+    def test_get_aws_versioning(self):
+        installed_version_provider = Mock()
+        installed_version_provider.get_semantic_version.return_value = SemanticVersion(1, 0, 0)
+
         github_version_provider = Mock()
         github_version_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
-        version_status = AWSVersioning(github_version_provider).get_version_status()
 
-        assert version_status.installed == SemanticVersion(1, 0, 0)
-        assert version_status.latest == SemanticVersion(2, 0, 0)
+        result = AWSVersioning(
+            github_version_provider, installed_version_provider
+        ).get_version_status()
+
+        assert result.installed == SemanticVersion(1, 0, 0)
+        assert result.latest == SemanticVersion(2, 0, 0)
 
 
 class TestCopilotVersioning:
-    @patch("subprocess.run")
-    def test_copilot_versioning(self, mock_run):
-        mock_run.return_value.stdout = b"1.0.0"
+    def test_copilot_versioning(self):
+        installed_version_provider = Mock()
+        installed_version_provider.get_semantic_version.return_value = SemanticVersion(1, 0, 0)
 
         github_version_provider = Mock()
         github_version_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
-        version_status = CopilotVersioning(github_version_provider).get_version_status()
 
-        assert version_status.installed == SemanticVersion(1, 0, 0)
-        assert version_status.latest == SemanticVersion(2, 0, 0)
+        result = CopilotVersioning(
+            github_version_provider, installed_version_provider
+        ).get_version_status()
+
+        assert result.installed == SemanticVersion(1, 0, 0)
+        assert result.latest == SemanticVersion(2, 0, 0)

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -6,6 +6,8 @@ import pytest
 
 from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_FILE
+from dbt_platform_helper.domain.versioning import AWSVersioning
+from dbt_platform_helper.domain.versioning import CopilotVersioning
 from dbt_platform_helper.domain.versioning import PlatformHelperVersioning
 from dbt_platform_helper.domain.versioning import PlatformHelperVersionNotFoundException
 from dbt_platform_helper.domain.versioning import skip_version_checks
@@ -351,3 +353,28 @@ class TestPlatformHelperVersioningCheckIfNeedsUpdate:
         mocks.installed_version_provider.get_semantic_version.assert_not_called()
         mocks.io.warn.assert_not_called()
         mocks.io.error.assert_not_called()
+
+
+class TestAWSVersioning:
+    @patch("subprocess.run")
+    def test_get_aws_versions(self, mock_run):
+        mock_run.return_value.stdout = b"aws-cli/1.0.0"
+        github_version_provider = Mock()
+        github_version_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
+        versions = AWSVersioning(github_version_provider).get_version_status()
+
+        assert versions.installed == SemanticVersion(1, 0, 0)
+        assert versions.latest == SemanticVersion(2, 0, 0)
+
+
+class TestCopilotVersioning:
+    @patch("subprocess.run")
+    def test_copilot_versions(self, mock_run):
+        mock_run.return_value.stdout = b"1.0.0"
+
+        github_version_provider = Mock()
+        github_version_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
+        versions = CopilotVersioning(github_version_provider).get_version_status()
+
+        assert versions.installed == SemanticVersion(1, 0, 0)
+        assert versions.latest == SemanticVersion(2, 0, 0)

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -107,7 +107,7 @@ class TestPlatformHelperVersioningGetRequiredVersionWithInvalidConfig:
             self.INVALID_CONFIG_WITH_DEFAULT_VERSION
         )
 
-        mocks.pypi_provider.get_latest_version.return_value = SemanticVersion(2, 0, 0)
+        mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
 
         result = PlatformHelperVersioning(**mocks.params()).get_required_version()
 
@@ -122,7 +122,7 @@ class TestPlatformHelperVersioningGetRequiredVersionWithInvalidConfig:
             }
         }
         mocks.config_provider.load_unvalidated_config_file.return_value = platform_config
-        mocks.pypi_provider.get_latest_version.return_value = SemanticVersion(2, 0, 0)
+        mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
 
         result = PlatformHelperVersioning(**mocks.params()).get_required_version("main")
 
@@ -133,7 +133,7 @@ class TestPlatformHelperVersioningGetRequiredVersionWithInvalidConfig:
             1, 0, 1
         )
         mocks.version_file_version_provider.get_required_version.return_value = None
-        mocks.pypi_provider.get_latest_version.return_value = SemanticVersion(2, 0, 0)
+        mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
         mocks.config_provider.load_unvalidated_config_file.return_value = {"application": "my-app"}
 
         expected_message = f"""Cannot get dbt-platform-helper version from '{PLATFORM_CONFIG_FILE}'.
@@ -249,7 +249,7 @@ def test_platform_helper_version_deprecation_warnings(
     version_in_platform_config,
     expected_warnings,
 ):
-    mocks.pypi_provider.get_latest_version.return_value = SemanticVersion(2, 3, 4)
+    mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(2, 3, 4)
     platform_config = {"application": "my-app"}
     if version_in_platform_config:
         platform_config["default_versions"] = {"platform-helper": "2.2.2"}
@@ -316,7 +316,7 @@ class TestPlatformHelperVersioningCheckIfNeedsUpdate:
         mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 0
         )
-        mocks.pypi_provider.get_latest_version.return_value = SemanticVersion(2, 0, 0)
+        mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
 
         PlatformHelperVersioning(**mocks.params()).check_if_needs_update()
 
@@ -332,7 +332,7 @@ class TestPlatformHelperVersioningCheckIfNeedsUpdate:
         mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 0
         )
-        mocks.pypi_provider.get_latest_version.return_value = SemanticVersion(1, 1, 0)
+        mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(1, 1, 0)
 
         PlatformHelperVersioning(**mocks.params()).check_if_needs_update()
 

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -25,7 +25,9 @@ class PlatformHelperVersioningMocks:
         self.version_file_version_provider = kwargs.get(
             "version_file_version_provider", Mock(spec=DeprecatedVersionFileVersionProvider)
         )
-        self.pypi_provider = kwargs.get("pypi_provider", Mock(spec=PyPiLatestVersionProvider))
+        self.latest_version_provider = kwargs.get(
+            "latest_version_provider", Mock(spec=PyPiLatestVersionProvider)
+        )
         self.installed_version_provider = kwargs.get(
             "installed_version_provider", Mock(spec=InstalledVersionProvider)
         )
@@ -36,7 +38,7 @@ class PlatformHelperVersioningMocks:
             "io": self.io,
             "version_file_version_provider": self.version_file_version_provider,
             "config_provider": self.config_provider,
-            "pypi_provider": self.pypi_provider,
+            "latest_version_provider": self.latest_version_provider,
             "installed_version_provider": self.installed_version_provider,
             "skip_versioning_checks": self.skip_versioning_checks,
         }
@@ -107,7 +109,7 @@ class TestPlatformHelperVersioningGetRequiredVersionWithInvalidConfig:
             self.INVALID_CONFIG_WITH_DEFAULT_VERSION
         )
 
-        mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
+        mocks.latest_version_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
 
         result = PlatformHelperVersioning(**mocks.params()).get_required_version()
 
@@ -122,7 +124,7 @@ class TestPlatformHelperVersioningGetRequiredVersionWithInvalidConfig:
             }
         }
         mocks.config_provider.load_unvalidated_config_file.return_value = platform_config
-        mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
+        mocks.latest_version_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
 
         result = PlatformHelperVersioning(**mocks.params()).get_required_version("main")
 
@@ -133,7 +135,7 @@ class TestPlatformHelperVersioningGetRequiredVersionWithInvalidConfig:
             1, 0, 1
         )
         mocks.version_file_version_provider.get_semantic_version.return_value = None
-        mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
+        mocks.latest_version_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
         mocks.config_provider.load_unvalidated_config_file.return_value = {"application": "my-app"}
 
         expected_message = f"""Cannot get dbt-platform-helper version from '{PLATFORM_CONFIG_FILE}'.
@@ -249,7 +251,7 @@ def test_platform_helper_version_deprecation_warnings(
     version_in_platform_config,
     expected_warnings,
 ):
-    mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(2, 3, 4)
+    mocks.latest_version_provider.get_semantic_version.return_value = SemanticVersion(2, 3, 4)
     platform_config = {"application": "my-app"}
     if version_in_platform_config:
         platform_config["default_versions"] = {"platform-helper": "2.2.2"}
@@ -316,7 +318,7 @@ class TestPlatformHelperVersioningCheckIfNeedsUpdate:
         mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 0
         )
-        mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
+        mocks.latest_version_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
 
         PlatformHelperVersioning(**mocks.params()).check_if_needs_update()
 
@@ -332,7 +334,7 @@ class TestPlatformHelperVersioningCheckIfNeedsUpdate:
         mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 0
         )
-        mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(1, 1, 0)
+        mocks.latest_version_provider.get_semantic_version.return_value = SemanticVersion(1, 1, 0)
 
         PlatformHelperVersioning(**mocks.params()).check_if_needs_update()
 

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -49,7 +49,7 @@ def mocks():
 
 class TestPlatformHelperVersioningCheckPlatformHelperMismatch:
     def test_shows_warning_when_different_than_file_spec(self, mocks):
-        mocks.installed_version_provider.get_installed_tool_version.return_value = SemanticVersion(
+        mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 1
         )
         mocks.version_file_version_provider.get_required_version.return_value = SemanticVersion(
@@ -63,7 +63,7 @@ class TestPlatformHelperVersioningCheckPlatformHelperMismatch:
         )
 
     def test_shows_no_warning_when_same_as_file_spec(self, mocks):
-        mocks.installed_version_provider.get_installed_tool_version.return_value = SemanticVersion(
+        mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 0
         )
         mocks.version_file_version_provider.get_required_version.return_value = SemanticVersion(
@@ -80,7 +80,7 @@ class TestPlatformHelperVersioningCheckPlatformHelperMismatch:
         valid_platform_config,
         mocks,
     ):
-        mocks.installed_version_provider.get_installed_tool_version.return_value = SemanticVersion(
+        mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 1
         )
         mocks.version_file_version_provider.get_required_version.return_value = None
@@ -129,7 +129,7 @@ class TestPlatformHelperVersioningGetRequiredVersionWithInvalidConfig:
         assert result == pipeline_override_version
 
     def test_errors_if_version_is_not_specified_in_config_or_default_file(self, mocks):
-        mocks.installed_version_provider.get_installed_tool_version.return_value = SemanticVersion(
+        mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 1
         )
         mocks.version_file_version_provider.get_required_version.return_value = None
@@ -313,7 +313,7 @@ class TestPlatformHelperVersioningCheckIfNeedsUpdate:
         self,
         mocks,
     ):
-        mocks.installed_version_provider.get_installed_tool_version.return_value = SemanticVersion(
+        mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 0
         )
         mocks.pypi_provider.get_latest_version.return_value = SemanticVersion(2, 0, 0)
@@ -329,7 +329,7 @@ class TestPlatformHelperVersioningCheckIfNeedsUpdate:
         self,
         mocks,
     ):
-        mocks.installed_version_provider.get_installed_tool_version.return_value = SemanticVersion(
+        mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 0
         )
         mocks.pypi_provider.get_latest_version.return_value = SemanticVersion(1, 1, 0)
@@ -346,6 +346,6 @@ class TestPlatformHelperVersioningCheckIfNeedsUpdate:
 
         PlatformHelperVersioning(**mocks.params()).check_if_needs_update()
 
-        mocks.installed_version_provider.get_installed_tool_version.assert_not_called()
+        mocks.installed_version_provider.get_semantic_version.assert_not_called()
         mocks.io.warn.assert_not_called()
         mocks.io.error.assert_not_called()

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -52,7 +52,7 @@ class TestPlatformHelperVersioningCheckPlatformHelperMismatch:
         mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 1
         )
-        mocks.version_file_version_provider.get_required_version.return_value = SemanticVersion(
+        mocks.version_file_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 0
         )
 
@@ -66,7 +66,7 @@ class TestPlatformHelperVersioningCheckPlatformHelperMismatch:
         mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 0
         )
-        mocks.version_file_version_provider.get_required_version.return_value = SemanticVersion(
+        mocks.version_file_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 0
         )
 
@@ -83,7 +83,7 @@ class TestPlatformHelperVersioningCheckPlatformHelperMismatch:
         mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 1
         )
-        mocks.version_file_version_provider.get_required_version.return_value = None
+        mocks.version_file_version_provider.get_semantic_version.return_value = None
         mocks.config_provider.load_unvalidated_config_file.return_value = valid_platform_config
 
         PlatformHelperVersioning(**mocks.params()).check_platform_helper_version_mismatch()
@@ -132,7 +132,7 @@ class TestPlatformHelperVersioningGetRequiredVersionWithInvalidConfig:
         mocks.installed_version_provider.get_semantic_version.return_value = SemanticVersion(
             1, 0, 1
         )
-        mocks.version_file_version_provider.get_required_version.return_value = None
+        mocks.version_file_version_provider.get_semantic_version.return_value = None
         mocks.pypi_provider.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
         mocks.config_provider.load_unvalidated_config_file.return_value = {"application": "my-app"}
 
@@ -163,7 +163,7 @@ class TestPlatformHelperVersioningGetRequiredVersion:
         pipeline_override,
         expected_version,
     ):
-        mocks.version_file_version_provider.get_required_version.return_value = (
+        mocks.version_file_version_provider.get_semantic_version.return_value = (
             platform_helper_version_file_version
         )
         platform_config = {
@@ -257,11 +257,11 @@ def test_platform_helper_version_deprecation_warnings(
     mocks.config_provider.load_unvalidated_config_file.return_value = platform_config
 
     if version_in_phv_file:
-        mocks.version_file_version_provider.get_required_version.return_value = SemanticVersion(
+        mocks.version_file_version_provider.get_semantic_version.return_value = SemanticVersion(
             3, 3, 3
         )
     else:
-        mocks.version_file_version_provider.get_required_version.return_value = None
+        mocks.version_file_version_provider.get_semantic_version.return_value = None
 
     PlatformHelperVersioning(**mocks.params()).get_required_version()
 

--- a/tests/platform_helper/providers/test_semantic_version.py
+++ b/tests/platform_helper/providers/test_semantic_version.py
@@ -6,9 +6,9 @@ from dbt_platform_helper.providers.semantic_version import (
 from dbt_platform_helper.providers.semantic_version import (
     IncompatibleMinorVersionException,
 )
-from dbt_platform_helper.providers.semantic_version import PlatformHelperVersionStatus
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
-from dbt_platform_helper.providers.semantic_version import VersionStatus
+from dbt_platform_helper.providers.version_status import PlatformHelperVersionStatus
+from dbt_platform_helper.providers.version_status import VersionStatus
 
 
 class TestSemanticVersion:

--- a/tests/platform_helper/providers/test_semantic_version.py
+++ b/tests/platform_helper/providers/test_semantic_version.py
@@ -7,8 +7,6 @@ from dbt_platform_helper.providers.semantic_version import (
     IncompatibleMinorVersionException,
 )
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
-from dbt_platform_helper.providers.version_status import PlatformHelperVersionStatus
-from dbt_platform_helper.providers.version_status import VersionStatus
 
 
 class TestSemanticVersion:
@@ -77,54 +75,3 @@ class TestSemanticVersion:
         input_version, expected_version = suite
         result = SemanticVersion.from_string(input_version)
         assert result == expected_version
-
-
-class TestVersionStatus:
-    @pytest.mark.parametrize(
-        "suite",
-        [
-            (SemanticVersion(1, 2, 3), SemanticVersion(1, 2, 3), False),
-            (SemanticVersion(1, 2, 0), SemanticVersion(1, 2, 3), True),
-        ],
-    )
-    def test_is_outdated(self, suite):
-        local_version, latest_release, expected = suite
-        assert (
-            VersionStatus(installed=local_version, latest=latest_release).is_outdated() == expected
-        )
-
-    def test_to_string(self):
-        result = f"{VersionStatus(SemanticVersion(1, 2, 0), SemanticVersion(1, 2, 3))}"
-        assert result == "VersionStatus: installed: 1.2.0, latest: 1.2.3"
-
-
-class TestPlatformHelperVersionStatus:
-    def test_to_string_with_populated_attributes(self):
-        platform_helper_version_status = PlatformHelperVersionStatus(
-            SemanticVersion(1, 2, 0),
-            SemanticVersion(1, 2, 3),
-            SemanticVersion(1, 1, 1),
-            SemanticVersion(1, 0, 0),
-            {
-                "main": SemanticVersion(2, 0, 0),
-                "dev": SemanticVersion(2, 1, 1),
-            },
-        )
-        result = f"{platform_helper_version_status}"
-        assert (
-            result
-            == "PlatformHelperVersionStatus: installed: 1.2.0, latest: 1.2.3, deprecated_version_file: 1.1.1, platform_config_default: 1.0.0, pipeline_overrides: main: 2.0.0, dev: 2.1.1"
-        )
-
-    def test_to_string_with_no_pipeline_overrides(self):
-        platform_helper_version_status = PlatformHelperVersionStatus(
-            SemanticVersion(1, 2, 0),
-            SemanticVersion(1, 2, 3),
-            SemanticVersion(1, 1, 1),
-            SemanticVersion(1, 0, 0),
-        )
-        result = f"{platform_helper_version_status}"
-        assert (
-            result
-            == "PlatformHelperVersionStatus: installed: 1.2.0, latest: 1.2.3, deprecated_version_file: 1.1.1, platform_config_default: 1.0.0"
-        )

--- a/tests/platform_helper/providers/test_version.py
+++ b/tests/platform_helper/providers/test_version.py
@@ -51,7 +51,7 @@ class TestInstalledVersionProvider:
 class TestGithubVersionProvider:
     @patch("requests.get", return_value=MockGithubReleaseResponse())
     def test_get_github_version_from_releases(self, request_get):
-        assert GithubLatestVersionProvider.get_latest_version("test/repo") == SemanticVersion(
+        assert GithubLatestVersionProvider.get_semantic_version("test/repo") == SemanticVersion(
             1, 1, 1
         )
         request_get.assert_called_once_with(
@@ -60,16 +60,16 @@ class TestGithubVersionProvider:
 
     @patch("requests.get", return_value=MockGithubTagResponse())
     def test_get_github_version_from_tags(self, request_get):
-        assert GithubLatestVersionProvider.get_latest_version("test/repo", True) == SemanticVersion(
-            1, 2, 3
-        )
+        assert GithubLatestVersionProvider.get_semantic_version(
+            "test/repo", True
+        ) == SemanticVersion(1, 2, 3)
         request_get.assert_called_once_with("https://api.github.com/repos/test/repo/tags")
 
 
 class TestPyPiVersionProvider:
     @patch("requests.get", return_value=MockPyPiResponse())
-    def test_get_latest_version(self, request_get):
-        result = PyPiVersionProvider.get_latest_version("foo")
+    def test_get_semantic_version(self, request_get):
+        result = PyPiVersionProvider.get_semantic_version("foo")
         assert result == SemanticVersion(1, 2, 3)
         request_get.assert_called_once_with(f"https://pypi.org/pypi/foo/json")
 
@@ -79,7 +79,7 @@ class TestAWSVersionProvider:
     def test_get_aws_versions(self, mock_run):
         mock_run.return_value.stdout = b"aws-cli/1.0.0"
         github_response = Mock()
-        github_response.get_latest_version.return_value = SemanticVersion(2, 0, 0)
+        github_response.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
         versions = AWSVersionProvider.get_version_status(github_response)
 
         assert versions.installed == SemanticVersion(1, 0, 0)
@@ -92,7 +92,7 @@ class TestCopilotVersionProvider:
         mock_run.return_value.stdout = b"1.0.0"
 
         github_response = Mock()
-        github_response.get_latest_version.return_value = SemanticVersion(2, 0, 0)
+        github_response.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
         versions = CopilotVersionProvider.get_version_status(github_response)
 
         assert versions.installed == SemanticVersion(1, 0, 0)

--- a/tests/platform_helper/providers/test_version.py
+++ b/tests/platform_helper/providers/test_version.py
@@ -7,7 +7,7 @@ import pytest
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.version import AWSVersionProvider
 from dbt_platform_helper.providers.version import CopilotVersionProvider
-from dbt_platform_helper.providers.version import GithubVersionProvider
+from dbt_platform_helper.providers.version import GithubLatestVersionProvider
 from dbt_platform_helper.providers.version import InstalledVersionProvider
 from dbt_platform_helper.providers.version import InstalledVersionProviderException
 from dbt_platform_helper.providers.version import PyPiVersionProvider
@@ -51,14 +51,16 @@ class TestInstalledVersionProvider:
 class TestGithubVersionProvider:
     @patch("requests.get", return_value=MockGithubReleaseResponse())
     def test_get_github_version_from_releases(self, request_get):
-        assert GithubVersionProvider.get_latest_version("test/repo") == SemanticVersion(1, 1, 1)
+        assert GithubLatestVersionProvider.get_latest_version("test/repo") == SemanticVersion(
+            1, 1, 1
+        )
         request_get.assert_called_once_with(
             "https://api.github.com/repos/test/repo/releases/latest"
         )
 
     @patch("requests.get", return_value=MockGithubTagResponse())
     def test_get_github_version_from_tags(self, request_get):
-        assert GithubVersionProvider.get_latest_version("test/repo", True) == SemanticVersion(
+        assert GithubLatestVersionProvider.get_latest_version("test/repo", True) == SemanticVersion(
             1, 2, 3
         )
         request_get.assert_called_once_with("https://api.github.com/repos/test/repo/tags")

--- a/tests/platform_helper/providers/test_version.py
+++ b/tests/platform_helper/providers/test_version.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 import pytest
 
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
+from dbt_platform_helper.providers.version import AWSCLIInstalledVersionProvider
+from dbt_platform_helper.providers.version import CopilotInstalledVersionProvider
 from dbt_platform_helper.providers.version import GithubLatestVersionProvider
 from dbt_platform_helper.providers.version import InstalledVersionProvider
 from dbt_platform_helper.providers.version import InstalledVersionProviderException
@@ -30,14 +32,12 @@ class MockPyPiResponse:
 
 class TestInstalledVersionProvider:
     @patch("dbt_platform_helper.providers.version.version", return_value="1.1.1")
-    def test_get_locally_installed_tool_version(self, mock_version):
+    def test_get_semantic_version(self, mock_version):
         assert InstalledVersionProvider.get_semantic_version("test") == SemanticVersion(1, 1, 1)
         mock_version.assert_called_once_with("test")
 
     @patch("dbt_platform_helper.providers.version.version", return_value="")
-    def test_get_locally_installed_tool_version_given_package_not_found_exception(
-        self, mock_version
-    ):
+    def test_get_semantic_version_given_package_not_found_exception(self, mock_version):
         mock_version.side_effect = PackageNotFoundError
         with pytest.raises(InstalledVersionProviderException) as exc:
             InstalledVersionProvider.get_semantic_version("test")
@@ -47,7 +47,7 @@ class TestInstalledVersionProvider:
 
 class TestGithubLatestVersionProvider:
     @patch("requests.get", return_value=MockGithubReleaseResponse())
-    def test_get_github_version_from_releases(self, request_get):
+    def test_get_semantic_version_from_releases(self, request_get):
         assert GithubLatestVersionProvider.get_semantic_version("test/repo") == SemanticVersion(
             1, 1, 1
         )
@@ -56,7 +56,7 @@ class TestGithubLatestVersionProvider:
         )
 
     @patch("requests.get", return_value=MockGithubTagResponse())
-    def test_get_github_version_from_tags(self, request_get):
+    def test_get_semantic_version_from_tags(self, request_get):
         assert GithubLatestVersionProvider.get_semantic_version(
             "test/repo", True
         ) == SemanticVersion(1, 2, 3)
@@ -69,3 +69,43 @@ class TestPyPiLatestVersionProvider:
         result = PyPiLatestVersionProvider.get_semantic_version("foo")
         assert result == SemanticVersion(1, 2, 3)
         request_get.assert_called_once_with(f"https://pypi.org/pypi/foo/json")
+
+
+@pytest.mark.parametrize(
+    "mock_run_stdout, expected",
+    (
+        (b"aws-cli/1.0.0", SemanticVersion(1, 0, 0)),
+        (b"aws-cli/1.0.1", SemanticVersion(1, 0, 1)),
+        (b"aws-cli/1.1.1", SemanticVersion(1, 1, 1)),
+        (b"aws-cli/2.0.0", SemanticVersion(2, 0, 0)),
+        (b"command not found: copilot", None),
+    ),
+)
+class TestAWSCLIInstalledVersionProvider:
+    @patch("subprocess.run")
+    def test_get_semantic_version(self, mock_run, mock_run_stdout, expected):
+        mock_run.return_value.stdout = mock_run_stdout
+
+        result = AWSCLIInstalledVersionProvider.get_semantic_version()
+
+        assert result == expected
+
+
+class TestCopilotVersioning:
+    @pytest.mark.parametrize(
+        "mock_run_stdout, expected",
+        (
+            (b"1.0.0", SemanticVersion(1, 0, 0)),
+            (b"1.0.1", SemanticVersion(1, 0, 1)),
+            (b"1.1.1", SemanticVersion(1, 1, 1)),
+            (b"2.0.0", SemanticVersion(2, 0, 0)),
+            (b"command not found: copilot", None),
+        ),
+    )
+    @patch("subprocess.run")
+    def test_get_semantic_version(self, mock_run, mock_run_stdout, expected):
+        mock_run.return_value.stdout = mock_run_stdout
+
+        result = CopilotInstalledVersionProvider().get_semantic_version()
+
+        assert result == expected

--- a/tests/platform_helper/providers/test_version.py
+++ b/tests/platform_helper/providers/test_version.py
@@ -10,7 +10,7 @@ from dbt_platform_helper.providers.version import CopilotVersionProvider
 from dbt_platform_helper.providers.version import GithubLatestVersionProvider
 from dbt_platform_helper.providers.version import InstalledVersionProvider
 from dbt_platform_helper.providers.version import InstalledVersionProviderException
-from dbt_platform_helper.providers.version import PyPiVersionProvider
+from dbt_platform_helper.providers.version import PyPiLatestVersionProvider
 
 
 class MockGithubReleaseResponse:
@@ -69,7 +69,7 @@ class TestGithubVersionProvider:
 class TestPyPiVersionProvider:
     @patch("requests.get", return_value=MockPyPiResponse())
     def test_get_semantic_version(self, request_get):
-        result = PyPiVersionProvider.get_semantic_version("foo")
+        result = PyPiLatestVersionProvider.get_semantic_version("foo")
         assert result == SemanticVersion(1, 2, 3)
         request_get.assert_called_once_with(f"https://pypi.org/pypi/foo/json")
 

--- a/tests/platform_helper/providers/test_version.py
+++ b/tests/platform_helper/providers/test_version.py
@@ -34,9 +34,7 @@ class MockPyPiResponse:
 class TestInstalledVersionProvider:
     @patch("dbt_platform_helper.providers.version.version", return_value="1.1.1")
     def test_get_locally_installed_tool_version(self, mock_version):
-        assert InstalledVersionProvider.get_installed_tool_version("test") == SemanticVersion(
-            1, 1, 1
-        )
+        assert InstalledVersionProvider.get_semantic_version("test") == SemanticVersion(1, 1, 1)
         mock_version.assert_called_once_with("test")
 
     @patch("dbt_platform_helper.providers.version.version", return_value="")
@@ -45,7 +43,7 @@ class TestInstalledVersionProvider:
     ):
         mock_version.side_effect = PackageNotFoundError
         with pytest.raises(InstalledVersionProviderException) as exc:
-            InstalledVersionProvider.get_installed_tool_version("test")
+            InstalledVersionProvider.get_semantic_version("test")
 
         assert "Package 'test' not found" in str(exc)
 

--- a/tests/platform_helper/providers/test_version.py
+++ b/tests/platform_helper/providers/test_version.py
@@ -80,7 +80,7 @@ class TestAWSVersionProvider:
         mock_run.return_value.stdout = b"aws-cli/1.0.0"
         github_response = Mock()
         github_response.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
-        versions = AWSVersioning.get_version_status(github_response)
+        versions = AWSVersioning(github_response).get_version_status()
 
         assert versions.installed == SemanticVersion(1, 0, 0)
         assert versions.latest == SemanticVersion(2, 0, 0)

--- a/tests/platform_helper/providers/test_version.py
+++ b/tests/platform_helper/providers/test_version.py
@@ -93,7 +93,7 @@ class TestCopilotVersionProvider:
 
         github_response = Mock()
         github_response.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
-        versions = CopilotVersioning.get_version_status(github_response)
+        versions = CopilotVersioning(github_response).get_version_status()
 
         assert versions.installed == SemanticVersion(1, 0, 0)
         assert versions.latest == SemanticVersion(2, 0, 0)

--- a/tests/platform_helper/providers/test_version.py
+++ b/tests/platform_helper/providers/test_version.py
@@ -6,7 +6,7 @@ import pytest
 
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.version import AWSVersioning
-from dbt_platform_helper.providers.version import CopilotVersionProvider
+from dbt_platform_helper.providers.version import CopilotVersioning
 from dbt_platform_helper.providers.version import GithubLatestVersionProvider
 from dbt_platform_helper.providers.version import InstalledVersionProvider
 from dbt_platform_helper.providers.version import InstalledVersionProviderException
@@ -93,7 +93,7 @@ class TestCopilotVersionProvider:
 
         github_response = Mock()
         github_response.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
-        versions = CopilotVersionProvider.get_version_status(github_response)
+        versions = CopilotVersioning.get_version_status(github_response)
 
         assert versions.installed == SemanticVersion(1, 0, 0)
         assert versions.latest == SemanticVersion(2, 0, 0)

--- a/tests/platform_helper/providers/test_version.py
+++ b/tests/platform_helper/providers/test_version.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
-from dbt_platform_helper.providers.version import AWSVersionProvider
+from dbt_platform_helper.providers.version import AWSVersioning
 from dbt_platform_helper.providers.version import CopilotVersionProvider
 from dbt_platform_helper.providers.version import GithubLatestVersionProvider
 from dbt_platform_helper.providers.version import InstalledVersionProvider
@@ -80,7 +80,7 @@ class TestAWSVersionProvider:
         mock_run.return_value.stdout = b"aws-cli/1.0.0"
         github_response = Mock()
         github_response.get_semantic_version.return_value = SemanticVersion(2, 0, 0)
-        versions = AWSVersionProvider.get_version_status(github_response)
+        versions = AWSVersioning.get_version_status(github_response)
 
         assert versions.installed == SemanticVersion(1, 0, 0)
         assert versions.latest == SemanticVersion(2, 0, 0)

--- a/tests/platform_helper/providers/test_version_status.py
+++ b/tests/platform_helper/providers/test_version_status.py
@@ -1,0 +1,56 @@
+import pytest
+
+from dbt_platform_helper.providers.semantic_version import SemanticVersion
+from dbt_platform_helper.providers.version_status import PlatformHelperVersionStatus
+from dbt_platform_helper.providers.version_status import VersionStatus
+
+
+class TestVersionStatus:
+    @pytest.mark.parametrize(
+        "suite",
+        [
+            (SemanticVersion(1, 2, 3), SemanticVersion(1, 2, 3), False),
+            (SemanticVersion(1, 2, 0), SemanticVersion(1, 2, 3), True),
+        ],
+    )
+    def test_is_outdated(self, suite):
+        local_version, latest_release, expected = suite
+        assert (
+            VersionStatus(installed=local_version, latest=latest_release).is_outdated() == expected
+        )
+
+    def test_to_string(self):
+        result = f"{VersionStatus(SemanticVersion(1, 2, 0), SemanticVersion(1, 2, 3))}"
+        assert result == "VersionStatus: installed: 1.2.0, latest: 1.2.3"
+
+
+class TestPlatformHelperVersionStatus:
+    def test_to_string_with_populated_attributes(self):
+        platform_helper_version_status = PlatformHelperVersionStatus(
+            SemanticVersion(1, 2, 0),
+            SemanticVersion(1, 2, 3),
+            SemanticVersion(1, 1, 1),
+            SemanticVersion(1, 0, 0),
+            {
+                "main": SemanticVersion(2, 0, 0),
+                "dev": SemanticVersion(2, 1, 1),
+            },
+        )
+        result = f"{platform_helper_version_status}"
+        assert (
+            result
+            == "PlatformHelperVersionStatus: installed: 1.2.0, latest: 1.2.3, deprecated_version_file: 1.1.1, platform_config_default: 1.0.0, pipeline_overrides: main: 2.0.0, dev: 2.1.1"
+        )
+
+    def test_to_string_with_no_pipeline_overrides(self):
+        platform_helper_version_status = PlatformHelperVersionStatus(
+            SemanticVersion(1, 2, 0),
+            SemanticVersion(1, 2, 3),
+            SemanticVersion(1, 1, 1),
+            SemanticVersion(1, 0, 0),
+        )
+        result = f"{platform_helper_version_status}"
+        assert (
+            result
+            == "PlatformHelperVersionStatus: installed: 1.2.0, latest: 1.2.3, deprecated_version_file: 1.1.1, platform_config_default: 1.0.0"
+        )

--- a/tests/platform_helper/test_command_generate.py
+++ b/tests/platform_helper/test_command_generate.py
@@ -6,8 +6,8 @@ from click.testing import CliRunner
 
 from dbt_platform_helper.commands.generate import generate as platform_helper_generate
 from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_FILE
-from dbt_platform_helper.providers.semantic_version import PlatformHelperVersionStatus
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
+from dbt_platform_helper.providers.version_status import PlatformHelperVersionStatus
 
 
 @patch("dbt_platform_helper.commands.copilot.get_aws_session_or_abort")


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1895.

- renames AWSVersionProvider and CopilotVersionProvider to AWSVersioning and CopilotVersioning to better align them with the PlatformHelperVersioning class.  
- Moves classes to appropriate files
- Aligns VerisonProvider function names to `get_semantic_version`

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
