### PR TITLE
feat: Convert scheduled tasks manifests (DBTP-2876)

### DIFF
--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -41,7 +41,7 @@ from dbt_platform_helper.providers.yaml_file import YamlFileProvider
 from dbt_platform_helper.utils.application import load_application
 from dbt_platform_helper.utils.deep_merge import deep_merge
 
-SERVICE_TYPES = ["Load Balanced Web Service", "Backend Service"]
+SERVICE_TYPES = ["Load Balanced Web Service", "Backend Service", "Scheduled Job"]
 DEPLOYMENT_TIMEOUT_SECONDS = 1200
 POLL_INTERVAL_SECONDS = 5
 
@@ -321,6 +321,11 @@ class ServiceManager:
                             service_manifest["image"]["healthcheck"]["start_period"] = int(
                                 start_period.rstrip("s")
                             )
+                    if "build" in service_manifest["image"]:
+                        service_manifest["image"][
+                            "location"
+                        ] = "563763463626.dkr.ecr.eu-west-2.amazonaws.com/demodjango/application"
+                        del service_manifest["image"]["build"]
 
                 if "count" in service_manifest:
                     if not isinstance(service_manifest.get("count"), int):

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -360,6 +360,10 @@ class ServiceManager:
                         service_manifest["schedule"] = schedule
                         del service_manifest["on"]
 
+                    elif "none" in service_manifest["on"]["schedule"]:
+                        service_manifest["schedule"] = "none"
+                        del service_manifest["on"]
+
                 if "count" in service_manifest:
                     if not isinstance(service_manifest.get("count"), int):
                         if "cooldown" in service_manifest.get("count"):

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -216,6 +216,15 @@ class ServiceManager:
         service_directory = Path("services/")
         service_directory.mkdir(parents=True, exist_ok=True)
 
+        # TODO Remove this check on keywords as part of the copilot cleanup.
+        # Note - get_on_key() function handles how YAML parsing may convert the *on* key into a boolean True. This ensures migration works reliably regardless of whether the key is read as "on" or True. Without this, the schedule section could be skipped/produce incorrect output. https://yaml.org/type/bool.html
+        def get_on_key(d: dict):
+            if "on" in d:
+                return "on"
+            if True in d:
+                return True
+            return None
+
         for dirname, _, filenames in os.walk("copilot"):
             if "manifest.yml" in filenames and "environments" not in dirname:
                 copilot_manifest = self.file_provider.load(f"{dirname}/manifest.yml")
@@ -286,30 +295,33 @@ class ServiceManager:
                             del env_config["network"]
                         if "observability" in env_config:
                             del env_config["observability"]
-                        if "on" in env_config:
-                            if "@" in env_config["on"]["schedule"]:
+
+                        on_key = get_on_key(env_config)
+                        if on_key is not None:
+                            if "@" in env_config[on_key]["schedule"]:
                                 rate_conversion = {
+                                    "@hourly": "rate(1 hours)",
                                     "@hourly": "rate(1 hours)",
                                     "@daily": "rate(1 days)",
                                     "@weekly": "0 0 * * 1",
                                     "@monthly": "0 0 1 * *",
                                     "@yearly": "0 * * * ?",
                                 }
-                                schedule = env_config["on"]["schedule"]
+                                schedule = env_config[on_key]["schedule"]
                                 env_config["schedule"] = rate_conversion.get(schedule, schedule)
-                                del env_config["on"]
+                                del env_config[on_key]
 
-                            elif "*" in env_config["on"]["schedule"]:
-                                split_cron = env_config["on"]["schedule"].split()
+                            elif "*" in env_config[on_key]["schedule"]:
+                                split_cron = env_config[on_key]["schedule"].split()
                                 if split_cron[2] == split_cron[4]:
                                     split_cron[4] = "?"
                                 schedule = " ".join(split_cron)
                                 env_config["schedule"] = schedule
-                                del env_config["on"]
+                                del env_config[on_key]
 
-                            elif "none" in env_config["on"]["schedule"]:
+                            elif "none" in env_config[on_key]["schedule"]:
                                 env_config["schedule"] = "none"
-                                del env_config["on"]
+                                del env_config[on_key]
 
                 if "healthcheck" in service_manifest.get("http", {}):
                     if "interval" in service_manifest["http"]["healthcheck"]:
@@ -363,8 +375,9 @@ class ServiceManager:
                             "location"
                         ] = f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"
 
-                if "on" in service_manifest:
-                    if "@" in service_manifest["on"]["schedule"]:
+                on_key = get_on_key(service_manifest)
+                if on_key is not None:
+                    if "@" in service_manifest[on_key]["schedule"]:
                         rate_conversion = {
                             "@hourly": "rate(1 hours)",
                             "@daily": "rate(1 days)",
@@ -372,21 +385,21 @@ class ServiceManager:
                             "@monthly": "0 0 1 * *",
                             "@yearly": "0 * * * ?",
                         }
-                        schedule = service_manifest["on"]["schedule"]
+                        schedule = service_manifest[on_key]["schedule"]
                         service_manifest["schedule"] = rate_conversion.get(schedule, schedule)
-                        del service_manifest["on"]
+                        del service_manifest[on_key]
 
-                    elif "*" in service_manifest["on"]["schedule"]:
-                        split_cron = service_manifest["on"]["schedule"].split()
+                    elif "*" in service_manifest[on_key]["schedule"]:
+                        split_cron = service_manifest[on_key]["schedule"].split()
                         if split_cron[2] == split_cron[4]:
                             split_cron[4] = "?"
                         schedule = " ".join(split_cron)
                         service_manifest["schedule"] = schedule
-                        del service_manifest["on"]
+                        del service_manifest[on_key]
 
-                    elif "none" in service_manifest["on"]["schedule"]:
+                    elif "none" in service_manifest[on_key]["schedule"]:
                         service_manifest["schedule"] = "none"
-                        del service_manifest["on"]
+                        del service_manifest[on_key]
 
                 if "count" in service_manifest:
                     if not isinstance(service_manifest.get("count"), int):

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -218,12 +218,16 @@ class ServiceManager:
 
         # TODO Remove this check on keywords as part of the copilot cleanup.
         # Note - get_on_key() function handles how YAML parsing may convert the *on* key into a boolean True. This ensures migration works reliably regardless of whether the key is read as "on" or True. Without this, the schedule section could be skipped/produce incorrect output. https://yaml.org/type/bool.html
-        def get_on_key(d: dict):
+        def get_on_key(d: dict) -> str | bool | None:
             if "on" in d:
                 return "on"
             if True in d:
                 return True
             return None
+
+        def set_schedule_order(d: dict, schedule: str) -> dict:
+            items = list(d.items())
+            return {**dict(items[:2]), "schedule": schedule, **dict(items[2:])}
 
         for dirname, _, filenames in os.walk("copilot"):
             if "manifest.yml" in filenames and "environments" not in dirname:
@@ -386,7 +390,9 @@ class ServiceManager:
                             "@yearly": "0 * * * ?",
                         }
                         schedule = service_manifest[on_key]["schedule"]
-                        service_manifest["schedule"] = rate_conversion.get(schedule, schedule)
+                        service_manifest = set_schedule_order(
+                            service_manifest, rate_conversion.get(schedule, schedule)
+                        )
                         del service_manifest[on_key]
 
                     elif "*" in service_manifest[on_key]["schedule"]:
@@ -394,11 +400,11 @@ class ServiceManager:
                         if split_cron[2] == split_cron[4]:
                             split_cron[4] = "?"
                         schedule = " ".join(split_cron)
-                        service_manifest["schedule"] = schedule
+                        service_manifest = set_schedule_order(service_manifest, schedule)
                         del service_manifest[on_key]
 
                     elif "none" in service_manifest[on_key]["schedule"]:
-                        service_manifest["schedule"] = "none"
+                        service_manifest = set_schedule_order(service_manifest, "none")
                         del service_manifest[on_key]
 
                 if "count" in service_manifest:

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -225,6 +225,8 @@ class ServiceManager:
                 return True
             return None
 
+        # Regenerate manifest with the *schedule* included after the *type* field
+        # This is required to avoid sending the *schedule* field to the bottom of the service-config.yml file
         def set_schedule_order(d: dict, schedule: str) -> dict:
             items = list(d.items())
             return {**dict(items[:2]), "schedule": schedule, **dict(items[2:])}

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -339,6 +339,18 @@ class ServiceManager:
                             "location"
                         ] = f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"
 
