### PR TITLE
feat: Update platform schema to include service deployment mode (DBTP-2152)

### DIFF
--- a/dbt_platform_helper/entities/platform_config_schema.py
+++ b/dbt_platform_helper/entities/platform_config_schema.py
@@ -196,7 +196,10 @@ class PlatformConfigSchema:
                     Optional("requires_approval"): bool,
                     Optional("vpc"): str,
                     Optional("service-deployment-mode"): Or(
-                        "copilot", "dual-copilot-traffic", "dual-platform-traffic", "platform"
+                        "copilot",
+                        "dual-deploy-copilot-traffic",
+                        "dual-deploy-platform-traffic",
+                        "platform",
                     ),
                 },
             )

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -419,9 +419,9 @@ environments:
     requires_approval: false
     vpc: non-prod-vpc
   dev: 
-    service-deployment-mode: dual-copilot-traffic
+    service-deployment-mode: dual-deploy-copilot-traffic
   test:
-    service-deployment-mode: dual-platform-traffic
+    service-deployment-mode: dual-deploy-platform-traffic
   staging:
     service-deployment-mode: platform
   hotfix:

--- a/tests/platform_helper/providers/test_config.py
+++ b/tests/platform_helper/providers/test_config.py
@@ -491,8 +491,12 @@ class TestDataMigrationValidation:
             config_provider._validate_platform_config()
 
         assert "'copilot' does not match 'something we dont want'" in str(exc.value)
-        assert "'dual-copilot-traffic' does not match 'something we dont want'" in str(exc.value)
-        assert "'dual-platform-traffic' does not match 'something we dont want'" in str(exc.value)
+        assert "'dual-deploy-copilot-traffic' does not match 'something we dont want'" in str(
+            exc.value
+        )
+        assert "'dual-deploy-platform-traffic' does not match 'something we dont want'" in str(
+            exc.value
+        )
         assert "'platform' does not match 'something we dont want'" in str(exc.value)
 
 


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-2152.

Update the platform config schema to have a service-deployment-mode option in the environments section.
---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
