### PR TITLE
fix: Add missing IAM permission to allow update of IAM policy versions (off-ticket)

### DIFF
--- a/terraform/environment-pipelines/locals.tf
+++ b/terraform/environment-pipelines/locals.tf
@@ -139,7 +139,7 @@ locals {
     }] : [])
   )
 
-  dns_ids                   = tolist(toset(flatten([for stage in local.all_stages : lookup(stage, "accounts", null) != null ? [stage.accounts.dns.id] : []])))
+  dns_ids = tolist(toset(flatten([for stage in local.all_stages : lookup(stage, "accounts", null) != null ? [stage.accounts.dns.id] : []])))
   dns_account_assumed_roles = toset([
     for env in local.environment_config :
     "arn:aws:iam::${env.accounts.dns.id}:role/${var.application}-${env.name}-pipeline-deployment-role"

--- a/terraform/extensions/iam.tf
+++ b/terraform/extensions/iam.tf
@@ -50,6 +50,7 @@ data "aws_iam_policy_document" "iam_access_for_codebase" {
       "iam:GetPolicy",
       "iam:GetPolicyVersion",
       "iam:CreatePolicyVersion",
+      "iam:DeletePolicyVersion",
       "iam:ListRolePolicies",
       "iam:GetRolePolicy",
       "iam:ListAttachedRolePolicies",


### PR DESCRIPTION
## WHAT

- add missing delete permission required for updating the policy version of a policy
- When you update an IAM policy in AWS (e.g. add a new permission), AWS doesn't replace the policy - it creates a new numbered version of the policy (v1, v2, v3...) and sets the new one as the default. The old version then needs to be deleted. 

This requires two IAM permissions:
```
iam:CreatePolicyVersion  # existing - to create the updated policy
iam:DeletePolicyVersion  # added - to remove the old version
```

## ISSUE SEEN

- The [par-api-manual-release](https://eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/par-api-manual-release/view?region=eu-west-2) CodePipeline was used to manually deploy the API service to staging. 
- There has been a change to `services/api/custom-iam-policy/staging.yml` that had not been re-deployed to staging.
- This pipeline has a Deploy stage that runs a CodeBuild project called `par-api-codebase-service-terraform`. 
- This CodeBuild project runs Terraform to apply ECS service infrastructure - including any changes to the custom IAM policy of a service.
- The CodeBuild project has its own service role to run. The buildspec that CodeBuild executes is platform-tools-main/terraform/codebase-pipelines/buildspec-service-terraform.yml:
```
assumed_role=$(aws sts assume-role \
  --role-arn "arn:aws:iam::${account_id}:role/${APPLICATION}-${ENVIRONMENT}-codebase-pipeline-deploy" \
  --role-session-name "${ENVIRONMENT}-codebase-pipeline-deploy")
```
- This role has an `iam-permissions` policy
- This policy was missing the required IAM permission

Full chain is:
par-api-manual-release CodePipeline → Deploy stage
Deploy stage triggers CodeBuild project par-api-codebase-service-terraform
Inside the build, buildspec-service-terraform.yml calls `aws sts assume-role targeting arn:aws:iam::970547347857:role/par-staging-codebase-pipeline-deploy`
Role missing required IAM permission

Terraform tries to update par-staging-api-custom-iam-policy → needs iam:DeletePolicyVersion → 403

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present