+                if "on" in service_manifest:
+                    if "@" in service_manifest["on"]["schedule"]:
+                        rate_conversion = {"@hourly": "rate(1 hours)", "@daily": "rate(1 days)"}
+                        schedule = service_manifest["on"]["schedule"]
+                        service_manifest["on"]["schedule"] = rate_conversion.get(schedule, schedule)
+                    elif "*" in service_manifest["on"]["schedule"]:
+                        split_cron = service_manifest["on"]["schedule"].split()
+                        if split_cron[2] == split_cron[4]:
+                            split_cron[4] = "?"
+                        schedule = " ".join(split_cron)
+                        service_manifest["on"]["schedule"] = schedule
+
                 if "count" in service_manifest:
                     if not isinstance(service_manifest.get("count"), int):
                         if "cooldown" in service_manifest.get("count"):

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -370,7 +370,7 @@ class ServiceManager:
 
                         environments = config.get("environments", {})
                         first_env = list(environments.values())[0] if environments else {}
-                        account_id = first_env.get("accounts", {}).get("deploy", {}).get("id", "")
+                        account_id = first_env["accounts"]["deploy"]["id"]
 
                         name = service_manifest["name"]
 

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -341,7 +341,13 @@ class ServiceManager:
 
                 if "on" in service_manifest:
                     if "@" in service_manifest["on"]["schedule"]:
-                        rate_conversion = {"@hourly": "rate(1 hours)", "@daily": "rate(1 days)"}
+                        rate_conversion = {
+                            "@hourly": "rate(1 hours)",
+                            "@daily": "rate(1 days)",
+                            "@weekly": "0 0 * * 1",
+                            "@monthly": "0 0 1 * *",
+                            "@yearly": "0 * * * ?",
+                        }
                         schedule = service_manifest["on"]["schedule"]
                         service_manifest["on"]["schedule"] = rate_conversion.get(schedule, schedule)
                     elif "*" in service_manifest["on"]["schedule"]:

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -286,6 +286,30 @@ class ServiceManager:
                             del env_config["network"]
                         if "observability" in env_config:
                             del env_config["observability"]
+                        if "on" in env_config:
+                            if "@" in env_config["on"]["schedule"]:
+                                rate_conversion = {
+                                    "@hourly": "rate(1 hours)",
+                                    "@daily": "rate(1 days)",
+                                    "@weekly": "0 0 * * 1",
+                                    "@monthly": "0 0 1 * *",
+                                    "@yearly": "0 * * * ?",
+                                }
+                                schedule = env_config["on"]["schedule"]
+                                env_config["schedule"] = rate_conversion.get(schedule, schedule)
+                                del env_config["on"]
+
+                            elif "*" in env_config["on"]["schedule"]:
+                                split_cron = env_config["on"]["schedule"].split()
+                                if split_cron[2] == split_cron[4]:
+                                    split_cron[4] = "?"
+                                schedule = " ".join(split_cron)
+                                env_config["schedule"] = schedule
+                                del env_config["on"]
+
+                            elif "none" in env_config["on"]["schedule"]:
+                                env_config["schedule"] = "none"
+                                del env_config["on"]
 
                 if "healthcheck" in service_manifest.get("http", {}):
                     if "interval" in service_manifest["http"]["healthcheck"]:

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -349,13 +349,16 @@ class ServiceManager:
                             "@yearly": "0 * * * ?",
                         }
                         schedule = service_manifest["on"]["schedule"]
-                        service_manifest["on"]["schedule"] = rate_conversion.get(schedule, schedule)
+                        service_manifest["schedule"] = rate_conversion.get(schedule, schedule)
+                        del service_manifest["on"]
+
                     elif "*" in service_manifest["on"]["schedule"]:
                         split_cron = service_manifest["on"]["schedule"].split()
                         if split_cron[2] == split_cron[4]:
                             split_cron[4] = "?"
                         schedule = " ".join(split_cron)
-                        service_manifest["on"]["schedule"] = schedule
+                        service_manifest["schedule"] = schedule
+                        del service_manifest["on"]
 
                 if "count" in service_manifest:
                     if not isinstance(service_manifest.get("count"), int):

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -409,6 +409,14 @@ class ServiceManager:
                         service_manifest = set_schedule_order(service_manifest, "none")
                         del service_manifest[on_key]
 
+                if "platform" in service_manifest:
+                    if service_manifest["platform"] == "linux/amd64":
+                        service_manifest["platform"] = "X86_64"
+                    else:
+                        service_manifest["platform"] = (
+                            service_manifest["platform"].split("/")[1].upper()
+                        )
+
                 if "count" in service_manifest:
                     if not isinstance(service_manifest.get("count"), int):
                         if "cooldown" in service_manifest.get("count"):

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -10,9 +10,6 @@ from importlib.metadata import version
 from pathlib import Path
 from typing import Any
 
-import yaml
-
-from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.constants import PLATFORM_HELPER_PACKAGE_NAME
 from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_OVERRIDE_KEY
 from dbt_platform_helper.constants import SERVICE_CONFIG_FILE
