### PR TITLE
fix: Removed unnecessary 'null' from empty values in platform-config. (DBTP-1952)

### DIFF
--- a/dbt_platform_helper/providers/yaml_file.py
+++ b/dbt_platform_helper/providers/yaml_file.py
@@ -56,10 +56,7 @@ class YamlFileProvider:
         with open(path, "w") as file:
             file.write(comment)
             yaml.add_representer(str, account_number_representer)
-            yaml.add_representer(
-                type(None),
-                lambda dumper, data: dumper.represent_scalar("tag:yaml.org,2002:null", ""),
-            )
+            yaml.add_representer(type(None), null_value_representer)
 
             yaml.dump(
                 contents,
@@ -94,3 +91,7 @@ def account_number_representer(dumper, data):
     if just_digits:
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="'")
     return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=None)
+
+
+def null_value_representer(dumper, data):
+    return dumper.represent_scalar("tag:yaml.org,2002:null", "")

--- a/dbt_platform_helper/providers/yaml_file.py
+++ b/dbt_platform_helper/providers/yaml_file.py
@@ -1,4 +1,3 @@
-import re
 from pathlib import Path
 
 import yaml
@@ -87,8 +86,7 @@ class YamlFileProvider:
 
 
 def account_number_representer(dumper, data):
-    just_digits = re.match(r"^[0-9]+$", data)
-    if just_digits:
+    if data.isdigit():
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="'")
     return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=None)
 

--- a/tests/platform_helper/providers/test_yaml_file_provider.py
+++ b/tests/platform_helper/providers/test_yaml_file_provider.py
@@ -64,7 +64,8 @@ opensearch:
 
     YamlFileProvider.write(test_path, test_content, test_comment)
     with open(test_path, "r") as test_yaml_file:
-        assert expected_test_cache_file in test_yaml_file.read()
+        actual_cache_file = test_yaml_file.read()
+        assert expected_test_cache_file in actual_cache_file
 
 
 def test_writes_with_no_comment(fs):
@@ -87,4 +88,31 @@ opensearch:
 
     YamlFileProvider.write(test_path, test_content)
     with open(test_path, "r") as test_yaml_file:
-        assert expected_test_cache_file in test_yaml_file.read()
+        actual_cache_file = test_yaml_file.read()
+        assert expected_test_cache_file in actual_cache_file
+
+
+def test_writes_account_numbers_as_quoted_strings(fs):
+    test_path = "./test"
+    test_content = {
+        "accounts": {
+            "deploy": {"name": "account1", "id": "0123456789"},
+            "dns": {"name": "account2", "id": "9876543210"},
+            "other": None,
+            "one_more": None,
+        }
+    }
+    expected_test_cache_file = """accounts:
+  deploy:
+    name: account1
+    id: '0123456789'
+  dns:
+    name: account2
+    id: '9876543210'
+  other:
+  one_more:
+"""
+
+    YamlFileProvider.write(test_path, test_content)
+    with open(test_path, "r") as test_yaml_file:
+        assert expected_test_cache_file.strip() == test_yaml_file.read().strip()


### PR DESCRIPTION
Fixed issue with missing string quotes for account numbers that start with a 0 thinking they are ints

Addresses https://uktrade.atlassian.net/browse/DBTP-1952

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
