### PR TITLE
fix: Bug in secrets copy & create commands for apps without prod environment (DBTP-3000)

### DIFF
--- a/dbt_platform_helper/domain/secrets.py
+++ b/dbt_platform_helper/domain/secrets.py
@@ -203,15 +203,17 @@ class Secrets:
         self.__has_access(source_env, actions=["ssm:GetParameter"], access_type="read")
         self.__has_access(target_env)
 
-        prod_account_id = self.application.environments["prod"].account_id
-        if (
-            self.application.environments[source].account_id == prod_account_id
-            and self.application.environments[target].account_id != prod_account_id
-        ):
-            raise PlatformException(
-                f"Cannot transfer secrets out from '{source}' in the prod account '{prod_account_id}'"
-                f" to '{target}' in '{self.application.environments[target].account_id}'"
-            )
+        prod_env = self.application.environments.get("prod")
+        if prod_env:
+            prod_account_id = prod_env.account_id
+            if (
+                self.application.environments[source].account_id == prod_account_id
+                and self.application.environments[target].account_id != prod_account_id
+            ):
+                raise PlatformException(
+                    f"Cannot transfer secrets out from '{source}' in the prod account '{prod_account_id}'"
+                    f" to '{target}' in '{self.application.environments[target].account_id}'"
+                )
 
         parameter_store: ParameterStore = self.parameter_store_provider(
             source_env.session.client("ssm"), with_model=True

--- a/dbt_platform_helper/domain/secrets.py
+++ b/dbt_platform_helper/domain/secrets.py
@@ -134,6 +134,8 @@ class Secrets:
             if overwrite and environment_name in found_params:
                 data_dict["Overwrite"] = True
                 del data_dict["Tags"]
+            else:
+                data_dict["Overwrite"] = False
             self.io.debug(
                 f"Creating AWS Parameter Store secret {get_secret_name(environment.name)} ..."
             )

--- a/tests/platform_helper/conftest.py
+++ b/tests/platform_helper/conftest.py
@@ -134,6 +134,26 @@ def mock_application():
 
 
 @pytest.fixture(scope="function")
+def mock_application_without_prod():
+    with patch(
+        "dbt_platform_helper.utils.application.load_application",
+    ) as load_application:
+        os.environ.pop("AWS_PROFILE", None)
+
+        from dbt_platform_helper.utils.application import Application
+        from dbt_platform_helper.utils.application import Environment
+
+        sessions = {"000000000": boto3, "111111111": boto3}
+        application = Application("test-application")
+        application.environments["dev"] = Environment("dev", "000000000", sessions)
+        application.environments["staging"] = Environment("staging", "111111111", sessions)
+
+        load_application.return_value = application
+
+        yield application
+
+
+@pytest.fixture(scope="function")
 def aws_credentials(monkeypatch):
     """Mocked AWS Credentials for moto."""
     moto_credentials_file_path = Path(__file__).parent.absolute() / "dummy_aws_credentials"

--- a/tests/platform_helper/integration/test_secrets.py
+++ b/tests/platform_helper/integration/test_secrets.py
@@ -214,9 +214,14 @@ class AWSMocks:
                 "env": env,
             }
 
-            if self.create_existing_params == "exists":
+            if isinstance(self.create_existing_params, dict):
+                env_param_status = self.create_existing_params.get(env, "none")
+            else:
+                env_param_status = self.create_existing_params
+
+            if env_param_status == "exists":
                 mock_ssm_client.get_parameter.return_value = {"Parameter": {"Name": "doesntmatter"}}
-            elif self.create_existing_params == "unexpected":
+            elif env_param_status == "unexpected":
                 mock_ssm_client.get_parameter.side_effect = AWSTestFixtures.client_error_response(
                     "GetParameter"
                 )
@@ -684,3 +689,23 @@ def test_secrets_copy_succeeds_when_application_has_no_prod_environment(
     secrets = Secrets(**inputs)
 
     secrets.copy(app_name="test-application", source="dev", target="staging")
+
+
+def test_create_with_overwrite_uses_correct_overwrite_per_environment(
+    mock_application_without_prod,
+):
+    mock = AWSMocks(create_existing_params={"dev": "exists", "staging": "none"})
+    input_mocks = mock.setup_create(mock_application_without_prod)
+    secrets = Secrets(**input_mocks)
+
+    secrets.create(app_name="test-application", name="SECRET", overwrite=True)
+
+    dev_env = mock_application_without_prod.environments["dev"]
+    staging_env = mock_application_without_prod.environments["staging"]
+
+    dev_env.session.client("ssm").put_parameter.assert_called_with(
+        **AWSTestFixtures.put_parameter_called_with("dev", "1", overwrite=True)
+    )
+    staging_env.session.client("ssm").put_parameter.assert_called_with(
+        **AWSTestFixtures.put_parameter_called_with("staging", "2", overwrite=False)
+    )

--- a/tests/platform_helper/integration/test_secrets.py
+++ b/tests/platform_helper/integration/test_secrets.py
@@ -674,3 +674,13 @@ def test_secrets_copy_exception_raised(mock_application, input_args, expected_me
         match=re.escape(expected_message),
     ):
         secrets.copy(**input_args)
+
+
+def test_secrets_copy_succeeds_when_application_has_no_prod_environment(
+    mock_application_without_prod,
+):
+    aws_mocks = AWSMocks()
+    inputs = aws_mocks.setup_copy(mock_application_without_prod, "dev", "staging")
+    secrets = Secrets(**inputs)
+
+    secrets.copy(app_name="test-application", source="dev", target="staging")


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-3000.

## What

- `platform-helper secrets` `copy` & `create` commands shown to raise errors
- `secrets copy` raised `KeyError: 'prod'` for any application that does not yet have a prod environment, crashing before any secrets were copied
- `secrets create --overwrite` raised `ValidationException` from AWS when a secret already existed in some environments but not others. The command sent `Overwrite=True` and `Tags` together in a single `PutParameter` call, which AWS always rejects
- Both bugs affect any service on the platform that has not yet provisioned a prod environment; reported against BICS (account `186565566705`)

## Fixes

- checks for existence of `prod` environment before comparisons
- ensure `Overwrite=False` when SSM oarameter does not yet exist in a given environment


---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present