@@ -307,7 +304,6 @@ class ServiceManager:
                             if "@" in env_config[on_key]["schedule"]:
                                 rate_conversion = {
                                     "@hourly": "rate(1 hours)",
-                                    "@hourly": "rate(1 hours)",
                                     "@daily": "rate(1 days)",
                                     "@weekly": "0 0 * * 1",
                                     "@monthly": "0 0 1 * *",
@@ -319,7 +315,7 @@ class ServiceManager:
 
                             elif "*" in env_config[on_key]["schedule"]:
                                 split_cron = env_config[on_key]["schedule"].split()
-                                if split_cron[2] == split_cron[4]:
+                                if split_cron[2] == "*" and split_cron[4] == "*":
                                     split_cron[4] = "?"
                                 schedule = " ".join(split_cron)
                                 env_config["schedule"] = schedule
@@ -369,13 +365,16 @@ class ServiceManager:
                     if "build" in service_manifest["image"]:
                         del service_manifest["image"]["build"]
 
-                        with open(PLATFORM_CONFIG_FILE, "r") as f:
-                            config = yaml.safe_load(f)
-
-                        application = config["application"]
-                        account_id = config["environments"]["*"]["accounts"]["deploy"]["id"]
+                        config = self.config_provider.get_enriched_config()
+                        application_name = config.get("application", "")
+                        
+                        environments = config.get("environments", {})
+                        first_env = list(environments.values())[0] if environments else {}
+                        account_id = first_env.get("accounts", {}).get("deploy", {}).get("id", "")
+                        
                         name = service_manifest["name"]
-                        ecr_repo = f"{application}/{name}"
+                        
+                        ecr_repo = f"{application_name}/{name}"
 
                         service_manifest["image"][
                             "location"
@@ -399,7 +398,7 @@ class ServiceManager:
 
                     elif "*" in service_manifest[on_key]["schedule"]:
                         split_cron = service_manifest[on_key]["schedule"].split()
-                        if split_cron[2] == split_cron[4]:
+                        if split_cron[2] == "*" and split_cron[4] == "*":
                             split_cron[4] = "?"
                         schedule = " ".join(split_cron)
                         service_manifest = set_schedule_order(service_manifest, schedule)

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -367,13 +367,13 @@ class ServiceManager:
 
                         config = self.config_provider.get_enriched_config()
                         application_name = config.get("application", "")
-                        
+
                         environments = config.get("environments", {})
                         first_env = list(environments.values())[0] if environments else {}
                         account_id = first_env.get("accounts", {}).get("deploy", {}).get("id", "")
-                        
+
                         name = service_manifest["name"]
-                        
+
                         ecr_repo = f"{application_name}/{name}"
 
                         service_manifest["image"][

--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -10,6 +10,9 @@ from importlib.metadata import version
 from pathlib import Path
 from typing import Any
 
+import yaml
+
+from dbt_platform_helper.constants import PLATFORM_CONFIG_FILE
 from dbt_platform_helper.constants import PLATFORM_HELPER_PACKAGE_NAME
 from dbt_platform_helper.constants import PLATFORM_HELPER_VERSION_OVERRIDE_KEY
 from dbt_platform_helper.constants import SERVICE_CONFIG_FILE
@@ -322,10 +325,19 @@ class ServiceManager:
                                 start_period.rstrip("s")
                             )
                     if "build" in service_manifest["image"]:
+                        del service_manifest["image"]["build"]
+
+                        with open(PLATFORM_CONFIG_FILE, "r") as f:
+                            config = yaml.safe_load(f)
+
+                        application = config["application"]
+                        account_id = config["environments"]["*"]["accounts"]["deploy"]["id"]
+                        name = service_manifest["name"]
+                        ecr_repo = f"{application}/{name}"
+
                         service_manifest["image"][
                             "location"
-                        ] = "563763463626.dkr.ecr.eu-west-2.amazonaws.com/demodjango/application"
-                        del service_manifest["image"]["build"]
+                        ] = f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"
 
                 if "count" in service_manifest:
                     if not isinstance(service_manifest.get("count"), int):

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -995,7 +995,7 @@ def test_migrate_scheduled_job_converts_schedule_to_eventbridge_format(
     expected_service_config = {
         "name": "my-scheduled-service",
         "type": "Scheduled Job",
-        "on": {"schedule": expected},
+        "schedule": expected,
         "retries": "1",
         "timeout": "60m",
         "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -38,16 +38,24 @@ def copilot_manifest(tmp_path):
         },
         "variables": {"S3_BUCKET_NAME": "${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}"},
     }
-    with open(manifest_path, "w") as f:
-        yaml.safe_dump(manifest_content, f)
-    return tmp_path
+
+    def _make(extra={}):
+        if extra:
+            manifest_content.update(extra)
+        with open(manifest_path, "w") as f:
+            yaml.safe_dump(manifest_content, f)
+
+        return tmp_path
+
+    return _make
 
 
-def test_migrate_copilot_manifests_creates_services_directory_and_files(tmp_path, copilot_manifest):
-    output_dir = tmp_path / "services"
+def test_migrate_copilot_manifests_creates_services_directory_and_files(copilot_manifest):
+    path = copilot_manifest()
+    output_dir = path / "services"
     file_path = output_dir / "my-service/service-config.yml"
 
-    os.chdir(tmp_path)
+    os.chdir(path)
     service_manager = ServiceManager()
     service_manager.migrate_copilot_manifests()
 
@@ -55,6 +63,7 @@ def test_migrate_copilot_manifests_creates_services_directory_and_files(tmp_path
 
 
 def test_migrate_copilot_manifests_generates_expected_service_config(tmp_path, copilot_manifest):
+    path = copilot_manifest()
     expected_service_config = {
         "name": "my-service",
         "type": "Load Balanced Web Service",
@@ -67,11 +76,11 @@ def test_migrate_copilot_manifests_generates_expected_service_config(tmp_path, c
         },
     }
 
-    os.chdir(tmp_path)
+    os.chdir(path)
     service_manager = ServiceManager()
     service_manager.migrate_copilot_manifests()
 
-    with open(tmp_path / "services/my-service/service-config.yml") as f:
+    with open(path / "services/my-service/service-config.yml") as f:
         service_config = yaml.safe_load(f)
 
     assert service_config == expected_service_config
@@ -802,6 +811,9 @@ def copilot_scheduled_job_manifest(tmp_path):
         "on": {"schedule": "none"},
         "retries": "1",
         "timeout": "60m",
+        "image": {
+            "location": "123456789012.dkr.ecr.eu-west-2.amazonaws.com/demodjango/my-scheduled-service:a-tag"
+        },
     }
 
     def _make(extra={}):
@@ -825,6 +837,9 @@ def expected_scheduled_job_config():
             "schedule": "none",
             "retries": "1",
             "timeout": "60m",
+            "image": {
+                "location": "123456789012.dkr.ecr.eu-west-2.amazonaws.com/demodjango/my-scheduled-service"
+            },
         }
 
         if extra:

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -961,8 +961,15 @@ def test_migrate_scheduled_job_removes_image_tag(tmp_path):
 
 @pytest.mark.parametrize(
     "test_input,expected",
-    [("@hourly", "rate(1 hours)"), ("@daily", "rate(1 days)"), ("5 * * * *", "5 * * * ?")],
-    ids=["hourly", "daily", "five minutes past each hour"],
+    [
+        ("@hourly", "rate(1 hours)"),
+        ("@daily", "rate(1 days)"),
+        ("@weekly", "0 0 * * 1"),
+        ("@monthly", "0 0 1 * *"),
+        ("@yearly", "0 * * * ?"),
+        ("5 * * * *", "5 * * * ?"),
+    ],
+    ids=["hourly", "daily", "weekly", "monthly", "yearly", "five minutes past each hour"],
 )
 def test_migrate_scheduled_job_converts_schedule_to_eventbridge_format(
     tmp_path, test_input, expected

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -937,3 +937,35 @@ def test_migrate_scheduled_job_converts_schedule_to_eventbridge_format(
         service_config = yaml.safe_load(f)
 
     assert service_config == expected_service_config
+
+
+def test_migrate_scheduled_job_handles_overrides(
+    copilot_scheduled_job_manifest, expected_scheduled_job_config
+):
+    path = copilot_scheduled_job_manifest(
+        {
+            "on": {"schedule": "none"},
+            "environments": {
+                "dev": {"on": {"schedule": "0 23 * * *"}},
+                "staging": {"on": {"schedule": "0 0 * * *"}},
+            },
+        }
+    )
+    expected_service_config = expected_scheduled_job_config(
+        {
+            "schedule": "none",
+            "environments": {
+                "dev": {"schedule": "0 23 * * ?"},
+                "staging": {"schedule": "0 0 * * ?"},
+            },
+        }
+    )
+
+    os.chdir(path)
+    service_manager = ServiceManager()
+    service_manager.migrate_copilot_manifests()
+
+    with open(path / "services/my-scheduled-service/service-config.yml") as f:
+        service_config = yaml.safe_load(f)
+
+    assert service_config == expected_service_config

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -870,6 +870,33 @@ def test_migrate_scheduled_job_removes_network_block(
     assert service_config == expected_service_config
 
 
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("linux/x86_64", "X86_64"),
+        ("linux/amd64", "X86_64"),
+        ("linux/arm64", "ARM64"),
+    ],
+    ids=["X86_64", "X86_64", "ARM64"],
+)
+def test_migrate_scheduled_job_converts_platform_architecture(
+    copilot_scheduled_job_manifest, expected_scheduled_job_config, test_input, expected
+):
+
+    path = copilot_scheduled_job_manifest({"platform": test_input})
+
+    expected_service_config = expected_scheduled_job_config({"platform": expected})
+
+    os.chdir(path)
+    service_manager = ServiceManager()
+    service_manager.migrate_copilot_manifests()
+
+    with open(path / "services/my-scheduled-service/service-config.yml") as f:
+        service_config = yaml.safe_load(f)
+
+    assert service_config == expected_service_config
+
+
 def test_migrate_scheduled_job_removes_image_tag(
     copilot_scheduled_job_manifest, expected_scheduled_job_config
 ):

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -815,6 +815,26 @@ def copilot_scheduled_job_manifest(tmp_path):
     return _make
 
 
+@pytest.fixture
+def expected_scheduled_job_config():
+
+    def _make(extra={}):
+        expected_content = {
+            "name": "my-scheduled-service",
+            "type": "Scheduled Job",
+            "schedule": "none",
+            "retries": "1",
+            "timeout": "60m",
+        }
+
+        if extra:
+            expected_content.update(extra)
+
+        return expected_content
+
+    return _make
+
+
 def test_migrate_scheduled_job_copilot_manifests_creates_services_directory_and_files(
     copilot_scheduled_job_manifest,
 ):
@@ -831,9 +851,13 @@ def test_migrate_scheduled_job_copilot_manifests_creates_services_directory_and_
 
 
 def test_migrate_scheduled_job_converts_image_build_to_location(
-    tmp_path, copilot_scheduled_job_manifest
+    copilot_scheduled_job_manifest, expected_scheduled_job_config
 ):
-    config_path = tmp_path / "platform-config.yml"
+    path = copilot_scheduled_job_manifest(
+        {"image": {"build": "./copilot/developer-database-dumper/image/Dockerfile"}}
+    )
+
+    config_path = path / "platform-config.yml"
     config_data = {
         "application": "demodjango",
         "environments": {"*": {"accounts": {"deploy": {"id": "563763463626"}}}},
@@ -845,43 +869,9 @@ def test_migrate_scheduled_job_converts_image_build_to_location(
     account_id = "563763463626"
     ecr_repo = "demodjango/my-scheduled-service"
 
-    copilot_scheduled_job_manifest(
-        {"image": {"build": "./copilot/developer-database-dumper/image/Dockerfile"}}
+    expected_service_config = expected_scheduled_job_config(
+        {"image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"}}
     )
-
-    expected_service_config = {
-        "name": "my-scheduled-service",
-        "type": "Scheduled Job",
-        "schedule": "none",
-        "retries": "1",
-        "timeout": "60m",
-        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
-    }
-
-    os.chdir(tmp_path)
-    service_manager = ServiceManager()
-    service_manager.migrate_copilot_manifests()
-
-    with open(tmp_path / "services/my-scheduled-service/service-config.yml") as f:
-        service_config = yaml.safe_load(f)
-
-    assert service_config == expected_service_config
-
-
-def test_migrate_scheduled_job_removes_network_block(tmp_path, copilot_scheduled_job_manifest):
-    path = copilot_scheduled_job_manifest(
-        {
-            "network": {"connect": "true", "vpc": {"placement": "private"}},
-        }
-    )
-
-    expected_service_config = {
-        "name": "my-scheduled-service",
-        "type": "Scheduled Job",
-        "schedule": "none",
-        "retries": "1",
-        "timeout": "60m",
-    }
 
     os.chdir(path)
     service_manager = ServiceManager()
@@ -893,77 +883,62 @@ def test_migrate_scheduled_job_removes_network_block(tmp_path, copilot_scheduled
     assert service_config == expected_service_config
 
 
-def test_migrate_scheduled_job_removes_image_tag(tmp_path):
-    account_id = "563763463626"
-    ecr_repo = "demodjango/my-scheduled-service"
+def test_migrate_scheduled_job_removes_network_block(
+    copilot_scheduled_job_manifest, expected_scheduled_job_config
+):
+    path = copilot_scheduled_job_manifest(
+        {
+            "network": {"connect": "true", "vpc": {"placement": "private"}},
+        }
+    )
 
-    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
-    copilot_dir.mkdir(parents=True)
-    manifest_path = copilot_dir / "manifest.yml"
+    expected_service_config = expected_scheduled_job_config()
 
-    manifest_content = {
-        "name": "my-scheduled-service",
-        "type": "Scheduled Job",
-        "on": {"schedule": "none"},
-        "retries": "1",
-        "timeout": "60m",
-        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}:some-tag"},
-    }
-    with open(manifest_path, "w") as f:
-        yaml.safe_dump(manifest_content, f)
-
-    expected_service_config = {
-        "name": "my-scheduled-service",
-        "type": "Scheduled Job",
-        "schedule": "none",
-        "retries": "1",
-        "timeout": "60m",
-        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
-    }
-
-    os.chdir(tmp_path)
+    os.chdir(path)
     service_manager = ServiceManager()
     service_manager.migrate_copilot_manifests()
 
-    with open(tmp_path / "services/my-scheduled-service/service-config.yml") as f:
+    with open(path / "services/my-scheduled-service/service-config.yml") as f:
         service_config = yaml.safe_load(f)
 
     assert service_config == expected_service_config
 
 
-def test_migrate_scheduled_job_handles_none(tmp_path):
+def test_migrate_scheduled_job_removes_image_tag(
+    copilot_scheduled_job_manifest, expected_scheduled_job_config
+):
     account_id = "563763463626"
     ecr_repo = "demodjango/my-scheduled-service"
 
-    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
-    copilot_dir.mkdir(parents=True)
-    manifest_path = copilot_dir / "manifest.yml"
+    path = copilot_scheduled_job_manifest(
+        {"image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}:some-tag"}}
+    )
 
-    manifest_content = {
-        "name": "my-scheduled-service",
-        "type": "Scheduled Job",
-        "on": {"schedule": "none"},
-        "retries": "1",
-        "timeout": "60m",
-        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
-    }
-    with open(manifest_path, "w") as f:
-        yaml.safe_dump(manifest_content, f)
+    expected_service_config = expected_scheduled_job_config(
+        {"image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"}}
+    )
 
-    expected_service_config = {
-        "name": "my-scheduled-service",
-        "type": "Scheduled Job",
-        "schedule": "none",
-        "retries": "1",
-        "timeout": "60m",
-        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
-    }
-
-    os.chdir(tmp_path)
+    os.chdir(path)
     service_manager = ServiceManager()
     service_manager.migrate_copilot_manifests()
 
-    with open(tmp_path / "services/my-scheduled-service/service-config.yml") as f:
+    with open(path / "services/my-scheduled-service/service-config.yml") as f:
+        service_config = yaml.safe_load(f)
+
+    assert service_config == expected_service_config
+
+
+def test_migrate_scheduled_job_handles_schedule_being_none(
+    copilot_scheduled_job_manifest, expected_scheduled_job_config
+):
+    path = copilot_scheduled_job_manifest({"on": {"schedule": "none"}})
+    expected_service_config = expected_scheduled_job_config({"schedule": "none"})
+
+    os.chdir(path)
+    service_manager = ServiceManager()
+    service_manager.migrate_copilot_manifests()
+
+    with open(path / "services/my-scheduled-service/service-config.yml") as f:
         service_config = yaml.safe_load(f)
 
     assert service_config == expected_service_config
@@ -982,40 +957,17 @@ def test_migrate_scheduled_job_handles_none(tmp_path):
     ids=["hourly", "daily", "weekly", "monthly", "yearly", "five minutes past each hour"],
 )
 def test_migrate_scheduled_job_converts_schedule_to_eventbridge_format(
-    tmp_path, test_input, expected
+    copilot_scheduled_job_manifest, expected_scheduled_job_config, test_input, expected
 ):
-    account_id = "563763463626"
-    ecr_repo = "demodjango/my-scheduled-service"
+    path = copilot_scheduled_job_manifest({"on": {"schedule": test_input}})
 
-    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
-    copilot_dir.mkdir(parents=True)
-    manifest_path = copilot_dir / "manifest.yml"
+    expected_service_config = expected_scheduled_job_config({"schedule": expected})
 
-    manifest_content = {
-        "name": "my-scheduled-service",
-        "type": "Scheduled Job",
-        "on": {"schedule": test_input},
-        "retries": "1",
-        "timeout": "60m",
-        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
-    }
-    with open(manifest_path, "w") as f:
-        yaml.safe_dump(manifest_content, f)
-
-    expected_service_config = {
-        "name": "my-scheduled-service",
-        "type": "Scheduled Job",
-        "schedule": expected,
-        "retries": "1",
-        "timeout": "60m",
-        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
-    }
-
-    os.chdir(tmp_path)
+    os.chdir(path)
     service_manager = ServiceManager()
     service_manager.migrate_copilot_manifests()
 
-    with open(tmp_path / "services/my-scheduled-service/service-config.yml") as f:
+    with open(path / "services/my-scheduled-service/service-config.yml") as f:
         service_config = yaml.safe_load(f)
 
     assert service_config == expected_service_config

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -804,7 +804,7 @@ def copilot_scheduled_job_manifest(tmp_path):
         "timeout": "60m",
     }
 
-    def _make(extra=None | dict):
+    def _make(extra={}):
         if extra:
             copilot_manifest_content.update(extra)
         with open(manifest_path, "w") as f:
@@ -816,12 +816,14 @@ def copilot_scheduled_job_manifest(tmp_path):
 
 
 def test_migrate_scheduled_job_copilot_manifests_creates_services_directory_and_files(
-    tmp_path, copilot_scheduled_job_manifest
+    copilot_scheduled_job_manifest,
 ):
-    output_dir = tmp_path / "services"
+    path = copilot_scheduled_job_manifest()
+
+    output_dir = path / "services"
     file_path = output_dir / "my-scheduled-service/service-config.yml"
 
-    os.chdir(tmp_path)
+    os.chdir(path)
     service_manager = ServiceManager()
     service_manager.migrate_copilot_manifests()
 

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -43,23 +43,23 @@ def copilot_manifest(tmp_path):
     return tmp_path
 
 
-@pytest.fixture
-def copilot_scheduled_job_manifest(tmp_path):
-    copilot_dir = tmp_path / "copilot" / "my-service"
-    copilot_dir.mkdir(parents=True)
-    manifest_path = copilot_dir / "manifest.yml"
-    manifest_content = {
-        "name": "my-scheduled-service",
-        "type": "Scheduled Job",
-        "on": {"schedule": "0 1 * * *"},
-        "retries": "1",
-        "timeout": "60m",
-        "image": {"build": "./copilot/developer-database-dumper/image/Dockerfile"},
-        "variables": {"S3_BUCKET_NAME": "${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}"},
-    }
-    with open(manifest_path, "w") as f:
-        yaml.safe_dump(manifest_content, f)
-    return tmp_path
+# @pytest.fixture
+# def copilot_scheduled_job_manifest(tmp_path):
+#     copilot_dir = tmp_path / "copilot" / "my-service"
+#     copilot_dir.mkdir(parents=True)
+#     manifest_path = copilot_dir / "manifest.yml"
+#     manifest_content = {
+#         "name": "my-scheduled-service",
+#         "type": "Scheduled Job",
+#         "on": {"schedule": "0 1 * * *"},
+#         "retries": "1",
+#         "timeout": "60m",
+#         "image": {"build": "./copilot/developer-database-dumper/image/Dockerfile"},
+#         "variables": {"S3_BUCKET_NAME": "${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}"},
+#     }
+#     with open(manifest_path, "w") as f:
+#         yaml.safe_dump(manifest_content, f)
+#     return tmp_path
 
 
 def test_migrate_copilot_manifests_creates_services_directory_and_files(tmp_path, copilot_manifest):
@@ -810,8 +810,17 @@ class TestServiceExecRaises:
 
 
 def test_migrate_copilot_scheduled_job_generates_expected_service_config(tmp_path):
+    config_path = tmp_path / "platform-config.yml"
+    config_data = {
+        "application": "demodjango",
+        "environments": {"*": {"accounts": {"deploy": {"id": "563763463626"}}}},
+    }
+
+    with open(config_path, "w") as f:
+        yaml.safe_dump(config_data, f)
+
     account_id = "563763463626"
-    ecr_repo = "demodjango/application"
+    ecr_repo = "demodjango/my-scheduled-service"
 
     copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
     copilot_dir.mkdir(parents=True)

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -43,6 +43,25 @@ def copilot_manifest(tmp_path):
     return tmp_path
 
 
+@pytest.fixture
+def copilot_scheduled_job_manifest(tmp_path):
+    copilot_dir = tmp_path / "copilot" / "my-service"
+    copilot_dir.mkdir(parents=True)
+    manifest_path = copilot_dir / "manifest.yml"
+    manifest_content = {
+        "name": "my-scheduled-service",
+        "type": "Scheduled Job",
+        "on": {"schedule": "0 1 * * *"},
+        "retries": "1",
+        "timeout": "60m",
+        "image": {"build": "./copilot/developer-database-dumper/image/Dockerfile"},
+        "variables": {"S3_BUCKET_NAME": "${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}"},
+    }
+    with open(manifest_path, "w") as f:
+        yaml.safe_dump(manifest_content, f)
+    return tmp_path
+
+
 def test_migrate_copilot_manifests_creates_services_directory_and_files(tmp_path, copilot_manifest):
     output_dir = tmp_path / "services"
     file_path = output_dir / "my-service/service-config.yml"
@@ -183,22 +202,22 @@ def test_migrate_service_configs_no_writable_dirs(tmp_path):
     assert service_config == expected_service_config
 
 
-def test_migrate_copilot_manifests_skips_unwanted_service_types(tmp_path):
-    copilot_dir = tmp_path / "copilot" / "my-service"
-    copilot_dir.mkdir(parents=True)
-    manifest_path = copilot_dir / "manifest.yml"
-    manifest_content = {"name": "my-service", "type": "Scheduled Job"}
-    with open(manifest_path, "w") as f:
-        yaml.safe_dump(manifest_content, f)
+# def test_migrate_copilot_manifests_skips_unwanted_service_types(tmp_path):
+#     copilot_dir = tmp_path / "copilot" / "my-service"
+#     copilot_dir.mkdir(parents=True)
+#     manifest_path = copilot_dir / "manifest.yml"
+#     manifest_content = {"name": "my-service", "type": "Scheduled Job"}
+#     with open(manifest_path, "w") as f:
+#         yaml.safe_dump(manifest_content, f)
 
-    output_dir = tmp_path / "services"
-    file_path = output_dir / "my-service/service-config.yml"
+#     output_dir = tmp_path / "services"
+#     file_path = output_dir / "my-service/service-config.yml"
 
-    os.chdir(tmp_path)
-    service_manager = ServiceManager()
-    service_manager.migrate_copilot_manifests()
+#     os.chdir(tmp_path)
+#     service_manager = ServiceManager()
+#     service_manager.migrate_copilot_manifests()
 
-    assert not file_path.exists()
+#     assert not file_path.exists()
 
 
 def test_migrate_copilot_manifests_sets_depends_on_for_remaining_sidecars(
@@ -785,3 +804,56 @@ class TestServiceExecRaises:
             service_manager.service_exec("test-app", "test-env", "test-service")
 
         assert "Command `some cli command` failed with error: command unknown" in str(e.value)
+
+
+# SCHEDULED JOBS TESTS --------------------------------------------------------------
+
+
+def test_migrate_copilot_scheduled_job_generates_expected_service_config(tmp_path):
+    account_id = "563763463626"
+    ecr_repo = "demodjango/application"
+
+    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
+    copilot_dir.mkdir(parents=True)
+    manifest_path = copilot_dir / "manifest.yml"
+
+    manifest_content = {
+        "name": "my-scheduled-service",
+        "type": "Scheduled Job",
+        "on": {"schedule": "none"},
+        "retries": "1",
+        "timeout": "60m",
+        "image": {"build": "./copilot/developer-database-dumper/image/Dockerfile"},
+        "environments": {
+            "dev": {"schedule": "0 * * * ? *"},
+            "prod": {"schedule": ""},
+        },
+        "variables": {"S3_BUCKET_NAME": "${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}"},
+    }
+    with open(manifest_path, "w") as f:
+        yaml.safe_dump(manifest_content, f)
+
+    expected_service_config = {
+        "name": "my-scheduled-service",
+        "type": "Scheduled Job",
+        "on": {"schedule": "none"},
+        "retries": "1",
+        "timeout": "60m",
+        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
+        "environments": {
+            "dev": {"schedule": "0 * * * ? *"},
+            "prod": {"schedule": ""},
+        },
+        "variables": {
+            "S3_BUCKET_NAME": "${PLATFORM_APPLICATION_NAME}-${PLATFORM_ENVIRONMENT_NAME}"
+        },
+    }
+
+    os.chdir(tmp_path)
+    service_manager = ServiceManager()
+    service_manager.migrate_copilot_manifests()
+
+    with open(tmp_path / "services/my-scheduled-service/service-config.yml") as f:
+        service_config = yaml.safe_load(f)
+
+    assert service_config == expected_service_config

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -969,3 +969,40 @@ def test_migrate_scheduled_job_handles_overrides(
         service_config = yaml.safe_load(f)
 
     assert service_config == expected_service_config
+
+
+# In Copilot manifests the key *on* is unquoted, and when parsed by YAML it is interpreted as a bool value (True). This test ensures our code correctly handles that behaviour and still processes the schedule configuration as expected. We can remove this test once we stop using Copilot manifests syntax.
+def test_migrate_scheduled_job_handles_unquoted_on_key(tmp_path, expected_scheduled_job_config):
+    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
+    copilot_dir.mkdir(parents=True)
+    manifest_path = copilot_dir / "manifest.yml"
+
+    manifest_path.write_text(
+        """
+name: my-scheduled-service
+type: Scheduled Job
+on:
+  schedule: "@daily"
+retries: "1"
+timeout: "60m"
+image:
+  location: 123456789012.dkr.ecr.eu-west-2.amazonaws.com/demodjango/my-scheduled-service:a-tag
+environments:
+  dev:
+    on:
+      schedule: "@hourly"
+""".lstrip()
+    )
+
+    expected_service_config = expected_scheduled_job_config(
+        {"schedule": "rate(1 days)", "environments": {"dev": {"schedule": "rate(1 hours)"}}}
+    )
+
+    os.chdir(tmp_path)
+    service_manager = ServiceManager()
+    service_manager.migrate_copilot_manifests()
+
+    with open(tmp_path / "services/my-scheduled-service/service-config.yml") as f:
+        service_config = yaml.safe_load(f)
+
+    assert service_config == expected_service_config

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -50,6 +50,29 @@ def copilot_manifest(tmp_path):
     return _make
 
 
+@pytest.fixture
+def expected_service_config():
+    def _make(extra={}):
+        expected_content = {
+            "name": "my-service",
+            "type": "Load Balanced Web Service",
+            "environments": {
+                "dev": {"http": {"alias": ["test.alias.com"]}},
+                "prod": {"http": {"alias": ["test.alias.com", "test2.alias.com"]}},
+            },
+            "variables": {
+                "S3_BUCKET_NAME": "${PLATFORM_APPLICATION_NAME}-${PLATFORM_ENVIRONMENT_NAME}"
+            },
+        }
+
+        if extra:
+            expected_content.update(extra)
+
+        return expected_content
+
+    return _make
+
+
 def test_migrate_copilot_manifests_creates_services_directory_and_files(copilot_manifest):
     path = copilot_manifest()
     output_dir = path / "services"
@@ -62,19 +85,10 @@ def test_migrate_copilot_manifests_creates_services_directory_and_files(copilot_
     assert file_path.exists()
 
 
-def test_migrate_copilot_manifests_generates_expected_service_config(copilot_manifest):
+def test_migrate_copilot_manifests_generates_expected_service_config(
+    copilot_manifest, expected_service_config
+):
     path = copilot_manifest()
-    expected_service_config = {
-        "name": "my-service",
-        "type": "Load Balanced Web Service",
-        "environments": {
-            "dev": {"http": {"alias": ["test.alias.com"]}},
-            "prod": {"http": {"alias": ["test.alias.com", "test2.alias.com"]}},
-        },
-        "variables": {
-            "S3_BUCKET_NAME": "${PLATFORM_APPLICATION_NAME}-${PLATFORM_ENVIRONMENT_NAME}"
-        },
-    }
 
     os.chdir(path)
     service_manager = ServiceManager()
@@ -83,10 +97,10 @@ def test_migrate_copilot_manifests_generates_expected_service_config(copilot_man
     with open(path / "services/my-service/service-config.yml") as f:
         service_config = yaml.safe_load(f)
 
-    assert service_config == expected_service_config
+    assert service_config == expected_service_config()
 
 
-def test_migrate_service_configs_writable_dirs(copilot_manifest):
+def test_migrate_service_configs_writable_dirs(copilot_manifest, expected_service_config):
     path = copilot_manifest(
         {
             "sidecars": {
@@ -99,20 +113,13 @@ def test_migrate_service_configs_writable_dirs(copilot_manifest):
         }
     )
 
-    expected_service_config = {
-        "name": "my-service",
-        "type": "Load Balanced Web Service",
-        "environments": {
-            "dev": {"http": {"alias": ["test.alias.com"]}},
-            "prod": {"http": {"alias": ["test.alias.com", "test2.alias.com"]}},
-        },
-        "image": {},
-        "sidecars": {},
-        "storage": {"readonly_fs": False, "writable_directories": ["/write/dir"]},
-        "variables": {
-            "S3_BUCKET_NAME": "${PLATFORM_APPLICATION_NAME}-${PLATFORM_ENVIRONMENT_NAME}"
-        },
-    }
+    expected_service_config = expected_service_config(
+        {
+            "image": {},
+            "sidecars": {},
+            "storage": {"readonly_fs": False, "writable_directories": ["/write/dir"]},
+        }
+    )
 
     os.chdir(path)
     service_manager = ServiceManager()
@@ -124,7 +131,7 @@ def test_migrate_service_configs_writable_dirs(copilot_manifest):
     assert service_config == expected_service_config
 
 
-def test_migrate_service_configs_no_writable_dirs(copilot_manifest):
+def test_migrate_service_configs_no_writable_dirs(copilot_manifest, expected_service_config):
     path = copilot_manifest(
         {
             "sidecars": {
@@ -140,25 +147,18 @@ def test_migrate_service_configs_no_writable_dirs(copilot_manifest):
         }
     )
 
-    expected_service_config = {
-        "name": "my-service",
-        "type": "Load Balanced Web Service",
-        "environments": {
-            "dev": {"http": {"alias": ["test.alias.com"]}},
-            "prod": {"http": {"alias": ["test.alias.com", "test2.alias.com"]}},
-        },
-        "sidecars": {
-            "not-real": {
-                "port": 2772,
-                "image": "not-real-image",
-                "essential": True,
-            }
-        },
-        "storage": {"readonly_fs": False, "writable_directories": []},
-        "variables": {
-            "S3_BUCKET_NAME": "${PLATFORM_APPLICATION_NAME}-${PLATFORM_ENVIRONMENT_NAME}"
-        },
-    }
+    expected_service_config = expected_service_config(
+        {
+            "sidecars": {
+                "not-real": {
+                    "port": 2772,
+                    "image": "not-real-image",
+                    "essential": True,
+                }
+            },
+            "storage": {"readonly_fs": False, "writable_directories": []},
+        }
+    )
 
     os.chdir(path)
     service_manager = ServiceManager()

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -788,26 +788,31 @@ class TestServiceExecRaises:
 
 
 # SCHEDULED JOBS TESTS --------------------------------------------------------------
+
+
 @pytest.fixture
 def copilot_scheduled_job_manifest(tmp_path):
-    account_id = "563763463626"
-    ecr_repo = "demodjango/my-scheduled-service"
 
     copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
     copilot_dir.mkdir(parents=True)
     manifest_path = copilot_dir / "manifest.yml"
-    manifest_content = {
+    copilot_manifest_content = {
         "name": "my-scheduled-service",
         "type": "Scheduled Job",
-        "on": {"schedule": "@hourly"},
+        "on": {"schedule": "none"},
         "retries": "1",
         "timeout": "60m",
-        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
-        "variables": {"S3_BUCKET_NAME": "${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}"},
     }
-    with open(manifest_path, "w") as f:
-        yaml.safe_dump(manifest_content, f)
-    return tmp_path
+
+    def _make(extra=None | dict):
+        if extra:
+            copilot_manifest_content.update(extra)
+        with open(manifest_path, "w") as f:
+            yaml.safe_dump(copilot_manifest_content, f)
+
+        return tmp_path
+
+    return _make
 
 
 def test_migrate_scheduled_job_copilot_manifests_creates_services_directory_and_files(
@@ -823,7 +828,9 @@ def test_migrate_scheduled_job_copilot_manifests_creates_services_directory_and_
     assert file_path.exists()
 
 
-def test_migrate_scheduled_job_converts_image_build_to_location(tmp_path):
+def test_migrate_scheduled_job_converts_image_build_to_location(
+    tmp_path, copilot_scheduled_job_manifest
+):
     config_path = tmp_path / "platform-config.yml"
     config_data = {
         "application": "demodjango",
@@ -836,40 +843,17 @@ def test_migrate_scheduled_job_converts_image_build_to_location(tmp_path):
     account_id = "563763463626"
     ecr_repo = "demodjango/my-scheduled-service"
 
-    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
-    copilot_dir.mkdir(parents=True)
-    manifest_path = copilot_dir / "manifest.yml"
-
-    manifest_content = {
-        "name": "my-scheduled-service",
-        "type": "Scheduled Job",
-        "on": {"schedule": "none"},
-        "retries": "1",
-        "timeout": "60m",
-        "image": {"build": "./copilot/developer-database-dumper/image/Dockerfile"},
-        "environments": {
-            "dev": {"schedule": "0 * * * ? *"},
-            "prod": {"schedule": ""},
-        },
-        "variables": {"S3_BUCKET_NAME": "${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}"},
-    }
-    with open(manifest_path, "w") as f:
-        yaml.safe_dump(manifest_content, f)
+    copilot_scheduled_job_manifest(
+        {"image": {"build": "./copilot/developer-database-dumper/image/Dockerfile"}}
+    )
 
     expected_service_config = {
         "name": "my-scheduled-service",
         "type": "Scheduled Job",
-        "on": {"schedule": "none"},
+        "schedule": "none",
         "retries": "1",
         "timeout": "60m",
         "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
-        "environments": {
-            "dev": {"schedule": "0 * * * ? *"},
-            "prod": {"schedule": ""},
-        },
-        "variables": {
-            "S3_BUCKET_NAME": "${PLATFORM_APPLICATION_NAME}-${PLATFORM_ENVIRONMENT_NAME}"
-        },
     }
 
     os.chdir(tmp_path)
@@ -905,7 +889,7 @@ def test_migrate_scheduled_job_removes_network_block(tmp_path):
     expected_service_config = {
         "name": "my-scheduled-service",
         "type": "Scheduled Job",
-        "on": {"schedule": "none"},
+        "schedule": "none",
         "retries": "1",
         "timeout": "60m",
         "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
@@ -943,7 +927,45 @@ def test_migrate_scheduled_job_removes_image_tag(tmp_path):
     expected_service_config = {
         "name": "my-scheduled-service",
         "type": "Scheduled Job",
+        "schedule": "none",
+        "retries": "1",
+        "timeout": "60m",
+        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
+    }
+
+    os.chdir(tmp_path)
+    service_manager = ServiceManager()
+    service_manager.migrate_copilot_manifests()
+
+    with open(tmp_path / "services/my-scheduled-service/service-config.yml") as f:
+        service_config = yaml.safe_load(f)
+
+    assert service_config == expected_service_config
+
+
+def test_migrate_scheduled_job_handles_none(tmp_path):
+    account_id = "563763463626"
+    ecr_repo = "demodjango/my-scheduled-service"
+
+    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
+    copilot_dir.mkdir(parents=True)
+    manifest_path = copilot_dir / "manifest.yml"
+
+    manifest_content = {
+        "name": "my-scheduled-service",
+        "type": "Scheduled Job",
         "on": {"schedule": "none"},
+        "retries": "1",
+        "timeout": "60m",
+        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
+    }
+    with open(manifest_path, "w") as f:
+        yaml.safe_dump(manifest_content, f)
+
+    expected_service_config = {
+        "name": "my-scheduled-service",
+        "type": "Scheduled Job",
+        "schedule": "none",
         "retries": "1",
         "timeout": "60m",
         "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -910,6 +910,52 @@ def test_migrate_scheduled_job_handles_schedule_being_none(
     assert service_config == expected_service_config
 
 
+def test_migrate_scheduled_job_places_schedule_key_in_correct_place(tmp_path):
+    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
+    copilot_dir.mkdir(parents=True)
+    manifest_path = copilot_dir / "manifest.yml"
+
+    manifest_path.write_text(
+        """
+name: my-scheduled-service
+type: Scheduled Job
+on:
+  schedule: none
+retries: 1
+timeout: 60m
+image:
+  location: 123456789012.dkr.ecr.eu-west-2.amazonaws.com/demodjango/my-scheduled-service:a-tag
+""".lstrip()
+    )
+
+    expected_output_dir = tmp_path / "expected_output"
+    expected_output_dir.mkdir(parents=True)
+    expected_output_path = expected_output_dir / "expected_output.yml"
+    expected_output_path.write_text(
+        """
+name: my-scheduled-service
+type: Scheduled Job
+schedule: none
+retries: 1
+timeout: 60m
+image:
+  location: 123456789012.dkr.ecr.eu-west-2.amazonaws.com/demodjango/my-scheduled-service
+""".lstrip()
+    )
+
+    os.chdir(tmp_path)
+    service_manager = ServiceManager()
+    service_manager.migrate_copilot_manifests()
+
+    with open(tmp_path / "services/my-scheduled-service/service-config.yml") as f:
+        service_config = f.read()
+
+    with open(expected_output_path) as f:
+        expected_output = f.read()
+
+    assert expected_output in service_config
+
+
 @pytest.mark.parametrize(
     "test_input,expected",
     [

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -62,7 +62,7 @@ def test_migrate_copilot_manifests_creates_services_directory_and_files(copilot_
     assert file_path.exists()
 
 
-def test_migrate_copilot_manifests_generates_expected_service_config(tmp_path, copilot_manifest):
+def test_migrate_copilot_manifests_generates_expected_service_config(copilot_manifest):
     path = copilot_manifest()
     expected_service_config = {
         "name": "my-service",
@@ -86,29 +86,18 @@ def test_migrate_copilot_manifests_generates_expected_service_config(tmp_path, c
     assert service_config == expected_service_config
 
 
-def test_migrate_service_configs_writable_dirs(tmp_path):
-
-    copilot_dir = tmp_path / "copilot" / "my-service"
-    copilot_dir.mkdir(parents=True)
-    manifest_path = copilot_dir / "manifest.yml"
-    manifest_content = {
-        "name": "my-service",
-        "type": "Load Balanced Web Service",
-        "image": {"depends_on": {"permissions_side": "success"}},
-        "environments": {
-            "dev": {"http": {"alb": "alb-arn", "alias": "test.alias.com"}},
-            "prod": {"http": {"alb": "alb-arn", "alias": ["test.alias.com", "test2.alias.com"]}},
-        },
-        "sidecars": {
-            "permissions_side": {
-                "command": ["chown"],
-                "mount_points": [{"path": "/write/dir"}],
-            }
-        },
-        "variables": {"S3_BUCKET_NAME": "${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}"},
-    }
-    with open(manifest_path, "w") as f:
-        yaml.safe_dump(manifest_content, f)
+def test_migrate_service_configs_writable_dirs(copilot_manifest):
+    path = copilot_manifest(
+        {
+            "sidecars": {
+                "permissions_side": {
+                    "command": ["chown"],
+                    "mount_points": [{"path": "/write/dir"}],
+                }
+            },
+            "image": {"depends_on": {"permissions_side": "success"}},
+        }
+    )
 
     expected_service_config = {
         "name": "my-service",
@@ -125,42 +114,31 @@ def test_migrate_service_configs_writable_dirs(tmp_path):
         },
     }
 
-    os.chdir(tmp_path)
+    os.chdir(path)
     service_manager = ServiceManager()
     service_manager.migrate_copilot_manifests()
 
-    with open(tmp_path / "services/my-service/service-config.yml") as f:
+    with open(path / "services/my-service/service-config.yml") as f:
         service_config = yaml.safe_load(f)
 
     assert service_config == expected_service_config
 
 
-def test_migrate_service_configs_no_writable_dirs(tmp_path):
-
-    copilot_dir = tmp_path / "copilot" / "my-service"
-    copilot_dir.mkdir(parents=True)
-    manifest_path = copilot_dir / "manifest.yml"
-    manifest_content = {
-        "name": "my-service",
-        "type": "Load Balanced Web Service",
-        "environments": {
-            "dev": {"http": {"alb": "alb-arn", "alias": "test.alias.com"}},
-            "prod": {"http": {"alb": "alb-arn", "alias": ["test.alias.com", "test2.alias.com"]}},
-        },
-        "sidecars": {
-            "not-real": {
-                "port": 2772,
-                "image": "not-real-image",
-                "essential": True,
-            }
-        },
-        "storage": {
-            "readonly_fs": False,
-        },
-        "variables": {"S3_BUCKET_NAME": "${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}"},
-    }
-    with open(manifest_path, "w") as f:
-        yaml.safe_dump(manifest_content, f)
+def test_migrate_service_configs_no_writable_dirs(copilot_manifest):
+    path = copilot_manifest(
+        {
+            "sidecars": {
+                "not-real": {
+                    "port": 2772,
+                    "image": "not-real-image",
+                    "essential": True,
+                }
+            },
+            "storage": {
+                "readonly_fs": False,
+            },
+        }
+    )
 
     expected_service_config = {
         "name": "my-service",
@@ -182,65 +160,38 @@ def test_migrate_service_configs_no_writable_dirs(tmp_path):
         },
     }
 
-    os.chdir(tmp_path)
+    os.chdir(path)
     service_manager = ServiceManager()
     service_manager.migrate_copilot_manifests()
 
-    with open(tmp_path / "services/my-service/service-config.yml") as f:
+    with open(path / "services/my-service/service-config.yml") as f:
         service_config = yaml.safe_load(f)
 
     assert service_config == expected_service_config
 
 
-# def test_migrate_copilot_manifests_skips_unwanted_service_types(tmp_path):
-#     copilot_dir = tmp_path / "copilot" / "my-service"
-#     copilot_dir.mkdir(parents=True)
-#     manifest_path = copilot_dir / "manifest.yml"
-#     manifest_content = {"name": "my-service", "type": "Scheduled Job"}
-#     with open(manifest_path, "w") as f:
-#         yaml.safe_dump(manifest_content, f)
-
-#     output_dir = tmp_path / "services"
-#     file_path = output_dir / "my-service/service-config.yml"
-
-#     os.chdir(tmp_path)
-#     service_manager = ServiceManager()
-#     service_manager.migrate_copilot_manifests()
-
-#     assert not file_path.exists()
-
-
-def test_migrate_copilot_manifests_sets_depends_on_for_remaining_sidecars(
-    tmp_path,
-):
-    copilot_dir = tmp_path / "copilot" / "my-service"
-    copilot_dir.mkdir(parents=True)
-    manifest_path = copilot_dir / "manifest.yml"
-
-    manifest_content = {
-        "name": "my-service",
-        "type": "Load Balanced Web Service",
-        "image": {"location": "myrepo/myimage:latest"},
-        "sidecars": {
-            "permissions": {
-                "command": "chown -R 1000:1000 /tmp",
-                "mount_points": [{"path": "/tmp"}],
+def test_migrate_copilot_manifests_sets_depends_on_for_remaining_sidecars(copilot_manifest):
+    path = copilot_manifest(
+        {
+            "sidecars": {
+                "permissions": {
+                    "command": "chown -R 1000:1000 /tmp",
+                    "mount_points": [{"path": "/tmp"}],
+                },
+                "hello-world": {
+                    "command": 'echo "Hello World"',
+                },
             },
-            "hello-world": {
-                "command": 'echo "Hello World"',
-            },
-        },
-    }
+            "image": {"location": "myrepo/myimage:latest"},
+        }
+    )
 
-    with open(manifest_path, "w") as f:
-        yaml.safe_dump(manifest_content, f)
-
-    os.chdir(tmp_path)
+    os.chdir(path)
     service_manager = ServiceManager()
 
     service_manager.migrate_copilot_manifests()
 
-    with open(tmp_path / "services/my-service/service-config.yml") as f:
+    with open(path / "services/my-service/service-config.yml") as f:
         service_config = yaml.safe_load(f)
 
     assert "sidecars" in service_config

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -826,13 +826,23 @@ def test_migrate_scheduled_job_converts_image_build_to_location(
     config_path = path / "platform-config.yml"
     config_data = {
         "application": "demodjango",
-        "environments": {"*": {"accounts": {"deploy": {"id": "563763463626"}}}},
+        "schema_version": 1,
+        "default_versions": {"platform-helper": "15.25.0"},
+        "environments": {
+            "*": {
+                "accounts": {
+                    "deploy": {"id": "123456789012", "name": "test-account"},
+                    "dns": {"id": "011755346992", "name": "dev"},
+                }
+            },
+            "env1": {},
+        },
     }
 
     with open(config_path, "w") as f:
         yaml.safe_dump(config_data, f)
 
-    account_id = "563763463626"
+    account_id = "123456789012"
     ecr_repo = "demodjango/my-scheduled-service"
 
     expected_service_config = expected_scheduled_job_config(

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -868,25 +868,12 @@ def test_migrate_scheduled_job_converts_image_build_to_location(
     assert service_config == expected_service_config
 
 
-def test_migrate_scheduled_job_removes_network_block(tmp_path):
-    account_id = "563763463626"
-    ecr_repo = "demodjango/my-scheduled-service"
-
-    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
-    copilot_dir.mkdir(parents=True)
-    manifest_path = copilot_dir / "manifest.yml"
-
-    manifest_content = {
-        "name": "my-scheduled-service",
-        "type": "Scheduled Job",
-        "on": {"schedule": "none"},
-        "retries": "1",
-        "timeout": "60m",
-        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
-        "network": {"connect": "true", "vpc": {"placement": "private"}},
-    }
-    with open(manifest_path, "w") as f:
-        yaml.safe_dump(manifest_content, f)
+def test_migrate_scheduled_job_removes_network_block(tmp_path, copilot_scheduled_job_manifest):
+    path = copilot_scheduled_job_manifest(
+        {
+            "network": {"connect": "true", "vpc": {"placement": "private"}},
+        }
+    )
 
     expected_service_config = {
         "name": "my-scheduled-service",
@@ -894,14 +881,13 @@ def test_migrate_scheduled_job_removes_network_block(tmp_path):
         "schedule": "none",
         "retries": "1",
         "timeout": "60m",
-        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
     }
 
-    os.chdir(tmp_path)
+    os.chdir(path)
     service_manager = ServiceManager()
     service_manager.migrate_copilot_manifests()
 
-    with open(tmp_path / "services/my-scheduled-service/service-config.yml") as f:
+    with open(path / "services/my-scheduled-service/service-config.yml") as f:
         service_config = yaml.safe_load(f)
 
     assert service_config == expected_service_config

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -43,25 +43,6 @@ def copilot_manifest(tmp_path):
     return tmp_path
 
 
-# @pytest.fixture
-# def copilot_scheduled_job_manifest(tmp_path):
-#     copilot_dir = tmp_path / "copilot" / "my-service"
-#     copilot_dir.mkdir(parents=True)
-#     manifest_path = copilot_dir / "manifest.yml"
-#     manifest_content = {
-#         "name": "my-scheduled-service",
-#         "type": "Scheduled Job",
-#         "on": {"schedule": "0 1 * * *"},
-#         "retries": "1",
-#         "timeout": "60m",
-#         "image": {"build": "./copilot/developer-database-dumper/image/Dockerfile"},
-#         "variables": {"S3_BUCKET_NAME": "${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}"},
-#     }
-#     with open(manifest_path, "w") as f:
-#         yaml.safe_dump(manifest_content, f)
-#     return tmp_path
-
-
 def test_migrate_copilot_manifests_creates_services_directory_and_files(tmp_path, copilot_manifest):
     output_dir = tmp_path / "services"
     file_path = output_dir / "my-service/service-config.yml"
@@ -807,6 +788,39 @@ class TestServiceExecRaises:
 
 
 # SCHEDULED JOBS TESTS --------------------------------------------------------------
+@pytest.fixture
+def copilot_scheduled_job_manifest(tmp_path):
+    account_id = "563763463626"
+    ecr_repo = "demodjango/my-scheduled-service"
+
+    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
+    copilot_dir.mkdir(parents=True)
+    manifest_path = copilot_dir / "manifest.yml"
+    manifest_content = {
+        "name": "my-scheduled-service",
+        "type": "Scheduled Job",
+        "on": {"schedule": "@hourly"},
+        "retries": "1",
+        "timeout": "60m",
+        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
+        "variables": {"S3_BUCKET_NAME": "${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}"},
+    }
+    with open(manifest_path, "w") as f:
+        yaml.safe_dump(manifest_content, f)
+    return tmp_path
+
+
+def test_migrate_scheduled_job_copilot_manifests_creates_services_directory_and_files(
+    tmp_path, copilot_scheduled_job_manifest
+):
+    output_dir = tmp_path / "services"
+    file_path = output_dir / "my-scheduled-service/service-config.yml"
+
+    os.chdir(tmp_path)
+    service_manager = ServiceManager()
+    service_manager.migrate_copilot_manifests()
+
+    assert file_path.exists()
 
 
 def test_migrate_scheduled_job_converts_image_build_to_location(tmp_path):
@@ -930,6 +944,51 @@ def test_migrate_scheduled_job_removes_image_tag(tmp_path):
         "name": "my-scheduled-service",
         "type": "Scheduled Job",
         "on": {"schedule": "none"},
+        "retries": "1",
+        "timeout": "60m",
+        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
+    }
+
+    os.chdir(tmp_path)
+    service_manager = ServiceManager()
+    service_manager.migrate_copilot_manifests()
+
+    with open(tmp_path / "services/my-scheduled-service/service-config.yml") as f:
+        service_config = yaml.safe_load(f)
+
+    assert service_config == expected_service_config
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [("@hourly", "rate(1 hours)"), ("@daily", "rate(1 days)"), ("5 * * * *", "5 * * * ?")],
+    ids=["hourly", "daily", "five minutes past each hour"],
+)
+def test_migrate_scheduled_job_converts_schedule_to_eventbridge_format(
+    tmp_path, test_input, expected
+):
+    account_id = "563763463626"
+    ecr_repo = "demodjango/my-scheduled-service"
+
+    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
+    copilot_dir.mkdir(parents=True)
+    manifest_path = copilot_dir / "manifest.yml"
+
+    manifest_content = {
+        "name": "my-scheduled-service",
+        "type": "Scheduled Job",
+        "on": {"schedule": test_input},
+        "retries": "1",
+        "timeout": "60m",
+        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
+    }
+    with open(manifest_path, "w") as f:
+        yaml.safe_dump(manifest_content, f)
+
+    expected_service_config = {
+        "name": "my-scheduled-service",
+        "type": "Scheduled Job",
+        "on": {"schedule": expected},
         "retries": "1",
         "timeout": "60m",
         "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -809,7 +809,7 @@ class TestServiceExecRaises:
 # SCHEDULED JOBS TESTS --------------------------------------------------------------
 
 
-def test_migrate_copilot_scheduled_job_generates_expected_service_config(tmp_path):
+def test_migrate_scheduled_job_converts_image_build_to_location(tmp_path):
     config_path = tmp_path / "platform-config.yml"
     config_data = {
         "application": "demodjango",
@@ -856,6 +856,83 @@ def test_migrate_copilot_scheduled_job_generates_expected_service_config(tmp_pat
         "variables": {
             "S3_BUCKET_NAME": "${PLATFORM_APPLICATION_NAME}-${PLATFORM_ENVIRONMENT_NAME}"
         },
+    }
+
+    os.chdir(tmp_path)
+    service_manager = ServiceManager()
+    service_manager.migrate_copilot_manifests()
+
+    with open(tmp_path / "services/my-scheduled-service/service-config.yml") as f:
+        service_config = yaml.safe_load(f)
+
+    assert service_config == expected_service_config
+
+
+def test_migrate_scheduled_job_removes_network_block(tmp_path):
+    account_id = "563763463626"
+    ecr_repo = "demodjango/my-scheduled-service"
+
+    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
+    copilot_dir.mkdir(parents=True)
+    manifest_path = copilot_dir / "manifest.yml"
+
+    manifest_content = {
+        "name": "my-scheduled-service",
+        "type": "Scheduled Job",
+        "on": {"schedule": "none"},
+        "retries": "1",
+        "timeout": "60m",
+        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
+        "network": {"connect": "true", "vpc": {"placement": "private"}},
+    }
+    with open(manifest_path, "w") as f:
+        yaml.safe_dump(manifest_content, f)
+
+    expected_service_config = {
+        "name": "my-scheduled-service",
+        "type": "Scheduled Job",
+        "on": {"schedule": "none"},
+        "retries": "1",
+        "timeout": "60m",
+        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
+    }
+
+    os.chdir(tmp_path)
+    service_manager = ServiceManager()
+    service_manager.migrate_copilot_manifests()
+
+    with open(tmp_path / "services/my-scheduled-service/service-config.yml") as f:
+        service_config = yaml.safe_load(f)
+
+    assert service_config == expected_service_config
+
+
+def test_migrate_scheduled_job_removes_image_tag(tmp_path):
+    account_id = "563763463626"
+    ecr_repo = "demodjango/my-scheduled-service"
+
+    copilot_dir = tmp_path / "copilot" / "my-scheduled-service"
+    copilot_dir.mkdir(parents=True)
+    manifest_path = copilot_dir / "manifest.yml"
+
+    manifest_content = {
+        "name": "my-scheduled-service",
+        "type": "Scheduled Job",
+        "on": {"schedule": "none"},
+        "retries": "1",
+        "timeout": "60m",
+        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}:some-tag"},
+    }
+    with open(manifest_path, "w") as f:
+        yaml.safe_dump(manifest_content, f)
+
+    expected_service_config = {
+        "name": "my-scheduled-service",
+        "type": "Scheduled Job",
+        "on": {"schedule": "none"},
+        "retries": "1",
+        "timeout": "60m",
+        "image": {"location": f"{account_id}.dkr.ecr.eu-west-2.amazonaws.com/{ecr_repo}"},
     }
 
     os.chdir(tmp_path)


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-2876.

- Updates the `migrate-service-manifests` command to handle `Scheduled Job` manifests as pa
  - Removes `on` keyword from Scheduled Job manifest (requires the user to only specify `schedule`)
  - Ensure correct placement of `schedule` field in the `service-config.yml` file
  - (See ticket for other acceptance criteria covered by PR)
- Refactors existing tests to use Pytest fixtures

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [X] Link to ticket included (unless it's a quick out of ticket thing)
- [X] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present