### PR TITLE
chore: Ensure patches are at module level and not global (off-ticket)

### DIFF
--- a/tests/platform_helper/domain/test_codebase.py
+++ b/tests/platform_helper/domain/test_codebase.py
@@ -65,7 +65,7 @@ class CodebaseMocks:
         }
 
 
-@patch("requests.get")
+@patch("dbt_platform_helper.domain.codebase.requests.get")
 def test_codebase_prepare_generates_the_expected_files(mocked_requests_get, tmp_path):
     mocks = CodebaseMocks()
     codebase = Codebase(**mocks.params())

--- a/tests/platform_helper/providers/test_copilot.py
+++ b/tests/platform_helper/providers/test_copilot.py
@@ -271,7 +271,7 @@ def test_create_addon_client_task_does_not_add_execution_role_if_role_not_found(
     )
 
 
-@patch("click.secho")
+@patch("dbt_platform_helper.commands.copilot.click.secho")
 def test_create_addon_client_task_abort_with_message_on_other_exceptions(
     mock_secho,
     mock_application,

--- a/tests/platform_helper/providers/test_ecs.py
+++ b/tests/platform_helper/providers/test_ecs.py
@@ -124,7 +124,7 @@ def test_ecs_exec_is_available(mock_cluster_client_task, mocked_cluster, mock_ap
     )
 
 
-@patch("time.sleep", return_value=None)
+@patch("dbt_platform_helper.providers.ecs.time.sleep", return_value=None)
 @mock_aws
 def test_ecs_exec_is_available_with_exec_not_running_raises_exception(
     sleep, mock_cluster_client_task, mocked_cluster, mock_application

--- a/tests/platform_helper/providers/test_io.py
+++ b/tests/platform_helper/providers/test_io.py
@@ -59,37 +59,37 @@ class TestClickIOProvider:
                 ClickIOProvider().confirm("Is that really your name?")
             assert str(e.value) == "Is that really your name? [y/N]: Error: invalid input"
 
-    @patch("click.secho")
+    @patch("dbt_platform_helper.providers.io.click.secho")
     def test_warn_calls_secho_with_correct_formatting(self, mock_echo):
         io = ClickIOProvider()
         io.warn("Warning!")
         mock_echo.assert_called_once_with("Warning!", fg="magenta")
 
-    @patch("click.secho")
+    @patch("dbt_platform_helper.providers.io.click.secho")
     def test_error_calls_secho_with_correct_formatting(self, mock_echo):
         io = ClickIOProvider()
         io.error("Error!")
         mock_echo.assert_called_once_with("Error: Error!", fg="red")
 
-    @patch("click.secho")
+    @patch("dbt_platform_helper.providers.io.click.secho")
     def test_info_calls_secho_with_correct_formatting(self, mock_echo):
         io = ClickIOProvider()
         io.info("Info.")
         mock_echo.assert_called_once_with("Info.")
 
-    @patch("click.prompt")
+    @patch("dbt_platform_helper.providers.io.click.prompt")
     def test_input(self, mock_prompt):
         io = ClickIOProvider()
         io.input("Please select a service")
         mock_prompt.assert_called_once_with("Please select a service")
 
-    @patch("click.confirm")
+    @patch("dbt_platform_helper.providers.io.click.confirm")
     def test_confirm(self, mock_confirm):
         io = ClickIOProvider()
         io.confirm("Are you sure?")
         mock_confirm.assert_called_once_with("Are you sure?")
 
-    @patch("click.secho")
+    @patch("dbt_platform_helper.providers.io.click.secho")
     def test_info_calls_secho_with_correct_formatting(self, mock_echo):
         io = ClickIOProvider()
         with pytest.raises(SystemExit):
@@ -98,21 +98,21 @@ class TestClickIOProvider:
 
 
 class TestClickIOProviderProcessMessages:
-    @patch("click.secho")
+    @patch("dbt_platform_helper.providers.io.click.secho")
     def test_with_empty_messages(self, mock_echo):
         io = ClickIOProvider()
         messages = {"errors": [], "warnings": [], "info": []}
         io.process_messages(messages)
         mock_echo.assert_not_called()
 
-    @patch("click.secho")
+    @patch("dbt_platform_helper.providers.io.click.secho")
     def test_with_none_messages(self, mock_echo):
         io = ClickIOProvider()
         messages = {"errors": [], "warnings": [], "info": []}
         io.process_messages(None)
         mock_echo.assert_not_called()
 
-    @patch("click.secho")
+    @patch("dbt_platform_helper.providers.io.click.secho")
     def test_echos_populated_messages_with_correct_formatting(self, mock_echo):
         io = ClickIOProvider()
         messages = {

--- a/tests/platform_helper/providers/test_version.py
+++ b/tests/platform_helper/providers/test_version.py
@@ -118,7 +118,7 @@ class TestPyPiLatestVersionProvider:
     ),
 )
 class TestAWSCLIInstalledVersionProvider:
-    @patch("subprocess.run")
+    @patch("dbt_platform_helper.providers.version.subprocess.run")
     def test_get_semantic_version(self, mock_run, mock_run_stdout, expected):
         mock_run.return_value.stdout = mock_run_stdout
 
@@ -138,7 +138,7 @@ class TestCopilotVersioning:
             (b"command not found: copilot", None),
         ),
     )
