### PR TITLE
fix: Add CreateCluster permission (off-ticket)

### DIFF
--- a/terraform/environment-pipelines/iam.tf
+++ b/terraform/environment-pipelines/iam.tf
@@ -794,6 +794,7 @@ data "aws_iam_policy_document" "ecs" {
     sid = "AllowECSClusterCreate"
     actions = [
       "ecs:CreateCluster",
+      "ecs:TagResource"
     ]
     resources = [
       "arn:aws:ecs:${local.account_region}:cluster/",

--- a/terraform/environment-pipelines/iam.tf
+++ b/terraform/environment-pipelines/iam.tf
@@ -794,7 +794,8 @@ data "aws_iam_policy_document" "ecs" {
     sid = "AllowECSClusterCreate"
     actions = [
       "ecs:CreateCluster",
-      "ecs:TagResource"
+      "ecs:TagResource",
+      "ecs:DescribeClusters",
     ]
     resources = [
       "arn:aws:ecs:${local.account_region}:cluster/",

--- a/terraform/environment-pipelines/iam.tf
+++ b/terraform/environment-pipelines/iam.tf
@@ -796,7 +796,8 @@ data "aws_iam_policy_document" "ecs" {
       "ecs:CreateCluster",
       "ecs:TagResource",
       "ecs:DescribeClusters",
-      "ecs:DeleteCluster"
+      "ecs:DeleteCluster",
+      "ecs:PutClusterCapacityProviders",
     ]
     resources = [
       "arn:aws:ecs:${local.account_region}:cluster/",

--- a/terraform/environment-pipelines/iam.tf
+++ b/terraform/environment-pipelines/iam.tf
@@ -791,7 +791,7 @@ resource "aws_iam_policy" "s3" {
 data "aws_iam_policy_document" "ecs" {
   # New ECS cluster perms here:
   statement {
-    sid = "AllowTaskDefinitionsRead"
+    sid = "AllowECSClusterCreate"
     actions = [
       "ecs:CreateCluster",
     ]

--- a/terraform/environment-pipelines/iam.tf
+++ b/terraform/environment-pipelines/iam.tf
@@ -788,6 +788,26 @@ resource "aws_iam_policy" "s3" {
   policy      = data.aws_iam_policy_document.s3.json
 }
 
+data "aws_iam_policy_document" "platform-ecs" {
+  statement {
+    sid = "AllowTaskDefinitionsRead"
+    actions = [
+      "ecs:CreateCluster",
+    ]
+    resources = [
+      "arn:aws:ecs:${local.account_region}:cluster/",
+      "arn:aws:ecs:${local.account_region}:cluster/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "platform-ecs" {
+  name        = "${var.application}-${var.pipeline_name}-pipeline-platform-ecs-access"
+  path        = "/${var.application}/codebuild/"
+  description = "Allow ${var.application} codebuild job to access ecs resources"
+  policy      = data.aws_iam_policy_document.platform-ecs.json
+}
+
 data "aws_iam_policy_document" "ecs" {
   statement {
     sid = "AllowTaskDefinitionsRead"
@@ -1212,6 +1232,11 @@ resource "aws_iam_role_policy_attachment" "attach_s3_policy" {
 resource "aws_iam_role_policy_attachment" "attach_ecs_policy" {
   role       = aws_iam_role.environment_pipeline_codebuild.name
   policy_arn = aws_iam_policy.ecs.arn
+}
+
+resource "aws_iam_role_policy_attachment" "attach_platform_ecs_policy" {
+  role       = aws_iam_role.environment_pipeline_codebuild.name
+  policy_arn = aws_iam_policy.platform-ecs.arn
 }
 
 resource "aws_iam_role_policy_attachment" "attach_origin_secret_rotate_policy" {

--- a/terraform/environment-pipelines/iam.tf
+++ b/terraform/environment-pipelines/iam.tf
@@ -800,8 +800,8 @@ data "aws_iam_policy_document" "ecs" {
       "ecs:PutClusterCapacityProviders",
     ]
     resources = [
-      "arn:aws:ecs:${local.account_region}:cluster/",
-      "arn:aws:ecs:${local.account_region}:cluster/*"
+      for env in local.environment_config :
+      "arn:aws:ecs:${local.account_region}:cluster/${var.application}-${env.name}-cluster"
     ]
   }
 

--- a/terraform/environment-pipelines/iam.tf
+++ b/terraform/environment-pipelines/iam.tf
@@ -788,7 +788,8 @@ resource "aws_iam_policy" "s3" {
   policy      = data.aws_iam_policy_document.s3.json
 }
 
-data "aws_iam_policy_document" "platform-ecs" {
+data "aws_iam_policy_document" "ecs" {
+  # New ECS cluster perms here:
   statement {
     sid = "AllowTaskDefinitionsRead"
     actions = [
@@ -799,16 +800,8 @@ data "aws_iam_policy_document" "platform-ecs" {
       "arn:aws:ecs:${local.account_region}:cluster/*"
     ]
   }
-}
 
-resource "aws_iam_policy" "platform-ecs" {
-  name        = "${var.application}-${var.pipeline_name}-pipeline-platform-ecs-access"
-  path        = "/${var.application}/codebuild/"
-  description = "Allow ${var.application} codebuild job to access ecs resources"
-  policy      = data.aws_iam_policy_document.platform-ecs.json
-}
-
-data "aws_iam_policy_document" "ecs" {
+  # Old Copilot ECS cluster perms below:
   statement {
     sid = "AllowTaskDefinitionsRead"
     actions = [
@@ -1232,11 +1225,6 @@ resource "aws_iam_role_policy_attachment" "attach_s3_policy" {
 resource "aws_iam_role_policy_attachment" "attach_ecs_policy" {
   role       = aws_iam_role.environment_pipeline_codebuild.name
   policy_arn = aws_iam_policy.ecs.arn
-}
-
-resource "aws_iam_role_policy_attachment" "attach_platform_ecs_policy" {
-  role       = aws_iam_role.environment_pipeline_codebuild.name
-  policy_arn = aws_iam_policy.platform-ecs.arn
 }
 
 resource "aws_iam_role_policy_attachment" "attach_origin_secret_rotate_policy" {

--- a/terraform/environment-pipelines/iam.tf
+++ b/terraform/environment-pipelines/iam.tf
@@ -796,6 +796,7 @@ data "aws_iam_policy_document" "ecs" {
       "ecs:CreateCluster",
       "ecs:TagResource",
       "ecs:DescribeClusters",
+      "ecs:DeleteCluster"
     ]
     resources = [
       "arn:aws:ecs:${local.account_region}:cluster/",


### PR DESCRIPTION
Environment pipeline can't currently deploy the new ECS cluster.

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- ~[ ] Link to ticket included (unless it's a quick out of ticket thing)~
- ~[ ] Includes tests (or an explanation for why it doesn't)~
- ~[ ] If the work includes user interface changes, before and after screenshots included in description~
- ~[ ] Includes any applicable changes to the documentation in this code base~
- ~[ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentatio`n](https://platform.readme.trade.gov.uk/) (can be to a pull request)~

### Tasks:
- [x] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
