### PR TITLE
fix: From and to account properties no longer required (DBTP-1847)

### DIFF
--- a/dbt_platform_helper/providers/config_validator.py
+++ b/dbt_platform_helper/providers/config_validator.py
@@ -206,6 +206,7 @@ class ConfigValidator:
                         f"database_copy 'to' parameter must be a valid environment ({all_envs_string}) but was '{to_env}' in extension '{extension_name}'."
                     )
 
+                # TODO - The from_account and to_account properties are deprecated and will be removed when terraform-platform-modules is merged with platform-tools
                 if from_account != to_account:
                     if "from_account" in section and section["from_account"] != from_account:
                         errors.append(

--- a/dbt_platform_helper/providers/config_validator.py
+++ b/dbt_platform_helper/providers/config_validator.py
@@ -207,20 +207,12 @@ class ConfigValidator:
                     )
 
                 if from_account != to_account:
-                    if "from_account" not in section:
-                        errors.append(
-                            f"Environments '{from_env}' and '{to_env}' are in different AWS accounts. The 'from_account' parameter must be present."
-                        )
-                    elif section["from_account"] != from_account:
+                    if "from_account" in section and section["from_account"] != from_account:
                         errors.append(
                             f"Incorrect value for 'from_account' for environment '{from_env}'"
                         )
 
-                    if "to_account" not in section:
-                        errors.append(
-                            f"Environments '{from_env}' and '{to_env}' are in different AWS accounts. The 'to_account' parameter must be present."
-                        )
-                    elif section["to_account"] != to_account:
+                    if "to_account" in section and section["to_account"] != to_account:
                         errors.append(
                             f"Incorrect value for 'to_account' for environment '{to_env}'"
                         )

--- a/tests/platform_helper/providers/test_config_validator.py
+++ b/tests/platform_helper/providers/test_config_validator.py
@@ -185,56 +185,6 @@ def test_validate_database_copy_multi_postgres_failures():
     )
 
 
-def test_validate_database_copy_fails_if_cross_account_with_no_from_account():
-    config = {
-        "application": "test-app",
-        "environments": {
-            "dev": {"accounts": {"deploy": {"id": "1122334455"}}},
-            "prod": {"accounts": {"deploy": {"id": "9999999999"}}},
-        },
-        "extensions": {
-            "our-postgres": {
-                "type": "postgres",
-                "version": 7,
-                "database_copy": [{"from": "prod", "to": "dev"}],
-            }
-        },
-    }
-
-    with pytest.raises(ConfigValidatorError) as exception:
-        ConfigValidator().validate_database_copy_section(config)
-
-    console_message = str(exception.value)
-
-    msg = f"Environments 'prod' and 'dev' are in different AWS accounts. The 'from_account' parameter must be present."
-    assert msg in console_message
-
-
-def test_validate_database_copy_fails_if_cross_account_with_no_to_account():
-    config = {
-        "application": "test-app",
-        "environments": {
-            "dev": {"accounts": {"deploy": {"id": "1122334455"}}},
-            "prod": {"accounts": {"deploy": {"id": "9999999999"}}},
-        },
-        "extensions": {
-            "our-postgres": {
-                "type": "postgres",
-                "version": 7,
-                "database_copy": [{"from": "prod", "to": "dev", "from_account": "9999999999"}],
-            }
-        },
-    }
-
-    with pytest.raises(ConfigValidatorError) as exception:
-        ConfigValidator().validate_database_copy_section(config)
-
-    console_message = str(exception.value)
-
-    msg = f"Environments 'prod' and 'dev' are in different AWS accounts. The 'to_account' parameter must be present."
-    assert msg in console_message
-
-
 def test_validate_database_copy_fails_if_cross_account_with_incorrect_account_ids():
     config = {
         "application": "test-app",


### PR DESCRIPTION
Relates to https://github.com/uktrade/terraform-platform-modules/pull/370

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