-    @patch("subprocess.run")
+    @patch("dbt_platform_helper.providers.version.subprocess.run")
     def test_get_semantic_version(self, mock_run, mock_run_stdout, expected):
         mock_run.return_value.stdout = mock_run_stdout
 

--- a/tests/platform_helper/test_command_codebase.py
+++ b/tests/platform_helper/test_command_codebase.py
@@ -44,8 +44,7 @@ class TestCodebasePrepare:
         assert result.exit_code == 0
 
     @patch("dbt_platform_helper.commands.codebase.Codebase")
-    @patch("click.secho")
-    def test_aborts_when_not_in_a_codebase_repository(self, mock_click, mock_codebase_object):
+    def test_aborts_when_not_in_a_codebase_repository(self, mock_codebase_object):
         mock_codebase_object_instance = mock_codebase_object.return_value
         mock_codebase_object_instance.prepare.side_effect = NotInCodeBaseRepositoryException
         os.environ["AWS_PROFILE"] = "foo"

--- a/tests/platform_helper/test_command_codebase.py
+++ b/tests/platform_helper/test_command_codebase.py
@@ -83,9 +83,8 @@ class TestCodebaseBuild:
         assert result.exit_code == 0
 
     @patch("dbt_platform_helper.commands.codebase.Codebase")
-    @patch("click.secho")
     def test_codebase_build_does_not_trigger_build_without_an_application(
-        self, mock_click, mock_codebase_object
+        self, mock_codebase_object
     ):
 
         mock_codebase_object_instance = mock_codebase_object.return_value
@@ -227,8 +226,7 @@ class TestCodebaseList:
         assert result.exit_code == 0
 
     @patch("dbt_platform_helper.commands.codebase.Codebase")
-    @patch("click.secho")
-    def test_aborts_when_application_does_not_exist(self, mock_click, mock_codebase_object):
+    def test_aborts_when_application_does_not_exist(self, mock_codebase_object):
         mock_codebase_object_instance = mock_codebase_object.return_value
         mock_codebase_object_instance.list.side_effect = ApplicationNotFoundException
         os.environ["AWS_PROFILE"] = "foo"

--- a/tests/platform_helper/test_command_conduit.py
+++ b/tests/platform_helper/test_command_conduit.py
@@ -45,7 +45,7 @@ def test_start_conduit(mock_application, validate_version, mock_conduit_object, 
 @patch("dbt_platform_helper.commands.conduit.Conduit")
 @patch("dbt_platform_helper.commands.conduit.load_application")
 @patch("dbt_platform_helper.commands.conduit.PlatformHelperVersioning.check_if_needs_update")
-@patch("click.secho")
+@patch("dbt_platform_helper.commands.conduit.click.secho")
 def test_start_conduit_with_exception_raised_exit_1(
     mock_click,
     validate_version,

--- a/tests/platform_helper/test_command_copilot.py
+++ b/tests/platform_helper/test_command_copilot.py
@@ -56,7 +56,7 @@ class TestMakeAddonsCommand:
     @patch("dbt_platform_helper.commands.copilot.ConfigValidator")
     @patch("dbt_platform_helper.commands.copilot.FileProvider")
     @patch("dbt_platform_helper.commands.copilot.CopilotTemplating")
-    @patch("click.secho")
+    @patch("dbt_platform_helper.commands.copilot.click.secho")
     def test_prints_error_message_if_exception_is_thrown_by_make_addons(
         self,
         mock_click,

--- a/tests/platform_helper/test_command_database.py
+++ b/tests/platform_helper/test_command_database.py
@@ -289,7 +289,7 @@ def test_command_copy_success_with_maintenance_page(mock_database_copy_object):
 
 
 @patch("dbt_platform_helper.commands.database.DatabaseCopy")
-@patch("click.secho")
+@patch("dbt_platform_helper.commands.database.click.secho")
 def test_command_copy_raises_platform_exception(mock_click, mock_database_copy_object):
     mock_database_copy_instance = mock_database_copy_object.return_value
     mock_database_copy_instance.copy.side_effect = PlatformException("i've failed")
@@ -328,7 +328,7 @@ def test_command_copy_raises_platform_exception(mock_click, mock_database_copy_o
 
 
 @patch("dbt_platform_helper.commands.database.DatabaseCopy")
-@patch("click.secho")
+@patch("dbt_platform_helper.commands.database.click.secho")
 def test_command_load_raises_platform_exception(mock_click, mock_database_copy_object):
     mock_database_copy_instance = mock_database_copy_object.return_value
     mock_database_copy_instance.load.side_effect = PlatformException("i've failed")
@@ -355,7 +355,7 @@ def test_command_load_raises_platform_exception(mock_click, mock_database_copy_o
 
 
 @patch("dbt_platform_helper.commands.database.DatabaseCopy")
-@patch("click.secho")
+@patch("dbt_platform_helper.commands.database.click.secho")
 def test_command_dump_raises_platform_exception(mock_click, mock_database_copy_object):
     mock_database_copy_instance = mock_database_copy_object.return_value
     mock_database_copy_instance.dump.side_effect = PlatformException("i've failed")

--- a/tests/platform_helper/test_command_environment.py
+++ b/tests/platform_helper/test_command_environment.py
@@ -32,7 +32,7 @@ class TestMaintenancePage:
         mock_maintenance_page_instance.deactivate.assert_called_with("test-env")
 
     @patch("dbt_platform_helper.commands.environment.MaintenancePage")
-    @patch("click.secho")
+    @patch("dbt_platform_helper.commands.environment.click.secho")
     @patch("dbt_platform_helper.commands.environment.load_application")
     def test_online_failure(
         self, load_application, mock_click, mock_maintenance_page, mock_application
@@ -88,7 +88,7 @@ class TestMaintenancePage:
         )
 
     @patch("dbt_platform_helper.commands.environment.MaintenancePage")
-    @patch("click.secho")
+    @patch("dbt_platform_helper.commands.environment.click.secho")
     @patch("dbt_platform_helper.commands.environment.load_application")
     def test_offline_failure(
         self, load_application, mock_click, mock_maintenance_page, mock_application
@@ -170,7 +170,7 @@ class TestGenerateCopilot:
 
     @patch("dbt_platform_helper.commands.environment.CopilotEnvironment")
     @patch("dbt_platform_helper.commands.environment.get_aws_session_or_abort")
-    @patch("click.secho")
+    @patch("dbt_platform_helper.commands.environment.click.secho")
     def test_generate_copilot_catches_platform_exception_and_exits(
         self, mock_click, mock_session, copilot_environment_mock
     ):
@@ -214,7 +214,7 @@ class TestGenerateTerraform:
 
     @mock_aws
     @patch("dbt_platform_helper.commands.environment.TerraformEnvironment")
-    @patch("click.secho")
+    @patch("dbt_platform_helper.commands.environment.click.secho")
     def test_generate_terraform_catches_platform_exception_and_exits(
         self, mock_click, terraform_environment_mock
     ):
@@ -234,7 +234,7 @@ class TestGenerateTerraform:
         mock_terraform_environment_instance.generate.assert_called_with("test")
 
     @patch("dbt_platform_helper.commands.environment.TerraformEnvironment")
-    @patch("click.secho")
+    @patch("dbt_platform_helper.commands.environment.click.secho")
     @patch("dbt_platform_helper.commands.environment.get_aws_session_or_abort")
     def test_generate_terraform_sso_token_expired(
         self, mock_session, mock_click, terraform_environment_mock

--- a/tests/platform_helper/utils/test_aws.py
+++ b/tests/platform_helper/utils/test_aws.py
@@ -51,7 +51,7 @@ def get_mock_session(name):
     return session
 
 
-@patch("boto3.session.Session")
+@patch("dbt_platform_helper.utils.aws.boto3.session.Session")
 def test_get_aws_session_caches_sessions_per_profile(mock_session):
     mock_session.side_effect = (get_mock_session("one"), get_mock_session("two"))
     session1 = get_aws_session_or_abort()
@@ -118,8 +118,8 @@ def test_get_ssm_secrets(mock_get_aws_session_or_abort):
     ],
 )
 @patch("dbt_platform_helper.utils.aws.get_account_details")
-@patch("boto3.session.Session")
-@patch("click.secho")
+@patch("dbt_platform_helper.utils.aws.boto3.session.Session")
+@patch("dbt_platform_helper.utils.aws.click.secho")
 def test_get_aws_session_or_abort_errors(
     mock_secho,
     mock_session,
@@ -141,8 +141,8 @@ def test_get_aws_session_or_abort_errors(
     assert mock_secho.call_args[0][0] == expected_error_message
 
 
-@patch("boto3.session.Session")
-@patch("click.secho")
+@patch("dbt_platform_helper.utils.aws.boto3.session.Session")
+@patch("dbt_platform_helper.utils.aws.click.secho")
 def test_get_aws_session_or_abort_with_misconfigured_profile(mock_secho, mock_session):
     misconfigured_profile = "nonexistent_profile"
     expected_error_message = f"""AWS profile "{misconfigured_profile}" is not configured."""

--- a/tests/platform_helper/utils/test_git.py
+++ b/tests/platform_helper/utils/test_git.py
@@ -23,7 +23,7 @@ def test_extract_repository_name_from_https_clone():
     assert result == "uktrade/platform-tools"
 
 
-@patch("subprocess.run")
+@patch("dbt_platform_helper.utils.git.subprocess.run")
 def test_repository_name_fetched_from_subprocess(subprocess_run):
     mock_stdout = Mock(**{"stdout.strip.return_value": "https://github.com/testorg/testrepo.git"})
     subprocess_run.return_value = mock_stdout

--- a/tests/utils/test_publish_notifications.py
+++ b/tests/utils/test_publish_notifications.py
@@ -17,7 +17,7 @@ class FakeOpts:
         self.__dict__ = data
 
 
-@patch("subprocess.run")
+@patch("utils.notify.publish_notification.subprocess.run")
 class TestPublishNotify(unittest.TestCase):
     def setUp(self):
         os.environ["SLACK_TOKEN"] = "slack-token"


### PR DESCRIPTION
Off-ticket clean up task.  [Patches should not be defined globally](https://pytest-with-eric.com/mocking/pytest-common-mocking-problems/#Confusing-or-Incorrect-Patch-Targets-Lead-To-False-Positives-or-Brittle-Tests) as this can cause unintended mocking if the patched function or class is called in other tests simultaneously.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [x] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
