### PR TITLE
chore: Tag database copy pipeline with platform-version (Off-ticket)

### DIFF
--- a/terraform/postgres/database-copy-pipeline/codepipeline.tf
+++ b/terraform/postgres/database-copy-pipeline/codepipeline.tf
@@ -15,7 +15,12 @@ resource "aws_codepipeline" "database_copy_pipeline" {
   depends_on     = [aws_iam_role_policy.artifact_store_access_for_database_pipeline]
   pipeline_type  = "V2"
   execution_mode = "QUEUED"
-  tags           = local.tags
+  tags = merge(
+    local.tags,
+    {
+      platform-version = var.pinned_version != null ? var.pinned_version : "Not pinned"
+    }
+  )
 
   variable {
     name          = "PLATFORM_HELPER_VERSION_OVERRIDE"


### PR DESCRIPTION
Since the database copy pipeline uses a version of platform-helper, it should be tagged with `platform-version` in the same way that the other pipelines are tagged.  This makes it clear what version of platform helper the pipeline has been deployed with.

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present