### PR TITLE
feat: Constrain environment terraform to only apply in the relevant aws account ID (DBTP-2031)

### DIFF
--- a/terraform/extensions/providers.tf
+++ b/terraform/extensions/providers.tf
@@ -17,6 +17,11 @@ provider "aws" {
   }
 }
 
+# This provider configuration prevents deployment to the wrong aws account
+provider "aws" {
+  allowed_account_ids = [local.deploy_account_id]
+}
+
 provider "datadog" {
   alias   = "ddog"
   api_key = data.aws_ssm_parameter.datadog_api_key.value


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-2031.

Running `terraform apply` against an account which doesn't match the `allowed_account_ids` results in the error:
<img width="676" height="103" alt="image" src="https://github.com/user-attachments/assets/773cf401-3389-427f-8844-a8e4293bd8d0" />

Not unit tested as the providers are not testable units, and are mocked in our tests.
The functionality is indirectly tested in our E2E test deployments.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [x] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
