### PR TITLE
fix: Ensure terraformed ALB is retrieved (off-ticket)

### DIFF
--- a/dbt_platform_helper/constants.py
+++ b/dbt_platform_helper/constants.py
@@ -53,6 +53,7 @@ MAINTENANCE_PAGE_TAGS = ["MaintenancePage", "AllowedIps", "BypassIpFilter", "All
 MAINTENANCE_PAGE_REASON = "MaintenancePage"
 MANAGED_BY_PLATFORM = "DBT Platform"
 MANAGED_BY_SERVICE_TERRAFORM = "DBT Platform - Service Terraform"
+MANAGED_BY_PLATFORM_TERRAFORM = "DBT Platform - Terraform"
 STANDARD_PLATFORM_SSO_ROLES = [
     "AdministratorAccess",
     "DBTPlatformDeveloperWrite",

--- a/dbt_platform_helper/domain/update_alb_rules.py
+++ b/dbt_platform_helper/domain/update_alb_rules.py
@@ -59,7 +59,7 @@ class UpdateALBRules:
         self.config_provider = config_provider
         self.io = io
         self.load_application = load_application
-        self.load_balancer: LoadBalancerProvider = load_balancer_p(session)
+        self.load_balancer: LoadBalancerProvider = load_balancer_p(session, io=self.io)
 
     def update_alb_rules(
         self,

--- a/dbt_platform_helper/providers/load_balancers.py
+++ b/dbt_platform_helper/providers/load_balancers.py
@@ -3,6 +3,7 @@ from typing import List
 
 from boto3 import Session
 
+from dbt_platform_helper.constants import MANAGED_BY_PLATFORM_TERRAFORM
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.io import ClickIOProvider
 from dbt_platform_helper.utils.aws import get_aws_session_or_abort
@@ -171,7 +172,11 @@ class LoadBalancerProvider:
         for lb in tag_descriptions:
             tags = {t["Key"]: t["Value"] for t in lb["Tags"]}
             # TODO: DBTP-1967: copilot hangover, creates coupling to specific tags could update to check application and environment
-            if tags.get("copilot-application") == app and tags.get("copilot-environment") == env:
+            if (
+                tags.get("copilot-application") == app
+                and tags.get("copilot-environment") == env
+                and tags.get("managed-by", "") == MANAGED_BY_PLATFORM_TERRAFORM
+            ):
                 return lb["ResourceArn"]
 
         raise LoadBalancerNotFoundException(app, env)

--- a/tests/platform_helper/integration/test_update_aws.py
+++ b/tests/platform_helper/integration/test_update_aws.py
@@ -183,6 +183,9 @@ class MockALBService:
             {
                 "LoadBalancers": [
                     {
+                        "LoadBalancerArn": "copilot-alb-arn",
+                    },
+                    {
                         "LoadBalancerArn": "alb-arn-doesnt-matter",
                     },
                 ],
@@ -247,7 +250,6 @@ class MockALBService:
                     "9000",
                 )
             )
-        print()
         paginator.paginate.return_value = [
             {
                 "Rules": rules,
@@ -369,12 +371,22 @@ class MockALBService:
                 {  # ALB
                     "TagDescriptions": [
                         self.fixtures.create_tag_descriptions(
-                            "alb-arn-doesnt-matter",
+                            "copilot-alb-arn",
                             {
                                 "copilot-application": "test-application",
                                 "copilot-environment": self.environment,
                             },
-                        )
+                        ),
+                        self.fixtures.create_tag_descriptions(
+                            "alb-arn-doesnt-matter",
+                            {
+                                "copilot-application": "test-application",
+                                "copilot-environment": self.environment,
+                                "application": "test-application",
+                                "environment": self.environment,
+                                "managed-by": "DBT Platform - Terraform",
+                            },
+                        ),
                     ]
                 },
                 {  # Listener rule tags
@@ -571,6 +583,7 @@ class MockALBService:
                     "Deleted rules: ['listener-rule-arn-doesnt-matter-8', 'listener-rule-arn-doesnt-matter-9', 'listener-rule-arn-doesnt-matter-10']",
                 ],
                 "debug": [
+                    "Load Balancer ARN: alb-arn-doesnt-matter",
                     "Listener ARN: listener-arn-doesnt-matter",
                     "Deleted existing rule: listener-rule-arn-doesnt-matter-8",
                     "Deleted existing rule: listener-rule-arn-doesnt-matter-9",
@@ -591,6 +604,7 @@ class MockALBService:
                     "Deleted rules: ['listener-rule-arn-doesnt-matter-8', 'listener-rule-arn-doesnt-matter-9', 'listener-rule-arn-doesnt-matter-10']",
                 ],
                 "debug": [
+                    "Load Balancer ARN: alb-arn-doesnt-matter",
                     "Listener ARN: listener-arn-doesnt-matter",
                     "Deleted existing rule: listener-rule-arn-doesnt-matter-8",
                     "Deleted existing rule: listener-rule-arn-doesnt-matter-9",
@@ -611,6 +625,7 @@ class MockALBService:
                     "Created rules: ['platform-new-web-path-arn', 'platform-new-web-arn', 'platform-new-api-arn']",
                 ],
                 "debug": [
+                    "Load Balancer ARN: alb-arn-doesnt-matter",
                     "Listener ARN: listener-arn-doesnt-matter",
                     "Building platform rule for corresponding copilot rule: listener-rule-arn-doesnt-matter-4",
                     "Updated forward action for service web-path to use: tg-arn-doesnt-matter-8",
@@ -637,6 +652,7 @@ class MockALBService:
                     "Platform rules already exist, skipping creation",
                 ],
                 "debug": [
+                    "Load Balancer ARN: alb-arn-doesnt-matter",
                     "Listener ARN: listener-arn-doesnt-matter",
                 ],
             },
@@ -654,6 +670,7 @@ class MockALBService:
                     "Created rules: ['platform-new-web-path-arn', 'platform-new-web-arn', 'platform-new-api-arn']",
                 ],
                 "debug": [
+                    "Load Balancer ARN: alb-arn-doesnt-matter",
                     "Listener ARN: listener-arn-doesnt-matter",
                     "Building platform rule for corresponding copilot rule: listener-rule-arn-doesnt-matter-4",
                     "Updated forward action for service web-path to use: tg-arn-doesnt-matter-8",

--- a/tests/platform_helper/providers/test_load_balancers.py
+++ b/tests/platform_helper/providers/test_load_balancers.py
@@ -33,6 +33,7 @@ def _create_load_balancer(session):
         Tags=[
             {"Key": "copilot-application", "Value": "test-application"},
             {"Key": "copilot-environment", "Value": "development"},
+            {"Key": "managed-by", "Value": "DBT Platform - Terraform"},
         ],
     )["LoadBalancers"][0]["LoadBalancerArn"]
 


### PR DESCRIPTION
## What:

- during testing with demodjango a copilotted ALB was retrieved and the rules failed to update. 
- When retrieving an ALB for DBT Platform we should always get the terraformed version for updating the rules or maintenance page
- This ensures we check for the terraform managed tag and only return that ALB

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
