### PR TITLE
refactor: Rename click test fixtures to workaround change (off-ticket)

### DIFF
--- a/tests/platform_helper/test-docs/example.py
+++ b/tests/platform_helper/test-docs/example.py
@@ -12,11 +12,11 @@ def cli():
 
 
 @click.group(chain=True, cls=ClickDocOptGroup)
-def group_command():
+def great_greets():
     pass
 
 
-@group_command.command(cls=ClickDocOptCommand)
+@great_greets.command(cls=ClickDocOptCommand)
 @click.option("--count", default=1, help="number of greetings")
 @click.argument("name")
 def hello(count, name):
@@ -24,7 +24,7 @@ def hello(count, name):
         click.echo(f"Hello {name}!")
 
 
-@group_command.command(cls=ClickDocOptCommand)
+@great_greets.command(cls=ClickDocOptCommand)
 @click.argument("app")
 @click.argument("env")
 @click.argument("svc")
@@ -32,7 +32,7 @@ def argument_replacements(app, env, svc):
     click.echo(f"app: {app}, env: {env}, svc: {svc}")
 
 
-@group_command.command(cls=ClickDocOptCommand)
+@great_greets.command(cls=ClickDocOptCommand)
 @click.option("--app")
 @click.option("--env")
 @click.option("--svc")
@@ -40,7 +40,7 @@ def option_replacements(app, env, svc):
     click.echo(f"app: {app}, env: {env}, svc: {svc}")
 
 
-cli.add_command(group_command)
+cli.add_command(great_greets)
 
 
 if __name__ == "__main__":

--- a/tests/platform_helper/test-docs/expected_output.md
+++ b/tests/platform_helper/test-docs/expected_output.md
@@ -1,17 +1,17 @@
 # Commands Reference
 
 - [cli](#cli)
-    - [cli group-command](#cli-group-command)
-        - [cli group-command hello](#cli-group-command-hello)
-        - [cli group-command argument-replacements](#cli-group-command-argument-replacements)
-        - [cli group-command option-replacements](#cli-group-command-option-replacements)
+    - [cli great-greets](#cli-great-greets)
+        - [cli great-greets hello](#cli-great-greets-hello)
+        - [cli great-greets argument-replacements](#cli-great-greets-argument-replacements)
+        - [cli great-greets option-replacements](#cli-great-greets-option-replacements)
 
 # cli
 
 ## Usage
 
 ```
-cli group-command 
+cli great-greets 
 ```
 
 ## Options
@@ -21,16 +21,16 @@ cli group-command
 
 ## Commands
 
-- [`group-command` ↪](#cli-group-command)
+- [`great-greets` ↪](#cli-great-greets)
 
-# cli group-command
+# cli great-greets
 
 [↩ Parent](#cli)
 
 ## Usage
 
 ```
-cli group-command (hello|argument-replacements|option-replacements) 
+cli great-greets (hello|argument-replacements|option-replacements) 
 ```
 
 ## Options
@@ -40,18 +40,18 @@ cli group-command (hello|argument-replacements|option-replacements)
 
 ## Commands
 
-- [`argument-replacements` ↪](#cli-group-command-argument-replacements)
-- [`hello` ↪](#cli-group-command-hello)
-- [`option-replacements` ↪](#cli-group-command-option-replacements)
+- [`argument-replacements` ↪](#cli-great-greets-argument-replacements)
+- [`hello` ↪](#cli-great-greets-hello)
+- [`option-replacements` ↪](#cli-great-greets-option-replacements)
 
-# cli group-command hello
+# cli great-greets hello
 
-[↩ Parent](#cli-group-command)
+[↩ Parent](#cli-great-greets)
 
 ## Usage
 
 ```
-cli group-command hello <name> [--count <count>] 
+cli great-greets hello <name> [--count <count>] 
 ```
 
 ## Arguments
@@ -65,14 +65,14 @@ cli group-command hello <name> [--count <count>]
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.
 
-# cli group-command argument-replacements
+# cli great-greets argument-replacements
 
-[↩ Parent](#cli-group-command)
+[↩ Parent](#cli-great-greets)
 
 ## Usage
 
 ```
-cli group-command argument-replacements <application> <environment> <service> 
+cli great-greets argument-replacements <application> <environment> <service> 
 ```
 
 ## Arguments
@@ -86,15 +86,15 @@ cli group-command argument-replacements <application> <environment> <service>
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.
 
-# cli group-command option-replacements
+# cli great-greets option-replacements
 
-[↩ Parent](#cli-group-command)
+[↩ Parent](#cli-great-greets)
 
 ## Usage
 
 ```
-cli group-command option-replacements [--app <application>] [--env <environment>] 
-                                      [--svc <service>] 
+cli great-greets option-replacements [--app <application>] [--env <environment>] 
+                                     [--svc <service>] 
 ```
 
 ## Options

--- a/tests/platform_helper/utils/test_click.py
+++ b/tests/platform_helper/utils/test_click.py
@@ -37,61 +37,61 @@ def test_click_docopt_command_help():
 
 def test_click_docopt_command_group_usage_command():
     @click.group(cls=ClickDocOptGroup)
-    def test_group():
+    def test_collection():
         pass
 
-    @test_group.command()
+    @test_collection.command()
     def command_one():
         pass
 
-    result = CliRunner().invoke(test_group, ["--help"])
+    result = CliRunner().invoke(test_collection, ["--help"])
 
-    assert "test-group command-one" in result.output
+    assert "test-collection command-one" in result.output
 
 
 def test_click_docopt_command_group_usage_command_choice():
     @click.group(cls=ClickDocOptGroup)
-    def test_group():
+    def test_collection():
         pass
 
-    @test_group.command()
+    @test_collection.command()
     def command_one():
         pass
 
-    @test_group.command()
+    @test_collection.command()
     def command_two():
         pass
 
-    result = CliRunner().invoke(test_group, ["--help"])
+    result = CliRunner().invoke(test_collection, ["--help"])
 
-    assert "test-group (command-one|command-two)" in result.output
+    assert "test-collection (command-one|command-two)" in result.output
 
 
 def test_click_docopt_command_group_usage_command_many():
     @click.group(cls=ClickDocOptGroup)
-    def test_group():
+    def test_collection():
         pass
 
-    @test_group.command()
+    @test_collection.command()
     def command_one():
         pass
 
-    @test_group.command()
+    @test_collection.command()
     def command_two():
         pass
 
-    @test_group.command()
+    @test_collection.command()
     def command_three():
         pass
 
-    @test_group.command()
+    @test_collection.command()
     def command_four():
         pass
 
-    @test_group.command()
+    @test_collection.command()
     def command_five():
         pass
 
-    result = CliRunner().invoke(test_group, ["--help"])
+    result = CliRunner().invoke(test_collection, ["--help"])
 
-    assert "test-group <command>" in result.output
+    assert "test-collection <command>" in result.output


### PR DESCRIPTION
In https://github.com/pallets/click/pull/2604 group name suffixes of "_command" or "_group" are stripped.

This changes our test fixtures to avoid using these new stripped names.

Signed-off-by: DBT pre-commit check

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present