### PR TITLE
fix: False success from pipeline after failed deployment (DBTP-2311)

### DIFF
--- a/terraform/codebase-pipelines/buildspec-deploy.yml
+++ b/terraform/codebase-pipelines/buildspec-deploy.yml
@@ -135,13 +135,15 @@ phases:
           STATUS_TEXT="COMPLETE"
         
           IMAGE_TAG=${DEPLOY_TAG} copilot svc deploy --env "${ENVIRONMENT}" --name "${SERVICE}" --force
+          copilot_deploy_status=$?
 
-          if [ $? -ne 0 ]; then
+          if [ ${copilot_deploy_status} -ne 0 ]; then
             STATUS_EMOJI=":red_circle::warning:"
             STATUS_TEXT="FAILED"
           fi
           MESSAGE="${STATUS_EMOJI} ${STATUS_TEXT} - Deployment of tag \`${DEPLOY_TAG}\` to service \`${SERVICE}\` for environment \`${ENVIRONMENT}\` <https://${AWS_REGION}.console.aws.amazon.com/codesuite/codebuild/${AWS_ACCOUNT_ID}/projects/${BUILD_ID_PREFIX}/build/${CODEBUILD_BUILD_ID}/?region=${AWS_REGION}|Build log> | <${PIPELINE_EXECUTION_URL}|Pipeline execution>"
           platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "${MESSAGE}"
+          exit ${copilot_deploy_status}
         else
           # Build image URI
           task_family="${APPLICATION}-${ENVIRONMENT}-${SERVICE}"


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-2311

- Ensure pipeline stage exits with deploy command exit code

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
