### PR TITLE
fix: Add ability to handle rate() schedule expressions (DBTP-2843)

### DIFF
--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -236,8 +236,8 @@ class ServiceManager:
 
         # Convert "@" schedule expressions to expressions understood by EventBridge
         rate_conversion = {
-            "@hourly": "rate(1 hours)",
-            "@daily": "rate(1 days)",
+            "@hourly": "1 hours",
+            "@daily": "1 days",
             "@weekly": "0 0 * * 1 *",
             "@monthly": "0 0 1 * * *",
             "@yearly": "0 * * * ? *",

--- a/terraform/ecs-service/scheduling/locals.tf
+++ b/terraform/ecs-service/scheduling/locals.tf
@@ -1,5 +1,5 @@
 locals {
-
+  schedule_expression = can(regex("minutes|hours|days", var.schedule)) ? "rate(${var.schedule})" : "cron(${var.schedule})"
 
   full_service_name = var.name
 

--- a/terraform/ecs-service/scheduling/scheduling.tf
+++ b/terraform/ecs-service/scheduling/scheduling.tf
@@ -1,7 +1,7 @@
 ### Eventbridge
 resource "aws_scheduler_schedule" "this" {
 
-  schedule_expression = var.schedule == "none" ? "rate(5 minutes)" : "cron(${var.schedule})"
+  schedule_expression = var.schedule == "none" ? "rate(5 minutes)" : local.schedule_expression #var.schedule == "none" ? "rate(5 minutes)" : "cron(${var.schedule})"
 
   flexible_time_window {
     mode = "OFF"

--- a/terraform/ecs-service/scheduling/scheduling.tf
+++ b/terraform/ecs-service/scheduling/scheduling.tf
@@ -1,7 +1,7 @@
 ### Eventbridge
 resource "aws_scheduler_schedule" "this" {
 
-  schedule_expression = var.schedule == "none" ? "rate(5 minutes)" : local.schedule_expression #var.schedule == "none" ? "rate(5 minutes)" : "cron(${var.schedule})"
+  schedule_expression = var.schedule == "none" ? "rate(5 minutes)" : local.schedule_expression
 
   flexible_time_window {
     mode = "OFF"

--- a/terraform/ecs-service/scheduling/tests/unit.tftest.hcl
+++ b/terraform/ecs-service/scheduling/tests/unit.tftest.hcl
@@ -89,6 +89,58 @@ run "test_none_schedule_expression_defaults_to_rate_5_minutes" {
   }
 }
 
+run "test_minutes_rate_schedule_expression_gets_wrapped_with_rate_function" {
+  command = plan
+
+  variables {
+    schedule = "1 minutes"
+  }
+
+  assert {
+    condition     = aws_scheduler_schedule.this.schedule_expression == "rate(1 minutes)"
+    error_message = "Should be 'rate(1 minutes)'"
+  }
+}
+
+run "test_hours_rate_schedule_expression_gets_wrapped_with_rate_function" {
+  command = plan
+
+  variables {
+    schedule = "1 hours"
+  }
+
+  assert {
+    condition     = aws_scheduler_schedule.this.schedule_expression == "rate(1 hours)"
+    error_message = "Should be 'rate(1 hours)'"
+  }
+}
+
+run "test_days_rate_schedule_expression_gets_wrapped_with_rate_function" {
+  command = plan
+
+  variables {
+    schedule = "1 days"
+  }
+
+  assert {
+    condition     = aws_scheduler_schedule.this.schedule_expression == "rate(1 days)"
+    error_message = "Should be 'rate(1 days)'"
+  }
+}
+
+run "test_cron_schedule_expression_gets_wrapped_with_cron_function" {
+  command = plan
+
+  variables {
+    schedule = "5 * * * ?"
+  }
+
+  assert {
+    condition     = aws_scheduler_schedule.this.schedule_expression == "cron(5 * * * ?)"
+    error_message = "Should be 'cron(5 * * * ?)'"
+  }
+}
+
 run "test_state_machine_definition_has_no_retry" {
   command = plan
 

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -997,8 +997,8 @@ image:
 @pytest.mark.parametrize(
     "test_input,expected",
     [
-        ("@hourly", "rate(1 hours)"),
-        ("@daily", "rate(1 days)"),
+        ("@hourly", "1 hours"),
+        ("@daily", "1 days"),
         ("@weekly", "0 0 * * 1 *"),
         ("@monthly", "0 0 1 * * *"),
         ("@yearly", "0 * * * ? *"),
@@ -1057,7 +1057,7 @@ def test_migrate_scheduled_job_handles_overrides(
             "environments": {
                 "dev": {"schedule": "0 23 * * ? *"},
                 "staging": {"schedule": "0 0 * * ? *"},
-                "uat": {"schedule": "rate(1 hours)"},
+                "uat": {"schedule": "1 hours"},
             },
         }
     )
@@ -1096,7 +1096,7 @@ environments:
     )
 
     expected_service_config = expected_scheduled_job_config(
-        {"schedule": "rate(1 days)", "environments": {"dev": {"schedule": "rate(1 hours)"}}}
+        {"schedule": "1 days", "environments": {"dev": {"schedule": "1 hours"}}}
     )
 
     os.chdir(tmp_path)


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-2843.

- Adds ability to handle rate() schedule expressions
- No longer requires users to include `rate()` in the rate schedule expression values

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present