### PR TITLE
fix: Allow multiple destination environments for a database copy pipeline (off-ticket)

### DIFF
--- a/terraform/postgres/database-dump/main.tf
+++ b/terraform/postgres/database-dump/main.tf
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "assume_ecs_task_role" {
   dynamic "statement" {
     for_each = local.pipeline_tasks
     content {
-      sid    = "AllowPipelineAssumeRole-${statement.value.to}"
+      sid    = "AllowPipelineAssumeRole${title(statement.value.to)}"
       effect = "Allow"
 
       principals {

--- a/terraform/postgres/database-dump/main.tf
+++ b/terraform/postgres/database-dump/main.tf
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "assume_ecs_task_role" {
   dynamic "statement" {
     for_each = local.pipeline_tasks
     content {
-      sid    = "AllowPipelineAssumeRole"
+      sid    = "AllowPipelineAssumeRole-${statement.value.to}"
       effect = "Allow"
 
       principals {

--- a/terraform/postgres/database-dump/tests/unit.tftest.hcl
+++ b/terraform/postgres/database-dump/tests/unit.tftest.hcl
@@ -423,8 +423,8 @@ run "pipeline_unit_test" {
     error_message = "Should contain: scheduler.amazonaws.com"
   }
   assert {
-    condition     = data.aws_iam_policy_document.assume_ecs_task_role.statement[1].sid == "AllowPipelineAssumeRole-dev"
-    error_message = "Statement ID not found: AllowPipelineAssumeRole-dev"
+    condition     = data.aws_iam_policy_document.assume_ecs_task_role.statement[1].sid == "AllowPipelineAssumeRoleDev"
+    error_message = "Statement ID not found: AllowPipelineAssumeRoleDev"
   }
   assert {
     condition     = data.aws_iam_policy_document.assume_ecs_task_role.statement[2].effect == "Allow"
@@ -443,8 +443,8 @@ run "pipeline_unit_test" {
     error_message = "Should contain: scheduler.amazonaws.com"
   }
   assert {
-    condition     = data.aws_iam_policy_document.assume_ecs_task_role.statement[2].sid == "AllowPipelineAssumeRole-staging"
-    error_message = "Statement ID not found: AllowPipelineAssumeRole-staging"
+    condition     = data.aws_iam_policy_document.assume_ecs_task_role.statement[2].sid == "AllowPipelineAssumeRoleStaging"
+    error_message = "Statement ID not found: AllowPipelineAssumeRoleStaging"
   }
   assert {
     condition     = aws_iam_role_policy.allow_pipeline_access[""].name == "AllowPipelineAccess"

--- a/terraform/postgres/database-dump/tests/unit.tftest.hcl
+++ b/terraform/postgres/database-dump/tests/unit.tftest.hcl
@@ -2,12 +2,14 @@ variables {
   application   = "test-app"
   environment   = "test-env"
   database_name = "test-db"
-  tasks = [{
-    from : "staging"
-    from_account = "000123456789"
-    to : "dev"
-    to_account = "000123456789"
-  }]
+  tasks = [
+    {
+      from         = "staging"
+      from_account = "000123456789"
+      to           = "dev"
+      to_account   = "000123456789"
+    }
+  ]
 }
 
 mock_provider "aws" {}
@@ -344,12 +346,14 @@ run "cross_account_data_dump_unit_test" {
   command = plan
 
   variables {
-    tasks = [{
-      from : "dev"
-      from_account : "000123456789"
-      to : "hotfix"
-      to_account : "123456789000"
-    }]
+    tasks = [
+      {
+        from         = "dev"
+        from_account = "000123456789"
+        to           = "hotfix"
+        to_account   = "123456789000"
+      }
+    ]
   }
 
   assert {
@@ -379,19 +383,29 @@ run "pipeline_unit_test" {
   command = plan
 
   variables {
-    tasks = [{
-      from : "prod"
-      from_account : "123456789000"
-      to : "dev"
-      to_account : "000123456789"
-      pipeline : {}
-    }]
+    tasks = [
+      {
+        from         = "prod"
+        from_account = "123456789000"
+        to           = "dev"
+        to_account   = "000123456789"
+        pipeline     = {}
+      },
+      {
+        from         = "prod"
+        from_account = "123456789000"
+        to           = "staging"
+        to_account   = "000123456789"
+        pipeline     = {}
+      }
+    ]
   }
 
   assert {
-    condition     = length(local.pipeline_tasks) == 1
-    error_message = "There should be 1 pipeline task"
+    condition     = length(local.pipeline_tasks) == 2
+    error_message = "There should be 2 pipeline tasks"
   }
+
   assert {
     condition     = data.aws_iam_policy_document.assume_ecs_task_role.statement[1].effect == "Allow"
     error_message = "Should be: Allow"
@@ -407,6 +421,30 @@ run "pipeline_unit_test" {
   assert {
     condition     = contains(one(data.aws_iam_policy_document.assume_ecs_task_role.statement[1].principals).identifiers, "arn:aws:iam::000123456789:role/test-db-prod-to-dev-copy-pipeline-codebuild")
     error_message = "Should contain: scheduler.amazonaws.com"
+  }
+  assert {
+    condition     = data.aws_iam_policy_document.assume_ecs_task_role.statement[1].sid == "AllowPipelineAssumeRole-dev"
+    error_message = "Statement ID not found: AllowPipelineAssumeRole-dev"
+  }
+  assert {
+    condition     = data.aws_iam_policy_document.assume_ecs_task_role.statement[2].effect == "Allow"
+    error_message = "Should be: Allow"
+  }
+  assert {
+    condition     = one(data.aws_iam_policy_document.assume_ecs_task_role.statement[2].actions) == "sts:AssumeRole"
+    error_message = "Should be: sts:AssumeRole"
+  }
+  assert {
+    condition     = one(data.aws_iam_policy_document.assume_ecs_task_role.statement[2].principals).type == "AWS"
+    error_message = "Should be: AWS"
+  }
+  assert {
+    condition     = contains(one(data.aws_iam_policy_document.assume_ecs_task_role.statement[2].principals).identifiers, "arn:aws:iam::000123456789:role/test-db-prod-to-staging-copy-pipeline-codebuild")
+    error_message = "Should contain: scheduler.amazonaws.com"
+  }
+  assert {
+    condition     = data.aws_iam_policy_document.assume_ecs_task_role.statement[2].sid == "AllowPipelineAssumeRole-staging"
+    error_message = "Statement ID not found: AllowPipelineAssumeRole-staging"
   }
   assert {
     condition     = aws_iam_role_policy.allow_pipeline_access[""].name == "AllowPipelineAccess"


### PR DESCRIPTION
Addresses data copy issues when a pipeline has the same source but multiple destinations.

This addresses the following error.

```shell
│ Error: writing IAM Policy Document: duplicate Sid (AllowPipelineAssumeRole). Remove the Sid or ensure the Sid is unique.
│
│   with module.extensions.module.postgres["database"].module.database-dump[0].data.aws_iam_policy_document.assume_ecs_task_role,
│   on .terraform/modules/extensions/terraform/postgres/database-dump/main.tf line 32, in data "aws_iam_policy_document" "assume_ecs_task_role":
│   32: data "aws_iam_policy_document" "assume_ecs_task_role" {
```

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- ~~[ ] Link to ticket included (unless it's a quick out of ticket thing)~~
- [x] Includes tests (or an explanation for why it doesn't)
- ~~[ ] If the work includes user interface changes, before and after screenshots included in description~~
- ~~[ ] Includes any applicable changes to the documentation in this code base~~
- ~~[ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~~

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
