### PR TITLE
feat: Specify environment specific PostgreSQL versions (DBTP-2351)

### DIFF
--- a/dbt_platform_helper/entities/platform_config_schema.py
+++ b/dbt_platform_helper/entities/platform_config_schema.py
@@ -292,6 +292,7 @@ class PlatformConfigSchema:
     @staticmethod
     def __postgres_schema() -> dict:
         _valid_postgres_plans = Or(*plan_manager.get_plan_names("postgres"))
+        _valid_postgres_version = Or(int, float)
 
         # TODO: DBTP-1943: Move to Postgres provider?
         _valid_postgres_storage_types = Or("gp2", "gp3", "io1", "io2")
@@ -304,11 +305,12 @@ class PlatformConfigSchema:
 
         return {
             "type": "postgres",
-            "version": (Or(int, float)),
+            Optional("version"): _valid_postgres_version,
             Optional("deletion_policy"): PlatformConfigSchema.__valid_postgres_deletion_policy(),
             Optional("environments"): {
                 PlatformConfigSchema.__valid_environment_name(): {
                     Optional("plan"): _valid_postgres_plans,
+                    Optional("version"): (Or(int, float)),
                     Optional("volume_size"): PlatformConfigSchema.is_integer_between(20, 10000),
                     Optional("iops"): PlatformConfigSchema.is_integer_between(1000, 9950),
                     Optional("snapshot_id"): str,

--- a/tests/platform_helper/utils/fixtures/addons_files/postgres_addons.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/postgres_addons.yml
@@ -8,6 +8,7 @@ my-rds-db:
   environments:
     default:
       plan: small-ha
+      version: 15
       volume_size: 700
       snapshot_id: test-snapshot-id
       multi_az: false

--- a/tests/platform_helper/utils/fixtures/addons_files/postgres_addons_bad_data.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/postgres_addons_bad_data.yml
@@ -5,9 +5,6 @@ my-rds-db-invalid-param:
   version: 14.4
   im_invalid: true
 
-my-rds-db-missing-version:
-  type: postgres
-
 my-rds-db-bad-deletion-policy:
   type: postgres
   version: 14.4

--- a/tests/platform_helper/utils/test_validation.py
+++ b/tests/platform_helper/utils/test_validation.py
@@ -120,7 +120,6 @@ def test_validate_addons_success(addons_file):
             "postgres_addons_bad_data.yml",
             {
                 "my-rds-db-invalid-param": r"Wrong key 'im_invalid' in",
-                "my-rds-db-missing-version": r"Missing key: 'version'",
                 "my-rds-db-bad-deletion-policy": r"did not validate 77",
                 "my-rds-db-bad-plan": r"'environments'.*'default'.*'plan'.*does not match 'cunning'",
                 "my-rds-db-volume-too-small": r"environments'.*'default'.*'volume_size'.*should be an integer between 20 and 10000",


### PR DESCRIPTION
Addresses [DBTP-2351](https://uktrade.atlassian.net/browse/DBTP-2351).

PostgreSQL version can be specified as per this example

```yaml
db:
  type: postgres
  version: 14
  environments:
    staging:
      version: 15
```

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [x] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing

https://763451185160-zptr46bd.eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/pull-request-end-to-end-tests/executions/e5710662-3690-4c49-824a-32497333e4d0/visualization?region=eu-west-2


[DBTP-2351]: https://uktrade.atlassian.net/browse/DBTP-2351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