### PR TITLE
feat: Add `apply_immediately` PostgreSQL configuration (DBTP-2351)

### DIFF
--- a/dbt_platform_helper/entities/platform_config_schema.py
+++ b/dbt_platform_helper/entities/platform_config_schema.py
@@ -309,6 +309,7 @@ class PlatformConfigSchema:
             Optional("deletion_policy"): PlatformConfigSchema.__valid_postgres_deletion_policy(),
             Optional("environments"): {
                 PlatformConfigSchema.__valid_environment_name(): {
+                    Optional("apply_immediately"): bool,
                     Optional("plan"): _valid_postgres_plans,
                     Optional("version"): (Or(int, float)),
                     Optional("volume_size"): PlatformConfigSchema.is_integer_between(20, 10000),

--- a/terraform/postgres/rds.tf
+++ b/terraform/postgres/rds.tf
@@ -70,7 +70,7 @@ resource "aws_db_instance" "default" {
   # upgrades
   allow_major_version_upgrade = true
   auto_minor_version_upgrade  = true
-  apply_immediately           = false
+  apply_immediately           = coalesce(var.config.apply_immediately, false)
   maintenance_window          = "Mon:00:00-Mon:03:00"
 
   # storage

--- a/terraform/postgres/tests/unit.tftest.hcl
+++ b/terraform/postgres/tests/unit.tftest.hcl
@@ -641,6 +641,7 @@ run "aws_db_instance_unit_test_set_to_non_defaults" {
 
   variables {
     config = {
+      apply_immediately     = true
       version               = 14,
       deletion_protection   = false,
       multi_az              = true,
@@ -682,6 +683,11 @@ run "aws_db_instance_unit_test_set_to_non_defaults" {
   assert {
     condition     = aws_db_instance.default.instance_class == "db.t3.small"
     error_message = "Should be: db.t3.small"
+  }
+
+  assert {
+    condition     = aws_db_instance.default.apply_immediately == true
+    error_message = "Should be: true"
   }
 
   assert {

--- a/terraform/postgres/variables.tf
+++ b/terraform/postgres/variables.tf
@@ -20,6 +20,7 @@ variable "env_config" {
 
 variable "config" {
   type = object({
+    apply_immediately     = optional(bool)
     version               = number
     deletion_protection   = optional(bool)
     volume_size           = optional(number)

--- a/tests/platform_helper/utils/fixtures/addons_files/postgres_addons.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/postgres_addons.yml
@@ -17,6 +17,7 @@ my-rds-db:
     dev:
       deletion_policy: "Delete"
       deletion_protection: false
+      apply_immediately: true
   database_copy:
     - from: prod
       to: hotfix

--- a/tests/platform_helper/utils/fixtures/addons_files/postgres_addons_bad_data.yml
+++ b/tests/platform_helper/utils/fixtures/addons_files/postgres_addons_bad_data.yml
@@ -5,6 +5,12 @@ my-rds-db-invalid-param:
   version: 14.4
   im_invalid: true
 
+my-rds-apply-immediately-should-be-bool:
+  type: redis
+  environments:
+    default:
+      apply_immediately: "yes"
+
 my-rds-db-bad-deletion-policy:
   type: postgres
   version: 14.4

--- a/tests/platform_helper/utils/test_validation.py
+++ b/tests/platform_helper/utils/test_validation.py
@@ -120,6 +120,7 @@ def test_validate_addons_success(addons_file):
             "postgres_addons_bad_data.yml",
             {
                 "my-rds-db-invalid-param": r"Wrong key 'im_invalid' in",
+                "my-rds-apply-immediately-should-be-bool": r"'environments'.*'default'.*apply_immediately.*should be instance of 'bool'",
                 "my-rds-db-bad-deletion-policy": r"did not validate 77",
                 "my-rds-db-bad-plan": r"'environments'.*'default'.*'plan'.*does not match 'cunning'",
                 "my-rds-db-volume-too-small": r"environments'.*'default'.*'volume_size'.*should be an integer between 20 and 10000",


### PR DESCRIPTION
Allows a team to apply a Postgres change immediately as opposed to during the maintenance window.

See also:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#apply_immediately-1

Addresses [DBTP-2351](https://uktrade.atlassian.net/browse/DBTP-2351).

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing

https://763451185160-zptr46bd.eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/pull-request-end-to-end-tests/executions/ad9fbde4-d95d-4f1c-8bbd-49315cdbfa98/visualization?region=eu-west-2

[DBTP-2351]: https://uktrade.atlassian.net/browse/DBTP-2351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