### PR TITLE
refactor: Use built in `to_info_dict` method (off-ticket)

### DIFF
--- a/utils/create_command_docs.py
+++ b/utils/create_command_docs.py
@@ -71,18 +71,19 @@ def get_cmd_metadata(
     for subcommand in subcommands_names:
         subcommands[subcommand]["link"] = f"#{command_name.replace(' ', '-').lower()}-{subcommand}"
 
+    param_info_dicts = [param.to_info_dict() for param in cmd.get_params(context)]
     params = [
         Parameter(
-            default=param.default,
-            help=param.help if isinstance(param, click.core.Option) else None,
-            name=param.name or "",
-            param_type_name=param.param_type_name,
-            prompt=param.prompt if isinstance(param, click.core.Option) else None,
-            required=param.required,
-            type_name=param.type.name,
-            usage="\n".join(param.opts),
+            default=param.get("default"),
+            help=param.get("help"),
+            name=param.get("name"),
+            param_type_name=param.get("param_type_name"),
+            prompt=param.get("prompt"),
+            required=param.get("required"),
+            type_name=param.get("type").get("name"),
+            usage="\n".join(param.get("opts")),
         )
-        for param in cmd.get_params(context)
+        for param in param_info_dicts
     ]
 
     yield CommandMetadata(


### PR DESCRIPTION
Removes some custom code, and also avoids a change in Click version 8.3.1 where UNSET gets returned by param.default property

Unblocks #1228 

Signed-off-by: DBT pre-commit check

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present