### PR TITLE
chore: Pin debian-python to bookworm (off-ticket)

### DIFF
--- a/images/debian-python/Dockerfile.debian
+++ b/images/debian-python/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bookworm-slim
 
 ARG PYTHON_VERSIONS="3.9 3.10 3.11 3.12 3.13"
 


### PR DESCRIPTION
Trixie has been released, but `playwright` isn't compatible yet.

Pinning to bookworm specifically until `playwright` release an update.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
