### PR TITLE
fix: Do not validate config in the version command (DBTP-2016)

### DIFF
--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -50,7 +50,7 @@ class PlatformHelperVersioning:
         )
 
     def get_required_version(self):
-        platform_config = self.config_provider.load_and_validate_platform_config()
+        platform_config = self.config_provider.load_unvalidated_config_file()
         required_version = platform_config.get("default_versions", {}).get("platform-helper")
         self.io.info(required_version)
         return required_version

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -45,6 +45,7 @@ def mocks():
 
     mocks = PlatformHelperVersioningMocks()
     mocks.config_provider.load_and_validate_platform_config.return_value = platform_config
+    mocks.config_provider.load_unvalidated_config_file.return_value = platform_config
     return mocks
 
 
@@ -76,6 +77,8 @@ class TestPlatformHelperVersioningGetRequiredVersion:
         result = PlatformHelperVersioning(**mocks.params()).get_required_version()
 
         assert str(result) == "1.0.0"
+        mocks.config_provider.load_unvalidated_config_file.assert_called_once()
+        mocks.config_provider.load_and_validate_platform_config.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-2016

Stop validating the config in the version command

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
