### PR TITLE
fix: reduce SSM parameter size (DBTP-2272)

### DIFF
--- a/terraform/extensions/locals.tf
+++ b/terraform/extensions/locals.tf
@@ -8,12 +8,9 @@ locals {
   # So we don't hit a Parameter Store limit, filter environment config for extensions so it only includes the defaults (`"*"`) and the current environment
   extensions_for_environment = {
     for extension_name, extension_config in var.args.services :
-    extension_name => merge(extension_config, {
-      environments = {
-        for environment_name, environment_config in extension_config["environments"] :
-        environment_name => environment_config if contains(["*", var.environment], environment_name)
-      }
-    })
+    extension_name => {
+      type = extension_config.type
+    }
   }
 
   // Select environment for each service and expand config from "*"

--- a/terraform/extensions/tests/unit.tftest.hcl
+++ b/terraform/extensions/tests/unit.tftest.hcl
@@ -241,7 +241,7 @@ run "aws_ssm_parameter_unit_test" {
 
   # Value only includes current environment
   assert {
-    condition     = strcontains(aws_ssm_parameter.addons.value, "test-env")
+    condition     = strcontains(aws_ssm_parameter.addons.value, "type")
     error_message = ""
   }
   assert {


### PR DESCRIPTION
This is blocking Great from upgrading to the latest version. Reducing the SSM parameter content to extension name & type.

Addresses https://uktrade.atlassian.net/browse/DBTP-2272.

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
