### PR TITLE
ci: Add explicit permissions on GitHub Actions workflows (off-ticket)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,6 +5,8 @@ on: [push]
 jobs:
   lint:
     name: Run lint checks
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,8 @@ on: [push]
 jobs:
   tests:
     name: Test platform-helper against Python ${{ matrix.python-version }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     strategy:
@@ -50,6 +52,8 @@ jobs:
 
   terraform_python_tests:
     name: Test terraform python code against Python ${{ matrix.python-version }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   trigger:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Resolves the following code scanning alert:

    If a GitHub Actions job or workflow has no explicit permissions set,
    then the repository permissions are used. Repositories created under
    organizations inherit the organization permissions. The organizations
    or repositories created before February 2023 have the default
    permissions set to read-write. Often these permissions do not adhere
    to the principle of least privilege and can be reduced to read-only,
    leaving the write permission only to a specific types as
    `issues: write` or `pull-requests: write`.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
