### PR TITLE
feat: Remove override flags from pipeline generate & environment generate terraform commands (DBPT-1942)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-python 3.12.8 3.11.5 3.10.13 3.9.18
+python 3.12.8
 nodejs 18.18.2
 terraform 1.9.6
 direnv 2.35.0

--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -483,7 +483,7 @@ platform-helper environment generate --name <name>
 ## Usage
 
 ```
-platform-helper environment generate-terraform --name <name> [--platform-helper-version <platform_helper_version>] 
+platform-helper environment generate-terraform --name <name> 
 ```
 
 ## Options
@@ -491,8 +491,6 @@ platform-helper environment generate-terraform --name <name> [--platform-helper-
 - `--name
 -n <text>`
   - The name of the environment to generate a manifest for.
-- `--platform-helper-version <text>`
-  - Override the default version of platform-helper. (Default version is the installed version for `dbt-platform-helper`.
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.
 
@@ -557,16 +555,11 @@ platform-helper pipeline generate
 ## Usage
 
 ```
-platform-helper pipeline generate [--platform-helper-version <platform_helper_version>] 
-                                  [--deploy-branch <deploy_branch>] 
+platform-helper pipeline generate [--deploy-branch <deploy_branch>] 
 ```
 
 ## Options
 
-- `--platform-helper-version <text>`
-  - Override the default version of platform-helper with a specific version or branch. 
-Precedence of version used is version supplied via CLI, then the version found in 
-platform-config.yml/default_versions/platform-helper.
 - `--deploy-branch <text>`
   - Specify the branch of <application>-deploy used to configure the source stage in the environment-pipeline resource. 
 This is generated from the terraform/environments-pipeline/<aws_account>/main.tf file. 

--- a/dbt_platform_helper/commands/environment.py
+++ b/dbt_platform_helper/commands/environment.py
@@ -86,16 +86,12 @@ def generate(name):
 @click.option(
     "--name", "-n", required=True, help="The name of the environment to generate a manifest for."
 )
-@click.option(
-    "--platform-helper-version",
-    help=f"Override the default version of platform-helper. (Default version is the installed version for `dbt-platform-helper`.",
-)
-def generate_terraform(name, platform_helper_version):
+def generate_terraform(name):
     click_io = ClickIOProvider()
     try:
         session = get_aws_session_or_abort()
         config_provider = ConfigProvider(ConfigValidator(session=session))
-        TerraformEnvironment(config_provider).generate(name, platform_helper_version)
+        TerraformEnvironment(config_provider).generate(name)
 
     except PlatformException as err:
         click_io.abort_with_error(str(err))

--- a/dbt_platform_helper/commands/pipeline.py
+++ b/dbt_platform_helper/commands/pipeline.py
@@ -21,12 +21,6 @@ def pipeline():
 
 @pipeline.command()
 @click.option(
-    "--platform-helper-version",
-    help=f"""Override the default version of platform-helper with a specific version or branch. 
-    Precedence of version used is version supplied via CLI, then the version found in 
-    platform-config.yml/default_versions/platform-helper.""",
-)
-@click.option(
     "--deploy-branch",
     help="""Specify the branch of <application>-deploy used to configure the source stage in the environment-pipeline resource. 
     This is generated from the terraform/environments-pipeline/<aws_account>/main.tf file. 
@@ -34,7 +28,7 @@ def pipeline():
     <application>-deploy/platform-config.yml/environment_pipelines/<environment-pipeline>/branch).""",
     default=None,
 )
-def generate(platform_helper_version: str, deploy_branch: str):
+def generate(deploy_branch: str):
     """
     Given a platform-config.yml file, generate environment and service
     deployment pipelines.
@@ -59,6 +53,6 @@ def generate(platform_helper_version: str, deploy_branch: str):
             get_codestar_connection_arn,
             io,
         )
-        pipelines.generate(platform_helper_version, deploy_branch)
+        pipelines.generate(deploy_branch)
     except Exception as exc:
         io.abort_with_error(str(exc))

--- a/dbt_platform_helper/domain/pipelines.py
+++ b/dbt_platform_helper/domain/pipelines.py
@@ -84,10 +84,10 @@ class Pipelines:
         #     self.platform_helper_version_status.get_required_platform_helper_version(self.io)
         # )
 
-        self.platform_helper_versioning.cli_override = cli_platform_helper_version
-
         platform_helper_version = (
-            self.platform_helper_versioning.get_required_platform_helper_version(self.io)
+            self.platform_helper_versioning.get_required_platform_helper_version(
+                self.io, cli_platform_helper_version
+            )
         )
 
         # TODO - this whole code block/if-statement can fall away once the deploy_repository is a required key.
@@ -132,7 +132,7 @@ class Pipelines:
 
             self.terraform_manifest_provider.generate_codebase_pipeline_config(
                 platform_config,
-                platform_helper_version,
+                str(platform_helper_version),
                 ecrs_that_need_importing,
                 deploy_repository,
             )

--- a/dbt_platform_helper/domain/pipelines.py
+++ b/dbt_platform_helper/domain/pipelines.py
@@ -7,6 +7,7 @@ from dbt_platform_helper.constants import CODEBASE_PIPELINES_KEY
 from dbt_platform_helper.constants import ENVIRONMENT_PIPELINES_KEY
 from dbt_platform_helper.constants import SUPPORTED_AWS_PROVIDER_VERSION
 from dbt_platform_helper.constants import SUPPORTED_TERRAFORM_VERSION
+from dbt_platform_helper.domain.versioning import PlatformHelperVersionNotFoundException
 from dbt_platform_helper.providers.config import ConfigProvider
 from dbt_platform_helper.providers.ecr import ECRProvider
 from dbt_platform_helper.providers.files import FileProvider
@@ -66,6 +67,11 @@ class Pipelines:
         platform_config_platform_helper_default_version: str = platform_config.get(
             "default_versions", {}
         ).get("platform-helper")
+
+        if platform_config_platform_helper_default_version is None:
+            raise PlatformHelperVersionNotFoundException(
+                "cannot find 'platform-helper' in 'default_versions' in the platform-config.yml file."
+            )
 
         # TODO - this whole code block/if-statement can fall away once the deploy_repository is a required key.
         deploy_repository = ""

--- a/dbt_platform_helper/domain/pipelines.py
+++ b/dbt_platform_helper/domain/pipelines.py
@@ -132,7 +132,7 @@ class Pipelines:
 
             self.terraform_manifest_provider.generate_codebase_pipeline_config(
                 platform_config,
-                str(platform_helper_version),
+                platform_helper_version,
                 ecrs_that_need_importing,
                 deploy_repository,
             )

--- a/dbt_platform_helper/domain/pipelines.py
+++ b/dbt_platform_helper/domain/pipelines.py
@@ -44,9 +44,11 @@ class Pipelines:
 
     def generate(
         self,
+        # TODO: Remove this
         cli_platform_helper_version: str,
         deploy_branch: str,
     ):
+        # Something like cli_platform_helper_version = os.getenv("PLATFORM_HELPER_VERSION_OVERRIDE")
         platform_config = self.config_provider.load_and_validate_platform_config()
 
         has_codebase_pipelines = CODEBASE_PIPELINES_KEY in platform_config

--- a/dbt_platform_helper/domain/pipelines.py
+++ b/dbt_platform_helper/domain/pipelines.py
@@ -7,12 +7,14 @@ from dbt_platform_helper.constants import CODEBASE_PIPELINES_KEY
 from dbt_platform_helper.constants import ENVIRONMENT_PIPELINES_KEY
 from dbt_platform_helper.constants import SUPPORTED_AWS_PROVIDER_VERSION
 from dbt_platform_helper.constants import SUPPORTED_TERRAFORM_VERSION
+
+# from dbt_platform_helper.providers.version_status import PlatformHelperVersionStatus
+from dbt_platform_helper.domain.versioning import PlatformHelperVersioning
 from dbt_platform_helper.providers.config import ConfigProvider
 from dbt_platform_helper.providers.ecr import ECRProvider
 from dbt_platform_helper.providers.files import FileProvider
 from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.terraform_manifest import TerraformManifestProvider
-from dbt_platform_helper.providers.version_status import PlatformHelperVersionStatus
 from dbt_platform_helper.utils.application import get_application_name
 from dbt_platform_helper.utils.template import setup_templates
 
@@ -27,7 +29,8 @@ class Pipelines:
         get_codestar_arn: Callable[[str], str],
         io: ClickIOProvider = ClickIOProvider(),
         file_provider: FileProvider = FileProvider(),
-        platform_helper_version_status: PlatformHelperVersionStatus = PlatformHelperVersionStatus(),
+        # platform_helper_version_status: PlatformHelperVersionStatus = PlatformHelperVersionStatus(),
+        platform_helper_versioning: PlatformHelperVersioning = PlatformHelperVersioning(),
     ):
         self.config_provider = config_provider
         self.get_git_remote = get_git_remote
@@ -36,7 +39,8 @@ class Pipelines:
         self.ecr_provider = ecr_provider
         self.io = io
         self.file_provider = file_provider
-        self.platform_helper_version_status = platform_helper_version_status
+        # self.platform_helper_version_status = platform_helper_version_status
+        self.platform_helper_versioning = platform_helper_versioning
 
     def generate(
         self,
@@ -71,13 +75,19 @@ class Pipelines:
             "default_versions", {}
         ).get("platform-helper")
 
-        self.platform_helper_version_status.cli_override = cli_platform_helper_version
-        self.platform_helper_version_status.platform_config_default = (
-            platform_config_platform_helper_default_version
-        )
+        # self.platform_helper_version_status.cli_override = cli_platform_helper_version
+        # self.platform_helper_version_status.platform_config_default = (
+        #     platform_config_platform_helper_default_version
+        # )
+
+        # platform_helper_version = (
+        #     self.platform_helper_version_status.get_required_platform_helper_version(self.io)
+        # )
+
+        self.platform_helper_versioning.cli_override = cli_platform_helper_version
 
         platform_helper_version = (
-            self.platform_helper_version_status.get_required_platform_helper_version(self.io)
+            self.platform_helper_versioning.get_required_platform_helper_version(self.io)
         )
 
         # TODO - this whole code block/if-statement can fall away once the deploy_repository is a required key.

--- a/dbt_platform_helper/domain/terraform_environment.py
+++ b/dbt_platform_helper/domain/terraform_environment.py
@@ -31,8 +31,11 @@ class TerraformEnvironment:
     def generate(
         self,
         environment_name: str,
-        cli_platform_helper_version: str = None,
+        # TODO: Remove this option
+        # cli_platform_helper_version: str = None,
     ):
+
+        # Something like cli_platform_helper_version = os.getenv("PLATFORM_HELPER_VERSION_OVERRIDE")
         config = self.config_provider.get_enriched_config()
 
         if environment_name not in config.get("environments").keys():

--- a/dbt_platform_helper/domain/terraform_environment.py
+++ b/dbt_platform_helper/domain/terraform_environment.py
@@ -1,8 +1,6 @@
-from dbt_platform_helper.domain.versioning import PlatformHelperVersioning
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.terraform_manifest import TerraformManifestProvider
-from dbt_platform_helper.providers.version_status import PlatformHelperVersionStatus
 
 
 class TerraformEnvironmentException(PlatformException):
@@ -19,23 +17,16 @@ class TerraformEnvironment:
         config_provider,
         manifest_provider: TerraformManifestProvider = None,
         io: ClickIOProvider = ClickIOProvider(),
-        platform_helper_version_status: PlatformHelperVersionStatus = PlatformHelperVersionStatus(),
-        platform_helper_versioning: PlatformHelperVersioning = PlatformHelperVersioning(),
     ):
         self.io = io
         self.config_provider = config_provider
         self.manifest_provider = manifest_provider or TerraformManifestProvider()
-        self.platform_helper_version_status = platform_helper_version_status
-        self.platform_helper_versioning = platform_helper_versioning
 
     def generate(
         self,
         environment_name: str,
-        # TODO: Remove this option
-        # cli_platform_helper_version: str = None,
     ):
 
-        # Something like cli_platform_helper_version = os.getenv("PLATFORM_HELPER_VERSION_OVERRIDE")
         config = self.config_provider.get_enriched_config()
 
         if environment_name not in config.get("environments").keys():
@@ -43,25 +34,10 @@ class TerraformEnvironment:
                 f"cannot generate terraform for environment {environment_name}.  It does not exist in your configuration"
             )
 
-        # platform_config_platform_helper_default_version = config.get("default_versions", {}).get(
-        #     "platform-helper"
-        # )
-
-        # self.platform_helper_version_status.cli_override = cli_platform_helper_version
-        # self.platform_helper_version_status.platform_config_default = (
-        #     platform_config_platform_helper_default_version
-        # )
-
-        # platform_helper_version = (
-        #     self.platform_helper_version_status.get_required_platform_helper_version(self.io)
-        # )
-
-        platform_helper_version = (
-            self.platform_helper_versioning.get_required_platform_helper_version(
-                self.io, cli_platform_helper_version
-            )
-        )
+        platform_config_platform_helper_default_version: str = config.get(
+            "default_versions", {}
+        ).get("platform-helper")
 
         self.manifest_provider.generate_environment_config(
-            config, environment_name, platform_helper_version
+            config, environment_name, platform_config_platform_helper_default_version
         )

--- a/dbt_platform_helper/domain/terraform_environment.py
+++ b/dbt_platform_helper/domain/terraform_environment.py
@@ -60,5 +60,5 @@ class TerraformEnvironment:
         )
 
         self.manifest_provider.generate_environment_config(
-            config, environment_name, str(platform_helper_version)
+            config, environment_name, platform_helper_version
         )

--- a/dbt_platform_helper/domain/terraform_environment.py
+++ b/dbt_platform_helper/domain/terraform_environment.py
@@ -1,3 +1,4 @@
+from dbt_platform_helper.domain.versioning import PlatformHelperVersioning
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.terraform_manifest import TerraformManifestProvider
@@ -19,11 +20,13 @@ class TerraformEnvironment:
         manifest_provider: TerraformManifestProvider = None,
         io: ClickIOProvider = ClickIOProvider(),
         platform_helper_version_status: PlatformHelperVersionStatus = PlatformHelperVersionStatus(),
+        platform_helper_versioning: PlatformHelperVersioning = PlatformHelperVersioning(),
     ):
         self.io = io
         self.config_provider = config_provider
         self.manifest_provider = manifest_provider or TerraformManifestProvider()
         self.platform_helper_version_status = platform_helper_version_status
+        self.platform_helper_versioning = platform_helper_versioning
 
     def generate(
         self,
@@ -37,17 +40,23 @@ class TerraformEnvironment:
                 f"cannot generate terraform for environment {environment_name}.  It does not exist in your configuration"
             )
 
-        platform_config_platform_helper_default_version = config.get("default_versions", {}).get(
-            "platform-helper"
-        )
+        # platform_config_platform_helper_default_version = config.get("default_versions", {}).get(
+        #     "platform-helper"
+        # )
 
-        self.platform_helper_version_status.cli_override = cli_platform_helper_version
-        self.platform_helper_version_status.platform_config_default = (
-            platform_config_platform_helper_default_version
-        )
+        # self.platform_helper_version_status.cli_override = cli_platform_helper_version
+        # self.platform_helper_version_status.platform_config_default = (
+        #     platform_config_platform_helper_default_version
+        # )
+
+        # platform_helper_version = (
+        #     self.platform_helper_version_status.get_required_platform_helper_version(self.io)
+        # )
+
+        self.platform_helper_versioning.cli_override = cli_platform_helper_version
 
         platform_helper_version = (
-            self.platform_helper_version_status.get_required_platform_helper_version(self.io)
+            self.platform_helper_versioning.get_required_platform_helper_version(self.io)
         )
 
         self.manifest_provider.generate_environment_config(

--- a/dbt_platform_helper/domain/terraform_environment.py
+++ b/dbt_platform_helper/domain/terraform_environment.py
@@ -30,8 +30,8 @@ class TerraformEnvironment:
 
     def generate(
         self,
-        environment_name,
-        cli_platform_helper_version=None,
+        environment_name: str,
+        cli_platform_helper_version: str = None,
     ):
         config = self.config_provider.get_enriched_config()
 
@@ -53,12 +53,12 @@ class TerraformEnvironment:
         #     self.platform_helper_version_status.get_required_platform_helper_version(self.io)
         # )
 
-        self.platform_helper_versioning.cli_override = cli_platform_helper_version
-
         platform_helper_version = (
-            self.platform_helper_versioning.get_required_platform_helper_version(self.io)
+            self.platform_helper_versioning.get_required_platform_helper_version(
+                self.io, cli_platform_helper_version
+            )
         )
 
         self.manifest_provider.generate_environment_config(
-            config, environment_name, platform_helper_version
+            config, environment_name, str(platform_helper_version)
         )

--- a/dbt_platform_helper/domain/terraform_environment.py
+++ b/dbt_platform_helper/domain/terraform_environment.py
@@ -1,3 +1,4 @@
+from dbt_platform_helper.domain.versioning import PlatformHelperVersionNotFoundException
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.terraform_manifest import TerraformManifestProvider
@@ -37,6 +38,11 @@ class TerraformEnvironment:
         platform_config_platform_helper_default_version: str = config.get(
             "default_versions", {}
         ).get("platform-helper")
+
+        if platform_config_platform_helper_default_version is None:
+            raise PlatformHelperVersionNotFoundException(
+                "cannot find 'platform-helper' in 'default_versions' in the platform-config.yml file."
+            )
 
         self.manifest_provider.generate_environment_config(
             config, environment_name, platform_config_platform_helper_default_version

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -169,7 +169,7 @@ class PlatformHelperVersioning:
         version_preference_order = [
             cli_override,
             str(version_status.platform_config_default),
-            str(version_status.deprecated_version_file),
+            str(version_status.deprecated_version_file),  # TODO: Remove this
         ]
 
         # version_preference_order = [

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 
 from dbt_platform_helper.constants import MERGED_TPM_PLATFORM_HELPER_VERSION
 from dbt_platform_helper.platform_exception import PlatformException
@@ -49,7 +48,6 @@ class PlatformHelperVersioning:
         latest_version_provider: VersionProvider = PyPiLatestVersionProvider,
         installed_version_provider: InstalledVersionProvider = InstalledVersionProvider(),
         skip_versioning_checks: bool = None,
-        cli_override: Optional[SemanticVersion] = None,
     ):
         self.io = io
         self.version_file_version_provider = version_file_version_provider
@@ -59,7 +57,6 @@ class PlatformHelperVersioning:
         self.skip_versioning_checks = (
             skip_versioning_checks if skip_versioning_checks is not None else skip_version_checks()
         )
-        self.cli_override = cli_override
 
     def get_required_version(self, pipeline=None):
         version_status = self._get_version_status()
@@ -166,11 +163,13 @@ class PlatformHelperVersioning:
 
         return out
 
-    def get_required_platform_helper_version(self, io: ClickIOProvider):
+    def get_required_platform_helper_version(
+        self, io: ClickIOProvider, cli_override: str
+    ) -> SemanticVersion:
         version_status = self._get_version_status(include_project_versions=True)
 
         version_preference_order = [
-            self.cli_override,
+            SemanticVersion.from_string(cli_override),
             version_status.platform_config_default,
             version_status.deprecated_version_file,
         ]
@@ -184,12 +183,9 @@ class PlatformHelperVersioning:
         valid_versions = [version for version in version_preference_order if version]
 
         if valid_versions:
-            if SemanticVersion.is_semantic_version(valid_versions[0]):
-                semantic_version = SemanticVersion.from_string(valid_versions[0])
-                if semantic_version and (
-                    semantic_version.major < MERGED_TPM_PLATFORM_HELPER_VERSION
-                ):
-                    raise UnsupportedVersionException(valid_versions[0])
+            version = valid_versions[0]
+            if version and (version.major < MERGED_TPM_PLATFORM_HELPER_VERSION):
+                raise UnsupportedVersionException(valid_versions[0])
             return valid_versions[0]
         else:
             io.warn(

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -163,15 +163,13 @@ class PlatformHelperVersioning:
 
         return out
 
-    def get_required_platform_helper_version(
-        self, io: ClickIOProvider, cli_override: str
-    ) -> SemanticVersion:
+    def get_required_platform_helper_version(self, io: ClickIOProvider, cli_override: str) -> str:
         version_status = self._get_version_status(include_project_versions=True)
 
         version_preference_order = [
-            SemanticVersion.from_string(cli_override),
-            version_status.platform_config_default,
-            version_status.deprecated_version_file,
+            cli_override,
+            str(version_status.platform_config_default),
+            str(version_status.deprecated_version_file),
         ]
 
         # version_preference_order = [
@@ -184,9 +182,13 @@ class PlatformHelperVersioning:
 
         if valid_versions:
             version = valid_versions[0]
-            if version and (version.major < MERGED_TPM_PLATFORM_HELPER_VERSION):
-                raise UnsupportedVersionException(valid_versions[0])
-            return valid_versions[0]
+            if SemanticVersion.is_semantic_version(version):
+                semantic_version = SemanticVersion.from_string(valid_versions[0])
+                if semantic_version and (
+                    semantic_version.major < MERGED_TPM_PLATFORM_HELPER_VERSION
+                ):
+                    raise UnsupportedVersionException(valid_versions[0])
+            return version
         else:
             io.warn(
                 "No platform-helper version specified. No value was provided via CLI, nor was one found in platform-config.yml under `default_versions`."

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -1,5 +1,7 @@
 import os
+from typing import Optional
 
+from dbt_platform_helper.constants import MERGED_TPM_PLATFORM_HELPER_VERSION
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.config import ConfigProvider
 from dbt_platform_helper.providers.io import ClickIOProvider
@@ -18,6 +20,7 @@ from dbt_platform_helper.providers.version import InstalledVersionProvider
 from dbt_platform_helper.providers.version import PyPiLatestVersionProvider
 from dbt_platform_helper.providers.version import VersionProvider
 from dbt_platform_helper.providers.version_status import PlatformHelperVersionStatus
+from dbt_platform_helper.providers.version_status import UnsupportedVersionException
 from dbt_platform_helper.providers.version_status import VersionStatus
 from dbt_platform_helper.providers.yaml_file import YamlFileProvider
 
@@ -46,6 +49,7 @@ class PlatformHelperVersioning:
         latest_version_provider: VersionProvider = PyPiLatestVersionProvider,
         installed_version_provider: InstalledVersionProvider = InstalledVersionProvider(),
         skip_versioning_checks: bool = None,
+        cli_override: Optional[SemanticVersion] = None,
     ):
         self.io = io
         self.version_file_version_provider = version_file_version_provider
@@ -55,6 +59,7 @@ class PlatformHelperVersioning:
         self.skip_versioning_checks = (
             skip_versioning_checks if skip_versioning_checks is not None else skip_version_checks()
         )
+        self.cli_override = cli_override
 
     def get_required_version(self, pipeline=None):
         version_status = self._get_version_status()
@@ -160,6 +165,36 @@ class PlatformHelperVersioning:
             raise PlatformHelperVersionNotFoundException
 
         return out
+
+    def get_required_platform_helper_version(self, io: ClickIOProvider):
+        version_status = self._get_version_status(include_project_versions=True)
+
+        version_preference_order = [
+            self.cli_override,
+            version_status.platform_config_default,
+            version_status.deprecated_version_file,
+        ]
+
+        # version_preference_order = [
+        #     self.cli_override,
+        #     self.platform_config_default,
+        #     self.deprecated_version_file,
+        # ]
+
+        valid_versions = [version for version in version_preference_order if version]
+
+        if valid_versions:
+            if SemanticVersion.is_semantic_version(valid_versions[0]):
+                semantic_version = SemanticVersion.from_string(valid_versions[0])
+                if semantic_version and (
+                    semantic_version.major < MERGED_TPM_PLATFORM_HELPER_VERSION
+                ):
+                    raise UnsupportedVersionException(valid_versions[0])
+            return valid_versions[0]
+        else:
+            io.warn(
+                "No platform-helper version specified. No value was provided via CLI, nor was one found in platform-config.yml under `default_versions`."
+            )
 
 
 class AWSVersioning:

--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -33,8 +33,8 @@ def skip_version_checks():
 
 
 class PlatformHelperVersionNotFoundException(PlatformException):
-    def __init__(self):
-        super().__init__(f"""Platform helper version could not be resolved.""")
+    def __init__(self, message=None):
+        super().__init__(message or "Platform helper version could not be resolved.")
 
 
 class PlatformHelperVersioning:

--- a/dbt_platform_helper/providers/semantic_version.py
+++ b/dbt_platform_helper/providers/semantic_version.py
@@ -19,7 +19,7 @@ class IncompatibleMinorVersionException(ValidationException):
 
 
 class SemanticVersion:
-    def __init__(self, major, minor, patch):
+    def __init__(self, major: int, minor: int, patch: int):
         self.major = major
         self.minor = minor
         self.patch = patch

--- a/dbt_platform_helper/providers/version.py
+++ b/dbt_platform_helper/providers/version.py
@@ -49,6 +49,7 @@ class InstalledVersionProvider:
     def get_semantic_version(tool_name: str) -> SemanticVersion:
         try:
             return SemanticVersion.from_string(version(tool_name))
+
         except PackageNotFoundError:
             raise InstalledToolNotFoundException(tool_name)
 

--- a/dbt_platform_helper/providers/version_status.py
+++ b/dbt_platform_helper/providers/version_status.py
@@ -3,11 +3,9 @@ from dataclasses import field
 from typing import Dict
 from typing import Optional
 
-from dbt_platform_helper.constants import MERGED_TPM_PLATFORM_HELPER_VERSION
 from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_FILE
 from dbt_platform_helper.platform_exception import PlatformException
-from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 
 
@@ -90,24 +88,24 @@ class PlatformHelperVersionStatus(VersionStatus):
             "errors": errors,
         }
 
-    def get_required_platform_helper_version(self, io: ClickIOProvider):
-        version_preference_order = [
-            self.cli_override,
-            self.platform_config_default,
-            self.deprecated_version_file,
-        ]
+    # def get_required_platform_helper_version(self, io: ClickIOProvider):
+    #     version_preference_order = [
+    #         self.cli_override,
+    #         self.platform_config_default,
+    #         self.deprecated_version_file,
+    #     ]
 
-        valid_versions = [version for version in version_preference_order if version]
+    #     valid_versions = [version for version in version_preference_order if version]
 
-        if valid_versions:
-            if SemanticVersion.is_semantic_version(valid_versions[0]):
-                semantic_version = SemanticVersion.from_string(valid_versions[0])
-                if semantic_version and (
-                    semantic_version.major < MERGED_TPM_PLATFORM_HELPER_VERSION
-                ):
-                    raise UnsupportedVersionException(valid_versions[0])
-            return valid_versions[0]
-        else:
-            io.warn(
-                "No platform-helper version specified. No value was provided via CLI, nor was one found in platform-config.yml under `default_versions`."
-            )
+    #     if valid_versions:
+    #         if SemanticVersion.is_semantic_version(valid_versions[0]):
+    #             semantic_version = SemanticVersion.from_string(valid_versions[0])
+    #             if semantic_version and (
+    #                 semantic_version.major < MERGED_TPM_PLATFORM_HELPER_VERSION
+    #             ):
+    #                 raise UnsupportedVersionException(valid_versions[0])
+    #         return valid_versions[0]
+    #     else:
+    #         io.warn(
+    #             "No platform-helper version specified. No value was provided via CLI, nor was one found in platform-config.yml under `default_versions`."
+    #         )

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -619,6 +619,7 @@ def platform_env_config():
 def codebase_pipeline_config_for_1_pipeline_and_2_run_groups(platform_env_config):
     return {
         **platform_env_config,
+        "default_versions": {"platform-helper": "14.0.0"},
         "codebase_pipelines": {
             "test_codebase": {
                 "repository": "uktrade/repo1",

--- a/tests/platform_helper/domain/test_copilot_environment.py
+++ b/tests/platform_helper/domain/test_copilot_environment.py
@@ -485,7 +485,6 @@ class TestCopilotGenerate:
             "deploy": {"name": "non-prod-acc", "id": "1122334455"},
             "dns": {"name": "non-prod-dns-acc", "id": "6677889900"},
         },
-        "versions": {"terraform-platform-modules": "123456"},
     }
 
     MOCK_VPC = Vpc(

--- a/tests/platform_helper/domain/test_pipelines.py
+++ b/tests/platform_helper/domain/test_pipelines.py
@@ -27,8 +27,6 @@ class PipelineMocks:
             f"arn:aws:codestar-connections:eu-west-2:1234567:connection/{app_name}"
         )
         self.mock_ecr_provider.get_ecr_repo_names.return_value = []
-        self.platform_helper_versioning = Mock()
-        self.platform_helper_versioning.get_required_platform_helper_version.return_value = "14.0.0"
 
     def params(self):
         return {
@@ -38,7 +36,6 @@ class PipelineMocks:
             "io": self.io,
             "get_git_remote": self.mock_git_remote,
             "get_codestar_arn": self.mock_codestar,
-            "platform_helper_versioning": self.platform_helper_versioning,
         }
 
 
@@ -50,7 +47,7 @@ def test_pipeline_generate_with_empty_platform_config_yml_outputs_warning():
     mocks.mock_config_provider = mock_config_provider
     pipelines = Pipelines(**mocks.params())
 
-    pipelines.generate(None, None)
+    pipelines.generate(None)
 
     mocks.io.warn.assert_called_once_with("No pipelines defined: nothing to do.")
 
@@ -62,7 +59,7 @@ def test_pipeline_generate_with_non_empty_platform_config_but_no_pipelines_outpu
     mocks.mock_config_provider = mock_config_provider
     pipelines = Pipelines(**mocks.params())
 
-    pipelines.generate(None, None)
+    pipelines.generate(None)
 
     mocks.io.warn.assert_called_once_with("No pipelines defined: nothing to do.")
 
@@ -70,23 +67,20 @@ def test_pipeline_generate_with_non_empty_platform_config_but_no_pipelines_outpu
 @freeze_time("2024-10-28 12:00:00")
 @patch("dbt_platform_helper.jinja2_tags.version", new=Mock(return_value="v0.1-TEST"))
 @pytest.mark.parametrize(
-    "cli_platform_helper_version, config_platform_helper_version, expected_platform_helper_version, cli_demodjango_branch, expected_demodjango_branch",
+    "config_platform_helper_version, expected_platform_helper_version, cli_demodjango_branch, expected_demodjango_branch",
     [  # config_platform_helper_version sets the platform-config.yml to include the platform-helper version at platform-config.yml/default_versions/platform-helper
-        ("14", True, "14", None, None),  # Case with cli_platform_helper_version
+        (True, "14", None, None),
         (
-            None,
             True,
             "14.0.0",
             "demodjango-branch",
             "demodjango-branch",
-        ),  # Case with config_platform_helper_version and specific branch
-        (None, True, "14.0.0", None, None),
-        (None, True, "14.0.0", None, None),
+        ),
+        (True, "14.0.0", None, None),
     ],
 )
 def test_generate_pipeline_command_generate_terraform_files_for_environment_pipeline_manifest(
     fakefs,
-    cli_platform_helper_version,
     config_platform_helper_version,
     expected_platform_helper_version,
     cli_demodjango_branch,
@@ -101,7 +95,7 @@ def test_generate_pipeline_command_generate_terraform_files_for_environment_pipe
     mocks = PipelineMocks(app_name)
     pipelines = Pipelines(**mocks.params())
 
-    pipelines.generate(cli_platform_helper_version, cli_demodjango_branch)
+    pipelines.generate(cli_demodjango_branch)
 
     assert_terraform(
         app_name,
@@ -131,7 +125,7 @@ def test_generate_pipeline_generates_expected_terraform_manifest_when_no_deploy_
     mocks = PipelineMocks(app_name)
     pipelines = Pipelines(**mocks.params())
 
-    pipelines.generate("an-unimportant-platform-version", "a-branch")
+    pipelines.generate("a-branch")
 
     expected_files_dir = Path(f"terraform/environment-pipelines/platform-prod-test/main.tf")
     assert expected_files_dir.exists()
@@ -146,11 +140,10 @@ def test_generate_pipeline_generates_expected_terraform_manifest_when_no_deploy_
     assert re.search(r'repository += +"uktrade/test-app-deploy"', content)
 
 
-def test_generate_calls_generate_codebase_pipeline_config_with_expected_tpm_version(
+def test_pipeline_generate_calls_generate_codebase_pipeline_config_with_expected_platform_helper_version(
     codebase_pipeline_config_for_1_pipeline_and_2_run_groups,
     fakefs,
 ):
-    cli_platform_helper_version = "13"
     exp_version = "14.0.0"
     app_name = "test-app"
     fakefs.create_file(
@@ -160,7 +153,7 @@ def test_generate_calls_generate_codebase_pipeline_config_with_expected_tpm_vers
     mocks = PipelineMocks(app_name)
     pipelines = Pipelines(**mocks.params())
 
-    pipelines.generate(cli_platform_helper_version, None)
+    pipelines.generate(None)
 
     mock_t_m_p = mocks.mock_terraform_manifest_provider
     mock_t_m_p.generate_codebase_pipeline_config.assert_called_once_with(
@@ -188,7 +181,7 @@ def test_generate_calls_generate_codebase_pipeline_config_with_imports(
     ]
     pipelines = Pipelines(**mocks.params())
 
-    pipelines.generate("13", None)
+    pipelines.generate(None)
 
     mock_t_m_p = mocks.mock_terraform_manifest_provider
     mock_t_m_p.generate_codebase_pipeline_config.assert_called_once_with(

--- a/tests/platform_helper/domain/test_pipelines.py
+++ b/tests/platform_helper/domain/test_pipelines.py
@@ -154,7 +154,7 @@ def test_generate_calls_generate_codebase_pipeline_config_with_expected_tpm_vers
     fakefs,
 ):
     cli_platform_helper_version = "13"
-    exp_version = "13"
+    exp_version = "14.0.0"
     app_name = "test-app"
     fakefs.create_file(
         PLATFORM_CONFIG_FILE,
@@ -196,7 +196,7 @@ def test_generate_calls_generate_codebase_pipeline_config_with_imports(
     mock_t_m_p = mocks.mock_terraform_manifest_provider
     mock_t_m_p.generate_codebase_pipeline_config.assert_called_once_with(
         codebase_pipeline_config_for_2_pipelines_and_1_run_group,
-        "13",
+        "14.0.0",
         {"test_codebase": "my-app/test_codebase", "test_codebase_2": "my-app/test_codebase_2"},
         "uktrade/my-app-deploy",
     )

--- a/tests/platform_helper/domain/test_pipelines.py
+++ b/tests/platform_helper/domain/test_pipelines.py
@@ -11,7 +11,6 @@ from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.domain.pipelines import Pipelines
 from dbt_platform_helper.providers.config import ConfigProvider
 from dbt_platform_helper.providers.config_validator import ConfigValidator
-from dbt_platform_helper.providers.semantic_version import SemanticVersion
 
 
 class PipelineMocks:
@@ -29,9 +28,7 @@ class PipelineMocks:
         )
         self.mock_ecr_provider.get_ecr_repo_names.return_value = []
         self.platform_helper_versioning = Mock()
-        self.platform_helper_versioning.get_required_platform_helper_version.return_value = (
-            SemanticVersion(14, 0, 0)
-        )
+        self.platform_helper_versioning.get_required_platform_helper_version.return_value = "14.0.0"
 
     def params(self):
         return {

--- a/tests/platform_helper/domain/test_pipelines.py
+++ b/tests/platform_helper/domain/test_pipelines.py
@@ -11,6 +11,7 @@ from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.domain.pipelines import Pipelines
 from dbt_platform_helper.providers.config import ConfigProvider
 from dbt_platform_helper.providers.config_validator import ConfigValidator
+from dbt_platform_helper.providers.semantic_version import SemanticVersion
 
 
 class PipelineMocks:
@@ -27,6 +28,10 @@ class PipelineMocks:
             f"arn:aws:codestar-connections:eu-west-2:1234567:connection/{app_name}"
         )
         self.mock_ecr_provider.get_ecr_repo_names.return_value = []
+        self.platform_helper_versioning = Mock()
+        self.platform_helper_versioning.get_required_platform_helper_version.return_value = (
+            SemanticVersion(14, 0, 0)
+        )
 
     def params(self):
         return {
@@ -36,6 +41,7 @@ class PipelineMocks:
             "io": self.io,
             "get_git_remote": self.mock_git_remote,
             "get_codestar_arn": self.mock_codestar,
+            "platform_helper_versioning": self.platform_helper_versioning,
         }
 
 

--- a/tests/platform_helper/domain/test_terraform_environment.py
+++ b/tests/platform_helper/domain/test_terraform_environment.py
@@ -16,11 +16,11 @@ class TestGenerateTerraform:
             "deploy": {"name": "non-prod-acc", "id": "1122334455"},
             "dns": {"name": "non-prod-dns-acc", "id": "6677889900"},
         },
-        "versions": {"terraform-platform-modules": "123456"},
     }
 
     VALID_ENRICHED_CONFIG = {
         "application": "test-app",
+        "default_versions": {"platform-helper": "14.0.0"},
         "environments": {"test": VALID_ENV_CONFIG},
     }
 
@@ -41,7 +41,7 @@ class TestGenerateTerraform:
 
     def test_generate_success(self):
         environment_name = "test"
-        cli_platform_helper_version = "14.0.0"
+        platform_helper_version = "14.0.0"
 
         mock_manifest_provider = Mock(spec=TerraformManifestProvider)
 
@@ -54,8 +54,8 @@ class TestGenerateTerraform:
             io=Mock(),
         )
 
-        terraform_environment.generate(environment_name, cli_platform_helper_version)
+        terraform_environment.generate(environment_name)
 
         mock_manifest_provider.generate_environment_config.assert_called_once_with(
-            self.VALID_ENRICHED_CONFIG, environment_name, cli_platform_helper_version
+            self.VALID_ENRICHED_CONFIG, environment_name, platform_helper_version
         )

--- a/tests/platform_helper/domain/test_terraform_environment.py
+++ b/tests/platform_helper/domain/test_terraform_environment.py
@@ -41,7 +41,7 @@ class TestGenerateTerraform:
 
     def test_generate_success(self):
         environment_name = "test"
-        tpm_default_version = "123"
+        cli_platform_helper_version = "14.0.0"
 
         mock_manifest_provider = Mock(spec=TerraformManifestProvider)
 
@@ -54,8 +54,8 @@ class TestGenerateTerraform:
             io=Mock(),
         )
 
-        terraform_environment.generate(environment_name, tpm_default_version)
+        terraform_environment.generate(environment_name, cli_platform_helper_version)
 
         mock_manifest_provider.generate_environment_config.assert_called_once_with(
-            self.VALID_ENRICHED_CONFIG, environment_name, tpm_default_version
+            self.VALID_ENRICHED_CONFIG, environment_name, cli_platform_helper_version
         )

--- a/tests/platform_helper/domain/test_terraform_environment.py
+++ b/tests/platform_helper/domain/test_terraform_environment.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from dbt_platform_helper.domain.terraform_environment import TerraformEnvironment
+from dbt_platform_helper.domain.versioning import PlatformHelperVersionNotFoundException
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.config import ConfigProvider
 from dbt_platform_helper.providers.terraform_manifest import TerraformManifestProvider
@@ -24,6 +25,11 @@ class TestGenerateTerraform:
         "environments": {"test": VALID_ENV_CONFIG},
     }
 
+    INVALID_ENRICHED_CONFIG = {
+        "application": "test-app",
+        "environments": {"test": VALID_ENV_CONFIG},
+    }
+
     def test_raises_a_platform_exception_if_environment_does_not_exist_in_config(self):
         mock_config_provider = Mock(spec=ConfigProvider)
         mock_config_provider.get_enriched_config.return_value = self.VALID_ENRICHED_CONFIG
@@ -38,6 +44,23 @@ class TestGenerateTerraform:
             match="cannot generate terraform for environment not-an-environment.  It does not exist in your configuration",
         ):
             terraform_environment.generate("not-an-environment")
+
+    def test_terraform_environment_raises_a_platform_helper_version_not_found_exception_if_default_versions_is_empty_in_config(
+        self,
+    ):
+        mock_config_provider = Mock(spec=ConfigProvider)
+        mock_config_provider.get_enriched_config.return_value = self.INVALID_ENRICHED_CONFIG
+
+        terraform_environment = TerraformEnvironment(
+            config_provider=mock_config_provider,
+            manifest_provider=Mock(),
+            io=Mock(),
+        )
+        with pytest.raises(
+            PlatformHelperVersionNotFoundException,
+            match="cannot find 'platform-helper' in 'default_versions' in the platform-config.yml file.",
+        ):
+            terraform_environment.generate("test")
 
     def test_generate_success(self):
         environment_name = "test"

--- a/tests/platform_helper/providers/test_version_status.py
+++ b/tests/platform_helper/providers/test_version_status.py
@@ -1,10 +1,7 @@
-from unittest.mock import Mock
-
 import pytest
 
 from dbt_platform_helper.providers.semantic_version import SemanticVersion
 from dbt_platform_helper.providers.version_status import PlatformHelperVersionStatus
-from dbt_platform_helper.providers.version_status import UnsupportedVersionException
 from dbt_platform_helper.providers.version_status import VersionStatus
 
 
@@ -60,69 +57,69 @@ class TestPlatformHelperVersionStatus:
             == "PlatformHelperVersionStatus: installed: 1.2.0, latest: 1.2.3, deprecated_version_file: 1.1.1, platform_config_default: 1.0.0, cli_override: 2.0.0"
         )
 
-    @pytest.mark.parametrize(
-        "cli_version, config_version, expected",
-        [
-            ("14.0.0", "12.0.0", "14.0.0"),
-            (None, "14.0.0", "14.0.0"),
-            ("", "14.0.0", "14.0.0"),
-            ("14.0.0", None, "14.0.0"),
-            ("14.0.0", "", "14.0.0"),
-        ],
-    )
-    def test_get_required_platform_helper_version_valid_sources(
-        self, cli_version, config_version, expected
-    ):
-        mock_io = Mock()
+    # @pytest.mark.parametrize(
+    #     "cli_version, config_version, expected",
+    #     [
+    #         ("14.0.0", "12.0.0", "14.0.0"),
+    #         (None, "14.0.0", "14.0.0"),
+    #         ("", "14.0.0", "14.0.0"),
+    #         ("14.0.0", None, "14.0.0"),
+    #         ("14.0.0", "", "14.0.0"),
+    #     ],
+    # )
+    # def test_get_required_platform_helper_version_valid_sources(
+    #     self, cli_version, config_version, expected
+    # ):
+    #     mock_io = Mock()
 
-        result = PlatformHelperVersionStatus(
-            cli_override=cli_version, platform_config_default=config_version
-        ).get_required_platform_helper_version(mock_io)
+    #     result = PlatformHelperVersionStatus(
+    #         cli_override=cli_version, platform_config_default=config_version
+    #     ).get_required_platform_helper_version(mock_io)
 
-        assert result == expected, f"Expected {expected}, but got {result}"
+    #     assert result == expected, f"Expected {expected}, but got {result}"
 
-    @pytest.mark.parametrize(
-        "cli_version, config_version",
-        [
-            ("", ""),
-            (None, None),
-            ("", None),
-            (None, ""),
-        ],
-    )
-    def test_get_required_platform_helper_version_when_no_valid_source(
-        self, cli_version, config_version
-    ):
-        mock_io = Mock()
+    # @pytest.mark.parametrize(
+    #     "cli_version, config_version",
+    #     [
+    #         ("", ""),
+    #         (None, None),
+    #         ("", None),
+    #         (None, ""),
+    #     ],
+    # )
+    # def test_get_required_platform_helper_version_when_no_valid_source(
+    #     self, cli_version, config_version
+    # ):
+    #     mock_io = Mock()
 
-        PlatformHelperVersionStatus(
-            cli_override=cli_version, platform_config_default=config_version
-        ).get_required_platform_helper_version(mock_io)
+    #     PlatformHelperVersionStatus(
+    #         cli_override=cli_version, platform_config_default=config_version
+    #     ).get_required_platform_helper_version(mock_io)
 
-        mock_io.warn.assert_called_once_with(
-            "No platform-helper version specified. No value was provided via CLI, nor was one found in platform-config.yml under `default_versions`."
-        )
+    #     mock_io.warn.assert_called_once_with(
+    #         "No platform-helper version specified. No value was provided via CLI, nor was one found in platform-config.yml under `default_versions`."
+    #     )
 
-    @pytest.mark.parametrize(
-        "cli_version, config_version, deprecated_version",
-        [
-            ("13.0.0", None, None),
-            (None, "13.0.0", None),
-            (None, None, "13.0.0"),
-        ],
-    )
-    def test_get_required_platform_helper_version_errors_when_version_below_14(
-        self, cli_version, config_version, deprecated_version
-    ):
-        mock_io = Mock()
+    # @pytest.mark.parametrize(
+    #     "cli_version, config_version, deprecated_version",
+    #     [
+    #         ("13.0.0", None, None),
+    #         (None, "13.0.0", None),
+    #         (None, None, "13.0.0"),
+    #     ],
+    # )
+    # def test_get_required_platform_helper_version_errors_when_version_below_14(
+    #     self, cli_version, config_version, deprecated_version
+    # ):
+    #     mock_io = Mock()
 
-        with pytest.raises(UnsupportedVersionException):
-            PlatformHelperVersionStatus(
-                cli_override=cli_version,
-                platform_config_default=config_version,
-                deprecated_version_file=deprecated_version,
-            ).get_required_platform_helper_version(mock_io)
+    #     with pytest.raises(UnsupportedVersionException):
+    #         PlatformHelperVersionStatus(
+    #             cli_override=cli_version,
+    #             platform_config_default=config_version,
+    #             deprecated_version_file=deprecated_version,
+    #         ).get_required_platform_helper_version(mock_io)
 
-            mock_io.error.assert_called_once_with(
-                "Platform-helper version 13.0.0 is not compatible with platform-helper. Please install version platform-helper version 14 or later."
-            )
+    #         mock_io.error.assert_called_once_with(
+    #             "Platform-helper version 13.0.0 is not compatible with platform-helper. Please install version platform-helper version 14 or later."
+    #         )

--- a/tests/platform_helper/test_command_environment.py
+++ b/tests/platform_helper/test_command_environment.py
@@ -198,26 +198,8 @@ class TestGenerateTerraform:
     @mock_aws
     @patch("dbt_platform_helper.commands.environment.TerraformEnvironment")
     def test_generate_terraform_success(self, terraform_environment_mock):
-        """Test that given name and platform-helper-version, the generate
-        terraform command calls TerraformEnvironment generate with the expected
-        parameters."""
-
-        mock_terraform_environment_instance = terraform_environment_mock.return_value
-
-        result = CliRunner().invoke(
-            generate_terraform,
-            ["--name", "test", "--platform-helper-version", "14.0.0"],
-        )
-
-        assert result.exit_code == 0
-
-        mock_terraform_environment_instance.generate.assert_called_with("test", "14.0.0")
-
-    @mock_aws
-    @patch("dbt_platform_helper.commands.environment.TerraformEnvironment")
-    def test_generate_terraform_without_version_flag_success(self, terraform_environment_mock):
         """Test that given name, the generate terraform command calls
-        TerraformEnvironment generate with the expected parameters."""
+        TerraformEnvironment generate with the expected parameter."""
 
         mock_terraform_environment_instance = terraform_environment_mock.return_value
 
@@ -228,7 +210,7 @@ class TestGenerateTerraform:
 
         assert result.exit_code == 0
 
-        mock_terraform_environment_instance.generate.assert_called_with("test", None)
+        mock_terraform_environment_instance.generate.assert_called_with("test")
 
     @mock_aws
     @patch("dbt_platform_helper.commands.environment.TerraformEnvironment")
@@ -244,12 +226,12 @@ class TestGenerateTerraform:
 
         result = CliRunner().invoke(
             generate_terraform,
-            ["--name", "test", "--platform-helper-version", "14.0.0"],
+            ["--name", "test"],
         )
 
         assert result.exit_code == 1
         mock_click.assert_called_with("""Error: i've failed""", err=True, fg="red")
-        mock_terraform_environment_instance.generate.assert_called_with("test", "14.0.0")
+        mock_terraform_environment_instance.generate.assert_called_with("test")
 
     @patch("dbt_platform_helper.commands.environment.TerraformEnvironment")
     @patch("click.secho")
@@ -265,7 +247,7 @@ class TestGenerateTerraform:
 
         result = CliRunner().invoke(
             generate_terraform,
-            ["--name", "test", "--platform-helper-version", "14.0.0"],
+            ["--name", "test"],
         )
 
         assert result.exit_code == 1

--- a/tests/platform_helper/test_command_pipeline.py
+++ b/tests/platform_helper/test_command_pipeline.py
@@ -13,24 +13,8 @@ from tests.platform_helper.conftest import FIXTURES_DIR
 @pytest.mark.parametrize(
     "cli_args, expected_pipeline_args",
     [
-        ([], [None, None]),
-        (
-            [
-                "--platform-helper-version",
-                "14.0.0",
-                "--deploy-branch",
-                "my-branch",
-            ],
-            ["14.0.0", "my-branch"],
-        ),
-        (
-            [
-                "--platform-helper-version",
-                "14.0.0",
-            ],
-            ["14.0.0", None],
-        ),
-        (["--deploy-branch", "my-branch"], [None, "my-branch"]),
+        ([], [None]),
+        (["--deploy-branch", "my-branch"], ["my-branch"]),
     ],
 )
 @patch("dbt_platform_helper.commands.pipeline.Pipelines", return_value="uktrade/test-app-deploy")


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1842.

- Work to remove the override flags and fall back to the version of `platform-helper` defined in the platform-config.yml file:
```
   default_versions:
      platform-helper: 14.0.0
```
- Added exception to the commands to be raised if they cannot find a value for `platform-helper` in `default_versions`

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
