### PR TITLE
fix: Give permission for DataDog process level resource monitoring (DBTP-2238)

### DIFF
--- a/dbt_platform_helper/templates/svc/overrides/cfn.patches.yml
+++ b/dbt_platform_helper/templates/svc/overrides/cfn.patches.yml
@@ -24,3 +24,8 @@
     Condition:
       StringEquals:
           'ssm:ResourceTag/copilot-application': '__all__'
+
+- op: add
+  path: /Resources/TaskDefinition/Properties/pidMode
+  value:
+    task

--- a/tests/platform_helper/fixtures/make_addons/expected/web/overrides/cfn.patches.yml
+++ b/tests/platform_helper/fixtures/make_addons/expected/web/overrides/cfn.patches.yml
@@ -24,3 +24,8 @@
     Condition:
       StringEquals:
           'ssm:ResourceTag/copilot-application': '__all__'
+
+- op: add
+  path: /Resources/TaskDefinition/Properties/pidMode
+  value:
+    task


### PR DESCRIPTION
This is currently performed as a manual step each time Datadog is added into deploy repo files, but is then overwritten again when platform-helper generate command runs.



---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
