### PR TITLE
fix: Intermittent failures when calling via requests library (off-ticket)

### DIFF
--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -10,6 +10,7 @@ import requests
 
 from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_FILE
 from dbt_platform_helper.platform_exception import PlatformException
+from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.yaml_file import FileProviderException
 from dbt_platform_helper.providers.yaml_file import YamlFileProvider
@@ -49,6 +50,7 @@ class GithubLatestVersionProvider(VersionProvider):
     def get_semantic_version(repo_name: str, tags: bool = False) -> SemanticVersion:
         if tags:
             tags_list = requests.get(f"https://api.github.com/repos/{repo_name}/tags").json()
+            ClickIOProvider().info(tags_list)
             versions = [SemanticVersion.from_string(v["name"]) for v in tags_list]
             versions.sort(reverse=True)
             return versions[0]

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -21,7 +21,7 @@ from dbt_platform_helper.providers.yaml_file import YamlFileProvider
 
 def set_up_retry():
     session = Session()
-    retries = Retry(total=5, backoff_factor=0.5, status_forcelist=[403, 500, 502, 503, 504])
+    retries = Retry(total=5, backoff_factor=0.1, status_forcelist=[403, 500, 502, 503, 504])
     session.mount("https://", HTTPAdapter(max_retries=retries))
     return session
 


### PR DESCRIPTION
---
## Why:
When calling via `requests` to github we get Intermittent failures within the end to end tests

## What:
- add retry to requests
- on exception log the error and return `None` for the version,  so usage doesn't break.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- ~[ ] Link to ticket included (unless it's a quick out of ticket thing)~
- [x] Includes tests (or an explanation for why it doesn't)
- ~[ ] If the work includes user interface changes, before and after screenshots included in description~
- ~[ ] Includes any applicable changes to the documentation in this code base~
- ~[ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~

### Tasks:
- [x] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
