### PR TITLE
refactor: Pass session to config validator (DBTP-1888)

### DIFF
--- a/dbt_platform_helper/commands/environment.py
+++ b/dbt_platform_helper/commands/environment.py
@@ -94,9 +94,8 @@ def generate(name):
 def generate_terraform(name, terraform_platform_modules_version):
     click_io = ClickIOProvider()
     try:
-        # TODO = pass the session to ConfigValidator
-        get_aws_session_or_abort()
-        config_provider = ConfigProvider(ConfigValidator())
+        session = get_aws_session_or_abort()
+        config_provider = ConfigProvider(ConfigValidator(session=session))
         TerraformEnvironment(config_provider).generate(name, terraform_platform_modules_version)
     except PlatformException as err:
         click_io.abort_with_error(str(err))

--- a/dbt_platform_helper/providers/config_validator.py
+++ b/dbt_platform_helper/providers/config_validator.py
@@ -80,10 +80,10 @@ class ConfigValidator:
                 f"{extension_type} version for environment {version_failure['environment']} is not in the list of supported {extension_type} versions: {supported_extension_versions}. Provided Version: {version_failure['version']}",
             )
 
-    def _get_client(self, type: str):
+    def _get_client(self, service_name: str):
         if self.session:
-            return self.session.client(type)
-        return boto3.client(type)
+            return self.session.client(service_name)
+        return boto3.client(service_name)
 
     def validate_supported_redis_versions(self, config):
         return self._validate_extension_supported_versions(

--- a/dbt_platform_helper/providers/config_validator.py
+++ b/dbt_platform_helper/providers/config_validator.py
@@ -17,7 +17,10 @@ class ConfigValidatorError(PlatformException):
 class ConfigValidator:
 
     def __init__(
-        self, validations: Callable[[dict], None] = None, io: ClickIOProvider = ClickIOProvider()
+        self,
+        validations: Callable[[dict], None] = None,
+        io: ClickIOProvider = ClickIOProvider(),
+        session: boto3.Session = None,
     ):
         self.validations = validations or [
             self.validate_supported_redis_versions,


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1888).

Allows (optional) injection of session into the config validator for validations depending on AWS
Addresses TODO to ensure the same session created at the beginning of the command is used for the validations


---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
