### PR TITLE
feat: Dynamically determine which iam role to use when generating aws config profiles (off-ticket)

### DIFF
--- a/dbt_platform_helper/constants.py
+++ b/dbt_platform_helper/constants.py
@@ -45,3 +45,8 @@ SERVICE_NAME_SUFFIX = f"Service-{COPILOT_IDENTIFIER}"
 REFRESH_TOKEN_MESSAGE = (
     "To refresh this SSO session run `aws sso login` with the corresponding profile"
 )
+PLATFORM_SSO_ROLES = [
+    "AdministratorAccess",
+    "DBTPlatformDeveloperWrite",
+    "DBTPlatformDeveloperRead",
+]

--- a/dbt_platform_helper/domain/config.py
+++ b/dbt_platform_helper/domain/config.py
@@ -141,7 +141,9 @@ class Config:
         if self.io.confirm(
             f"This command is destructive and will overwrite file contents at {file_path}. Are you sure you want to continue?"
         ):
-            self.io.info("Fetching credentials... this may take a while.")
+            self.io.info(
+                "Fetching credentials... this may take longer if you have access to many accounts."
+            )
 
             with open(aws_config_path, "w") as config_file:
                 config_file.write(AWS_CONFIG)

--- a/dbt_platform_helper/domain/config.py
+++ b/dbt_platform_helper/domain/config.py
@@ -7,6 +7,7 @@ from typing import Dict
 from prettytable import PrettyTable
 
 from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
+from dbt_platform_helper.constants import PLATFORM_SSO_ROLES
 from dbt_platform_helper.domain.versioning import AWSVersioning
 from dbt_platform_helper.domain.versioning import CopilotVersioning
 from dbt_platform_helper.domain.versioning import PlatformHelperVersioning
@@ -140,6 +141,8 @@ class Config:
         if self.io.confirm(
             f"This command is destructive and will overwrite file contents at {file_path}. Are you sure you want to continue?"
         ):
+            self.io.info("Fetching credentials... this may take a while.")
+
             with open(aws_config_path, "w") as config_file:
                 config_file.write(AWS_CONFIG)
 
@@ -147,7 +150,9 @@ class Config:
                     config_file.write(f"[profile {account['accountName']}]\n")
                     config_file.write("sso_session = uktrade\n")
                     config_file.write(f"sso_account_id = {account['accountId']}\n")
-                    config_file.write("sso_role_name = AdministratorAccess\n")
+                    config_file.write(
+                        f"sso_role_name = {self._retrieve_role_for_aws_account(aws_sso_token=access_token, account_id=account['accountId'])}\n"
+                    )
                     config_file.write("region = eu-west-2\n")
                     config_file.write("output = json\n")
                     config_file.write("\n")
@@ -176,6 +181,28 @@ class Config:
             max_results=100,
         )
         return accounts_list
+
+    def _retrieve_role_for_aws_account(self, aws_sso_token, account_id):
+        """
+        Selects the most appropriate IAM role for a given AWS account.
+
+        Roles listed in PLATFORM_SSO_ROLES are preferred if available. If none
+        are found, the first available role returned by sso.list_account_roles
+        is used.
+        """
+
+        role_list = self.sso.list_account_roles(
+            access_token=aws_sso_token,
+            account_id=account_id,
+            max_results=100,
+        )
+
+        roles_available = [r["roleName"] for r in role_list]
+
+        for role_type in PLATFORM_SSO_ROLES:
+            if role_type in roles_available:
+                return role_type
+        return role_list[0]["roleName"]
 
     def _add_version_status_row(
         self, table: PrettyTable, header: str, version_status: VersionStatus

--- a/dbt_platform_helper/providers/aws/exceptions.py
+++ b/dbt_platform_helper/providers/aws/exceptions.py
@@ -63,3 +63,8 @@ class CreateAccessTokenException(AWSException):
 class UnableToRetrieveSSOAccountList(AWSException):
     def __init__(self):
         super().__init__("Unable to retrieve AWS SSO account list")
+
+
+class UnableToRetrieveSSOAccountRolesList(AWSException):
+    def __init__(self, account_id: str):
+        super().__init__(f"Unable to retrieve AWS SSO roles list for AWS account {account_id}")

--- a/dbt_platform_helper/providers/aws/sso_auth.py
+++ b/dbt_platform_helper/providers/aws/sso_auth.py
@@ -3,6 +3,9 @@ from boto3 import Session
 
 from dbt_platform_helper.providers.aws.exceptions import CreateAccessTokenException
 from dbt_platform_helper.providers.aws.exceptions import UnableToRetrieveSSOAccountList
+from dbt_platform_helper.providers.aws.exceptions import (
+    UnableToRetrieveSSOAccountRolesList,
+)
 from dbt_platform_helper.utils.aws import get_aws_session_or_abort
 
 
@@ -54,6 +57,17 @@ class SSOAuthProvider:
         if len(aws_accounts_response.get("accountList", [])) == 0:
             raise UnableToRetrieveSSOAccountList()
         return aws_accounts_response.get("accountList")
+
+    def list_account_roles(self, access_token, account_id, max_results=100):
+        aws_account_roles_response = self.sso.list_account_roles(
+            accessToken=access_token,
+            accountId=account_id,
+            maxResults=max_results,
+        )
+
+        if len(aws_account_roles_response.get("roleList", [])) == 0:
+            raise UnableToRetrieveSSOAccountRolesList(account_id=account_id)
+        return aws_account_roles_response.get("roleList")
 
     def _get_client(self, client: str):
         if not self.session:

--- a/tests/platform_helper/domain/test_config.py
+++ b/tests/platform_helper/domain/test_config.py
@@ -473,6 +473,11 @@ class TestConfigGenerateAWS:
             }
         ]
 
+        config_mocks.sso.list_account_roles.return_value = [
+            {"roleName": "DBTPlatformDeveloperWrite"},
+            {"roleName": "DBTPlatformDeveloperRead"},
+        ]
+
         config_domain.generate_aws("/test/aws/config")
 
         config_mocks.sso.register.assert_called_with(
@@ -519,7 +524,7 @@ class TestConfigGenerateAWS:
                 call("[profile TEST_AWS_ACCOUNT]\n"),
                 call("sso_session = uktrade\n"),
                 call("sso_account_id = TEST_AWS_ACCOUNT_ID\n"),
-                call("sso_role_name = AdministratorAccess\n"),
+                call("sso_role_name = DBTPlatformDeveloperWrite\n"),
                 call("region = eu-west-2\n"),
                 call("output = json\n"),
                 call("\n"),


### PR DESCRIPTION
The current `platform-helper config aws` command sets up aws config profiles for you, but hardcodes the `sso_role_name` property to `AdministratorAccess`. This limits usage of that command to a small number of users with that level of access.

This ticket improves upon that by:
- Dynamically determining which IAM role to use when generating `~/.aws/config` profiles.
- Standard platform roles listed in `PLATFORM_SSO_ROLES` are preferred if available.
- Falling back to the first available role returned by `sso.list_account_roles` if no standard roles are found.



---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
