### PR TITLE
fix: Handle missing ssm permission when getting environment details (off-ticket)

### DIFF
--- a/dbt_platform_helper/utils/aws.py
+++ b/dbt_platform_helper/utils/aws.py
@@ -158,7 +158,17 @@ def get_ssm_secrets(app, env, session=None, path=None):
     secrets = []
 
     while True:
-        response = client.get_parameters_by_path(**params)
+        try:
+            response = client.get_parameters_by_path(**params)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "AccessDeniedException":
+                click.secho(
+                    "Access denied on SSM, due to missing permissions. Please update your environment infrastructure.",
+                    fg="magenta",
+                )
+                break
+            else:
+                raise e
 
         for secret in response["Parameters"]:
             secrets.append((secret["Name"], secret["Value"]))


### PR DESCRIPTION
Handle missing ssm permission when calling `GetParametersByPath` for data copy, if the environmnet infrastructure (terraform) hasn't been updated.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- ~[ ] Link to ticket included (unless it's a quick out of ticket thing)~
- [x] Includes tests (or an explanation for why it doesn't)
- ~[ ] If the work includes user interface changes, before and after screenshots included in description~
- ~[ ] Includes any applicable changes to the documentation in this code base~
- ~[ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~

### Tasks:
- [x] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
