### PR TITLE
feat: Platform-helper command to list deployed Scheduled Jobs (DBTP-3023)

### DIFF
--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -273,7 +273,7 @@ platform-helper codebase deploy --app <application> --env <environment> --codeba
 [↩ Parent](#platform-helper)
 
     Opens a shell for a given addon_name create a conduit connection to
-interact with postgres, opensearch or redis.
+    interact with postgres, opensearch or redis.
 
 ## Usage
 
@@ -359,9 +359,9 @@ platform-helper config migrate
 [↩ Parent](#platform-helper-config)
 
     Writes a local config file containing all the AWS profiles to which the
-logged in user has access.
+    logged in user has access.
 
-If no `--file-path` is specified, defaults to `~/.aws/config`.
+    If no `--file-path` is specified, defaults to `~/.aws/config`.
 
 ## Usage
 
@@ -492,7 +492,7 @@ platform-helper environment online --app <application> --env <environment>
 [↩ Parent](#platform-helper-environment)
 
     Gathers various IDs and ARNs from AWS and generates the AWS Copilot
-environment manifest at copilot/environments/<environment>/manifest.yml.
+    environment manifest at copilot/environments/<environment>/manifest.yml.
 
 ## Usage
 
@@ -533,9 +533,9 @@ platform-helper environment generate-terraform --name <name>
 [↩ Parent](#platform-helper)
 
     Generate deployment pipeline configuration files and generate addons
-CloudFormation template files for each environment.
+    CloudFormation template files for each environment.
 
-Wraps pipeline generate and make-addons.
+    Wraps pipeline generate and make-addons.
 
 ## Usage
 
@@ -574,17 +574,17 @@ platform-helper pipeline generate
 [↩ Parent](#platform-helper-pipeline)
 
     Given a platform-config.yml file, generate environment and service
-deployment pipelines.
+    deployment pipelines.
 
-This command does the following in relation to the environment pipelines:
-- Reads contents of `platform-config.yml/environment_pipelines` configuration.
-  The `terraform/environment-pipelines/<aws_account>/main.tf` file is generated using this configuration.
-  The `main.tf` file is then used to generate Terraform for creating an environment pipeline resource.
+    This command does the following in relation to the environment pipelines:
+    - Reads contents of `platform-config.yml/environment_pipelines` configuration.
+      The `terraform/environment-pipelines/<aws_account>/main.tf` file is generated using this configuration.
+      The `main.tf` file is then used to generate Terraform for creating an environment pipeline resource.
 
-This command does the following in relation to the codebase pipelines:
-- Reads contents of `platform-config.yml/codebase_pipelines` configuration.
-  The `terraform/codebase-pipelines/main.tf.json` file is generated using this configuration.
-  The `main.tf.json` file is then used to generate Terraform for creating a codebase pipeline resource.
+    This command does the following in relation to the codebase pipelines:
+    - Reads contents of `platform-config.yml/codebase_pipelines` configuration.
+      The `terraform/codebase-pipelines/main.tf.json` file is generated using this configuration.
+      The `main.tf.json` file is then used to generate Terraform for creating a codebase pipeline resource.
 
 ## Usage
 
@@ -633,7 +633,7 @@ platform-helper secrets (create|copy|list)
 [↩ Parent](#platform-helper-secrets)
 
     Create a Parameter Store secret for all environments of an
-application.
+    application.
 
 ## Usage
 
@@ -949,7 +949,7 @@ platform-helper database copy --from <from_env> --to <to_env> --database <databa
 [↩ Parent](#platform-helper)
 
     Contains subcommands for getting version information about the current
-project.
+    project.
 
 ## Usage
 

--- a/dbt_platform_helper/COMMANDS.md
+++ b/dbt_platform_helper/COMMANDS.md
@@ -42,6 +42,7 @@
         - [platform-helper service exec](#platform-helper-service-exec)
     - [platform-helper job](#platform-helper-job)
         - [platform-helper job run](#platform-helper-job-run)
+        - [platform-helper job ls](#platform-helper-job-ls)
 
 # platform-helper
 
@@ -272,7 +273,7 @@ platform-helper codebase deploy --app <application> --env <environment> --codeba
 [↩ Parent](#platform-helper)
 
     Opens a shell for a given addon_name create a conduit connection to
-    interact with postgres, opensearch or redis.
+interact with postgres, opensearch or redis.
 
 ## Usage
 
@@ -358,9 +359,9 @@ platform-helper config migrate
 [↩ Parent](#platform-helper-config)
 
     Writes a local config file containing all the AWS profiles to which the
-    logged in user has access.
+logged in user has access.
 
-    If no `--file-path` is specified, defaults to `~/.aws/config`.
+If no `--file-path` is specified, defaults to `~/.aws/config`.
 
 ## Usage
 
@@ -491,7 +492,7 @@ platform-helper environment online --app <application> --env <environment>
 [↩ Parent](#platform-helper-environment)
 
     Gathers various IDs and ARNs from AWS and generates the AWS Copilot
-    environment manifest at copilot/environments/<environment>/manifest.yml.
+environment manifest at copilot/environments/<environment>/manifest.yml.
 
 ## Usage
 
@@ -532,9 +533,9 @@ platform-helper environment generate-terraform --name <name>
 [↩ Parent](#platform-helper)
 
     Generate deployment pipeline configuration files and generate addons
-    CloudFormation template files for each environment.
+CloudFormation template files for each environment.
 
-    Wraps pipeline generate and make-addons.
+Wraps pipeline generate and make-addons.
 
 ## Usage
 
@@ -573,17 +574,17 @@ platform-helper pipeline generate
 [↩ Parent](#platform-helper-pipeline)
 
     Given a platform-config.yml file, generate environment and service
-    deployment pipelines.
+deployment pipelines.
 
-    This command does the following in relation to the environment pipelines:
-    - Reads contents of `platform-config.yml/environment_pipelines` configuration.
-      The `terraform/environment-pipelines/<aws_account>/main.tf` file is generated using this configuration.
-      The `main.tf` file is then used to generate Terraform for creating an environment pipeline resource.
+This command does the following in relation to the environment pipelines:
+- Reads contents of `platform-config.yml/environment_pipelines` configuration.
+  The `terraform/environment-pipelines/<aws_account>/main.tf` file is generated using this configuration.
+  The `main.tf` file is then used to generate Terraform for creating an environment pipeline resource.
 
-    This command does the following in relation to the codebase pipelines:
-    - Reads contents of `platform-config.yml/codebase_pipelines` configuration.
-      The `terraform/codebase-pipelines/main.tf.json` file is generated using this configuration.
-      The `main.tf.json` file is then used to generate Terraform for creating a codebase pipeline resource.
+This command does the following in relation to the codebase pipelines:
+- Reads contents of `platform-config.yml/codebase_pipelines` configuration.
+  The `terraform/codebase-pipelines/main.tf.json` file is generated using this configuration.
+  The `main.tf.json` file is then used to generate Terraform for creating a codebase pipeline resource.
 
 ## Usage
 
@@ -632,7 +633,7 @@ platform-helper secrets (create|copy|list)
 [↩ Parent](#platform-helper-secrets)
 
     Create a Parameter Store secret for all environments of an
-    application.
+application.
 
 ## Usage
 
@@ -948,7 +949,7 @@ platform-helper database copy --from <from_env> --to <to_env> --database <databa
 [↩ Parent](#platform-helper)
 
     Contains subcommands for getting version information about the current
-    project.
+project.
 
 ## Usage
 
@@ -1049,7 +1050,7 @@ platform-helper service exec --app <application> --env <environment> --name <nam
 ## Usage
 
 ```
-platform-helper job run 
+platform-helper job (run|ls) 
 ```
 
 ## Options
@@ -1059,6 +1060,7 @@ platform-helper job run
 
 ## Commands
 
+- [`ls` ↪](#platform-helper-job-ls)
 - [`run` ↪](#platform-helper-job-run)
 
 # platform-helper job run
@@ -1087,5 +1089,28 @@ platform-helper job run --app <application> --env <environment> --name <name> [-
 - `--follow
 -f <boolean>` _Defaults to False._
   - Wait for the execution to finish and report it's final status
+- `--help <boolean>` _Defaults to False._
+  - Show this message and exit.
+
+# platform-helper job ls
+
+[↩ Parent](#platform-helper-job)
+
+    Lists deployed scheduled jobs.
+
+## Usage
+
+```
+platform-helper job ls --app <application> --env <environment> 
+```
+
+## Options
+
+- `--app
+-a <text>`
+  - Application name
+- `--env
+-e <text>`
+  - Environment name
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.

--- a/dbt_platform_helper/commands/job.py
+++ b/dbt_platform_helper/commands/job.py
@@ -59,7 +59,6 @@ def ls(app: str, env: str):
 
         try:
             ssm_client = application.environments[env].session.client("ssm")
-            account_id = application.environments[env].account_id
         except KeyError:
             raise ApplicationEnvironmentNotFoundException(app, env)
 

--- a/dbt_platform_helper/commands/job.py
+++ b/dbt_platform_helper/commands/job.py
@@ -43,3 +43,29 @@ def run(app: str, env: str, name: str, follow: bool):
         JobManager(job_runner=job_runner).start_execution(app, env, name, follow)
     except PlatformException as err:
         ClickIOProvider().abort_with_error(str(err))
+        
+@job.command()
+@click.option("--app", "-a", help="Application name", required=True)
+@click.option("--env", "-e", help="Environment name", required=True)
+@click.option("--name", "-n", help="Name of the scheduled job", required=True)
+def ls(app: str, env: str, name: str):
+    """Lists deployed scheduled jobs."""
+    io = ClickIOProvider()
+
+    try:
+        application = load_application(app=app, env=env)
+
+        try:
+            sfn_client = application.environments[env].session.client("stepfunctions")
+            account_id = application.environments[env].account_id
+        except KeyError:
+            raise ApplicationEnvironmentNotFoundException(app, env)
+
+        job_runner: StepFunctions = StepFunctions(sfn_client, application.name, env, account_id)
+
+        jobs = JobManager(job_runner=job_runner).list_jobs(app, env, name)
+        
+        io.info("\n".join(jobs))
+        
+    except PlatformException as err:
+        io.abort_with_error(str(err))

--- a/dbt_platform_helper/commands/job.py
+++ b/dbt_platform_helper/commands/job.py
@@ -58,16 +58,14 @@ def ls(app: str, env: str):
         application = load_application(app=app, env=env)
 
         try:
-            sfn_client = application.environments[env].session.client("stepfunctions")
             ssm_client = application.environments[env].session.client("ssm")
             account_id = application.environments[env].account_id
         except KeyError:
             raise ApplicationEnvironmentNotFoundException(app, env)
 
-        job_runner = StepFunctions(sfn_client, application.name, env, account_id)
         service_repository = ServiceRepository(ParameterStore(ssm_client, True))
 
-        JobManager(job_runner=job_runner, service_repository=service_repository, io=io).list_jobs(
+        JobManager(job_runner=None, service_repository=service_repository, io=io).list_jobs(
             app, env
         )
 

--- a/dbt_platform_helper/commands/job.py
+++ b/dbt_platform_helper/commands/job.py
@@ -43,12 +43,12 @@ def run(app: str, env: str, name: str, follow: bool):
         JobManager(job_runner=job_runner).start_execution(app, env, name, follow)
     except PlatformException as err:
         ClickIOProvider().abort_with_error(str(err))
-        
+
+
 @job.command()
 @click.option("--app", "-a", help="Application name", required=True)
 @click.option("--env", "-e", help="Environment name", required=True)
-@click.option("--name", "-n", help="Name of the scheduled job", required=True)
-def ls(app: str, env: str, name: str):
+def ls(app: str, env: str):
     """Lists deployed scheduled jobs."""
     io = ClickIOProvider()
 
@@ -63,9 +63,9 @@ def ls(app: str, env: str, name: str):
 
         job_runner: StepFunctions = StepFunctions(sfn_client, application.name, env, account_id)
 
-        jobs = JobManager(job_runner=job_runner).list_jobs(app, env, name)
-        
+        jobs = JobManager(job_runner=job_runner).list_jobs(app, env)
+
         io.info("\n".join(jobs))
-        
+
     except PlatformException as err:
         io.abort_with_error(str(err))

--- a/dbt_platform_helper/commands/job.py
+++ b/dbt_platform_helper/commands/job.py
@@ -3,6 +3,7 @@ import click
 from dbt_platform_helper.domain.job import JobManager
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.io import ClickIOProvider
+from dbt_platform_helper.providers.service import ServiceRepository
 from dbt_platform_helper.providers.step_functions import StepFunctions
 from dbt_platform_helper.utils.application import (
     ApplicationEnvironmentNotFoundException,
@@ -57,13 +58,15 @@ def ls(app: str, env: str):
 
         try:
             sfn_client = application.environments[env].session.client("stepfunctions")
+            ssm_client = application.environments[env].session.client("ssm")
             account_id = application.environments[env].account_id
         except KeyError:
             raise ApplicationEnvironmentNotFoundException(app, env)
 
-        job_runner: StepFunctions = StepFunctions(sfn_client, application.name, env, account_id)
+        job_runner = StepFunctions(sfn_client, application.name, env, account_id)
+        service_repository = ServiceRepository(ssm_client)
 
-        jobs = JobManager(job_runner=job_runner).list_jobs(app, env)
+        jobs = JobManager(job_runner=job_runner, service_repository=service_repository).list_jobs(app, env)
 
         io.info("\n".join(jobs))
 

--- a/dbt_platform_helper/commands/job.py
+++ b/dbt_platform_helper/commands/job.py
@@ -3,6 +3,7 @@ import click
 from dbt_platform_helper.domain.job import JobManager
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.io import ClickIOProvider
+from dbt_platform_helper.providers.parameter_store import ParameterStore
 from dbt_platform_helper.providers.service import ServiceRepository
 from dbt_platform_helper.providers.step_functions import StepFunctions
 from dbt_platform_helper.utils.application import (
@@ -64,11 +65,11 @@ def ls(app: str, env: str):
             raise ApplicationEnvironmentNotFoundException(app, env)
 
         job_runner = StepFunctions(sfn_client, application.name, env, account_id)
-        service_repository = ServiceRepository(ssm_client)
+        service_repository = ServiceRepository(ParameterStore(ssm_client, True))
 
-        jobs = JobManager(job_runner=job_runner, service_repository=service_repository).list_jobs(app, env)
-
-        io.info("\n".join(jobs))
+        JobManager(job_runner=job_runner, service_repository=service_repository, io=io).list_jobs(
+            app, env
+        )
 
     except PlatformException as err:
         io.abort_with_error(str(err))

--- a/dbt_platform_helper/domain/job.py
+++ b/dbt_platform_helper/domain/job.py
@@ -2,6 +2,7 @@ import time
 
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.io import ClickIOProvider
+from dbt_platform_helper.providers.parameter_store import ParameterStore
 
 
 class ScheduledJobExecutionFailedException(PlatformException):
@@ -13,8 +14,9 @@ class JobManager:
     JOB_POLL_SECONDS = 5
     JOB_FINAL_STATUSES = {"SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"}
 
-    def __init__(self, job_runner, io: ClickIOProvider = ClickIOProvider()):
+    def __init__(self, job_runner, parameter_store: ParameterStore, io: ClickIOProvider = ClickIOProvider()):
         self.job_runner = job_runner
+        self.parameter_store = parameter_store
         self.io = io
 
     def start_execution(self, app: str, env: str, name: str, follow: bool):
@@ -45,3 +47,18 @@ class JobManager:
             raise ScheduledJobExecutionFailedException(
                 f"Job {execution_id} finished with status {status}"
             )
+            
+    def list_jobs(self, app: str, env: str):
+        # /platform/applications/demodjango/environments/ben/services/api
+        service_parameter_names = self.parameter_store.list_parameters_by_name_starts_with(f"/platform/applications/{app}/environments/{env}/services/")
+        jobs = []
+        for param_name in service_parameter_names:
+            service = self.parameter_store.get_ssm_parameter_by_name(param_name)
+            if service.value.get("type") == "Scheduled Job":
+                jobs.append(service.value.get("name"))
+        if jobs:
+            self.io.info(f"Scheduled Jobs currently deployed for {app} in the {env} environment:\n{"\n".join(jobs)}")
+        else:
+            self.io.info(f"No Scheduled Jobs currently deployed for {app} in the {env} environment.")
+            
+        

--- a/dbt_platform_helper/domain/job.py
+++ b/dbt_platform_helper/domain/job.py
@@ -56,8 +56,9 @@ class JobManager:
     def list_jobs(self, app: str, env: str):
         jobs = [job.name for job in self.service_repository.list_jobs(app, env)]
         if jobs:
+            jobs_list = "\n".join(jobs)
             self.io.info(
-                f"Scheduled Jobs currently deployed for {app} in the {env} environment:\n{'\n'.join(jobs)}"
+                f"Scheduled Jobs currently deployed for {app} in the {env} environment:\n{jobs_list}"
             )
         else:
             self.io.info(

--- a/dbt_platform_helper/domain/job.py
+++ b/dbt_platform_helper/domain/job.py
@@ -49,13 +49,7 @@ class JobManager:
             )
             
     def list_jobs(self, app: str, env: str):
-        # /platform/applications/demodjango/environments/ben/services/api
-        service_parameter_names = self.service_repository.list_parameters_by_name_starts_with(f"/platform/applications/{app}/environments/{env}/services/")
-        jobs = []
-        for param_name in service_parameter_names:
-            service = self.service_repository.get_ssm_parameter_by_name(param_name)
-            if service.value.get("type") == "Scheduled Job":
-                jobs.append(service.value.get("name"))
+        jobs = [job.name for job in self.service_repository.list_jobs(app, env)]
         if jobs:
             self.io.info(f"Scheduled Jobs currently deployed for {app} in the {env} environment:\n{"\n".join(jobs)}")
         else:

--- a/dbt_platform_helper/domain/job.py
+++ b/dbt_platform_helper/domain/job.py
@@ -2,7 +2,7 @@ import time
 
 from dbt_platform_helper.platform_exception import PlatformException
 from dbt_platform_helper.providers.io import ClickIOProvider
-from dbt_platform_helper.providers.parameter_store import ParameterStore
+from dbt_platform_helper.providers.service import ServiceRepository
 
 
 class ScheduledJobExecutionFailedException(PlatformException):
@@ -14,9 +14,9 @@ class JobManager:
     JOB_POLL_SECONDS = 5
     JOB_FINAL_STATUSES = {"SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"}
 
-    def __init__(self, job_runner, parameter_store: ParameterStore, io: ClickIOProvider = ClickIOProvider()):
+    def __init__(self, job_runner, service_repository: ServiceRepository = None, io: ClickIOProvider = ClickIOProvider()):
         self.job_runner = job_runner
-        self.parameter_store = parameter_store
+        self.service_repository = service_repository
         self.io = io
 
     def start_execution(self, app: str, env: str, name: str, follow: bool):
@@ -50,10 +50,10 @@ class JobManager:
             
     def list_jobs(self, app: str, env: str):
         # /platform/applications/demodjango/environments/ben/services/api
-        service_parameter_names = self.parameter_store.list_parameters_by_name_starts_with(f"/platform/applications/{app}/environments/{env}/services/")
+        service_parameter_names = self.service_repository.list_parameters_by_name_starts_with(f"/platform/applications/{app}/environments/{env}/services/")
         jobs = []
         for param_name in service_parameter_names:
-            service = self.parameter_store.get_ssm_parameter_by_name(param_name)
+            service = self.service_repository.get_ssm_parameter_by_name(param_name)
             if service.value.get("type") == "Scheduled Job":
                 jobs.append(service.value.get("name"))
         if jobs:

--- a/dbt_platform_helper/domain/job.py
+++ b/dbt_platform_helper/domain/job.py
@@ -14,7 +14,12 @@ class JobManager:
     JOB_POLL_SECONDS = 5
     JOB_FINAL_STATUSES = {"SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"}
 
-    def __init__(self, job_runner, service_repository: ServiceRepository = None, io: ClickIOProvider = ClickIOProvider()):
+    def __init__(
+        self,
+        job_runner,
+        service_repository: ServiceRepository = None,
+        io: ClickIOProvider = ClickIOProvider(),
+    ):
         self.job_runner = job_runner
         self.service_repository = service_repository
         self.io = io
@@ -47,12 +52,14 @@ class JobManager:
             raise ScheduledJobExecutionFailedException(
                 f"Job {execution_id} finished with status {status}"
             )
-            
+
     def list_jobs(self, app: str, env: str):
         jobs = [job.name for job in self.service_repository.list_jobs(app, env)]
         if jobs:
-            self.io.info(f"Scheduled Jobs currently deployed for {app} in the {env} environment:\n{"\n".join(jobs)}")
+            self.io.info(
+                f"Scheduled Jobs currently deployed for {app} in the {env} environment:\n{'\n'.join(jobs)}"
+            )
         else:
-            self.io.info(f"No Scheduled Jobs currently deployed for {app} in the {env} environment.")
-            
-        
+            self.io.info(
+                f"No Scheduled Jobs currently deployed for {app} in the {env} environment."
+            )

--- a/dbt_platform_helper/providers/service.py
+++ b/dbt_platform_helper/providers/service.py
@@ -1,5 +1,4 @@
 import json
-from dataclasses import dataclass
 
 from dbt_platform_helper.entities.service import ServiceType
 from dbt_platform_helper.providers.parameter_store import ParameterStore

--- a/dbt_platform_helper/providers/service.py
+++ b/dbt_platform_helper/providers/service.py
@@ -25,4 +25,4 @@ class ServiceRepository:
         return services
 
     def list_jobs(self, app, env) -> list[Service]:
-        return self.list_services(app, env, ServiceType("Scheduled Job"))
+        return self.list_services(app, env, ServiceType.SCHEDULED_JOB)

--- a/dbt_platform_helper/providers/service.py
+++ b/dbt_platform_helper/providers/service.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+import json
+
+from dbt_platform_helper.entities.service import ServiceType
+from dbt_platform_helper.providers.parameter_store import ParameterStore
+
+
+@dataclass
+class Service:
+    name: str
+    type: str
+    
+    def __eq__(self, other) -> bool:
+        return self.name == other.name and self.type == other.type
+        
+
+
+class ServiceRepository:
+    
+    def __init__(self, parameter_store: ParameterStore):
+        self.parameter_store = parameter_store
+        
+    def list_services(self, app, env, type: ServiceType=None):
+        service_parameters = self.parameter_store.get_ssm_parameters_by_path(f"/platform/applications/{app}/environments/{env}/services/")
+        services = []
+        for param in service_parameters:
+            value = json.loads(param.value)
+            print(value)
+            if type:
+                if value.get("type") == "Scheduled Job":
+                    services.append(Service(value.get("name")), type)
+            else:
+                services.append(Service(value.get("name"), value.get("type")))
+        return services
+            
+    def list_jobs(self, app, env):
+        return self.list_services(app, env, "Scheduled Job")

--- a/dbt_platform_helper/providers/service.py
+++ b/dbt_platform_helper/providers/service.py
@@ -18,7 +18,7 @@ class ServiceRepository:
         for param in service_parameters:
             value = json.loads(param.value)
             if type:
-                if value.get("type") == "Scheduled Job":
+                if value.get("type") == type:
                     services.append(Service(value.get("name"), type))
             else:
                 services.append(Service(value.get("name"), value.get("type")))

--- a/dbt_platform_helper/providers/service.py
+++ b/dbt_platform_helper/providers/service.py
@@ -10,7 +10,7 @@ class ServiceRepository:
     def __init__(self, parameter_store: ParameterStore):
         self.parameter_store = parameter_store
 
-    def list_services(self, app, env, type: ServiceType = None):
+    def list_services(self, app, env, type: ServiceType = None) -> list[Service]:
         service_parameters = self.parameter_store.get_ssm_parameters_by_path(
             f"/platform/applications/{app}/environments/{env}/services/"
         )
@@ -24,5 +24,5 @@ class ServiceRepository:
                 services.append(Service(value.get("name"), value.get("type")))
         return services
 
-    def list_jobs(self, app, env):
+    def list_jobs(self, app, env) -> list[Service]:
         return self.list_services(app, env, ServiceType("Scheduled Job"))

--- a/dbt_platform_helper/providers/service.py
+++ b/dbt_platform_helper/providers/service.py
@@ -3,15 +3,7 @@ from dataclasses import dataclass
 
 from dbt_platform_helper.entities.service import ServiceType
 from dbt_platform_helper.providers.parameter_store import ParameterStore
-
-
-@dataclass
-class Service:
-    name: str
-    type: str
-
-    def __eq__(self, other) -> bool:
-        return self.name == other.name and self.type == other.type
+from dbt_platform_helper.utils.application import Service
 
 
 class ServiceRepository:

--- a/dbt_platform_helper/providers/service.py
+++ b/dbt_platform_helper/providers/service.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
 import json
+from dataclasses import dataclass
 
 from dbt_platform_helper.entities.service import ServiceType
 from dbt_platform_helper.providers.parameter_store import ParameterStore
@@ -9,29 +9,29 @@ from dbt_platform_helper.providers.parameter_store import ParameterStore
 class Service:
     name: str
     type: str
-    
+
     def __eq__(self, other) -> bool:
         return self.name == other.name and self.type == other.type
-        
 
 
 class ServiceRepository:
-    
+
     def __init__(self, parameter_store: ParameterStore):
         self.parameter_store = parameter_store
-        
-    def list_services(self, app, env, type: ServiceType=None):
-        service_parameters = self.parameter_store.get_ssm_parameters_by_path(f"/platform/applications/{app}/environments/{env}/services/")
+
+    def list_services(self, app, env, type: ServiceType = None):
+        service_parameters = self.parameter_store.get_ssm_parameters_by_path(
+            f"/platform/applications/{app}/environments/{env}/services/"
+        )
         services = []
         for param in service_parameters:
             value = json.loads(param.value)
-            print(value)
             if type:
                 if value.get("type") == "Scheduled Job":
-                    services.append(Service(value.get("name")), type)
+                    services.append(Service(value.get("name"), type))
             else:
                 services.append(Service(value.get("name"), value.get("type")))
         return services
-            
+
     def list_jobs(self, app, env):
-        return self.list_services(app, env, "Scheduled Job")
+        return self.list_services(app, env, ServiceType("Scheduled Job"))

--- a/dbt_platform_helper/utils/application.py
+++ b/dbt_platform_helper/utils/application.py
@@ -36,7 +36,7 @@ class Environment:
 class Service:
     name: str
     kind: str
-    
+
     def __eq__(self, other) -> bool:
         return self.name == other.name and self.kind == other.kind
 

--- a/dbt_platform_helper/utils/application.py
+++ b/dbt_platform_helper/utils/application.py
@@ -36,6 +36,9 @@ class Environment:
 class Service:
     name: str
     kind: str
+    
+    def __eq__(self, other) -> bool:
+        return self.name == other.name and self.kind == other.kind
 
 
 @dataclass

--- a/platform_helper.py
+++ b/platform_helper.py
@@ -13,11 +13,11 @@ from dbt_platform_helper.commands.database import database as database_commands
 from dbt_platform_helper.commands.environment import environment as environment_commands
 from dbt_platform_helper.commands.generate import generate as generate_commands
 from dbt_platform_helper.commands.internal import internal as internal_commands
+from dbt_platform_helper.commands.job import job as job_commands
 from dbt_platform_helper.commands.notify import notify as notify_commands
 from dbt_platform_helper.commands.pipeline import pipeline as pipeline_commands
 from dbt_platform_helper.commands.secrets import secrets as secrets_commands
 from dbt_platform_helper.commands.service import service as service_commands
-from dbt_platform_helper.commands.job import job as job_commands
 from dbt_platform_helper.commands.version import version as version_commands
 from dbt_platform_helper.utils.click import ClickDocOptGroup
 

--- a/tests/platform_helper/domain/test_job.py
+++ b/tests/platform_helper/domain/test_job.py
@@ -5,6 +5,9 @@ import pytest
 
 from dbt_platform_helper.domain.job import JobManager
 from dbt_platform_helper.domain.job import ScheduledJobExecutionFailedException
+from dbt_platform_helper.providers.io import ClickIOProvider
+from dbt_platform_helper.providers.service import Service
+from dbt_platform_helper.providers.service import ServiceRepository
 from dbt_platform_helper.providers.step_functions import StepFunctions
 
 
@@ -48,3 +51,18 @@ def test_follow_execution_polls_until_fails(mock_sleep):
 
     with pytest.raises(ScheduledJobExecutionFailedException):
         manager.follow_execution("arn:exec:123")
+
+
+def test_list_jobs():
+    mock_io = Mock(spec=ClickIOProvider)
+    mock_sfn = Mock(spec=StepFunctions)
+    mock_repository = Mock(spec=ServiceRepository)
+    mock_repository.list_jobs.return_value = [Service("test-job", "test")]
+
+    manager = JobManager(job_runner=mock_sfn, service_repository=mock_repository, io=mock_io)
+
+    manager.list_jobs("test-app", "test-env")
+
+    mock_io.info.assert_called_with(
+        f"Scheduled Jobs currently deployed for test-app in the test-env environment:\ntest-job"
+    )

--- a/tests/platform_helper/domain/test_job.py
+++ b/tests/platform_helper/domain/test_job.py
@@ -55,11 +55,11 @@ def test_follow_execution_polls_until_fails(mock_sleep):
 
 def test_list_jobs():
     mock_io = Mock(spec=ClickIOProvider)
-    mock_sfn = Mock(spec=StepFunctions)
+
     mock_repository = Mock(spec=ServiceRepository)
     mock_repository.list_jobs.return_value = [Service("test-job", "test")]
 
-    manager = JobManager(job_runner=mock_sfn, service_repository=mock_repository, io=mock_io)
+    manager = JobManager(job_runner=None, service_repository=mock_repository, io=mock_io)
 
     manager.list_jobs("test-app", "test-env")
 

--- a/tests/platform_helper/domain/test_job.py
+++ b/tests/platform_helper/domain/test_job.py
@@ -66,3 +66,18 @@ def test_list_jobs():
     mock_io.info.assert_called_with(
         f"Scheduled Jobs currently deployed for test-app in the test-env environment:\ntest-job"
     )
+
+
+def test_list_jobs_given_no_jobs():
+    mock_io = Mock(spec=ClickIOProvider)
+
+    mock_repository = Mock(spec=ServiceRepository)
+    mock_repository.list_jobs.return_value = []
+
+    manager = JobManager(job_runner=None, service_repository=mock_repository, io=mock_io)
+
+    manager.list_jobs("test-app", "test-env")
+
+    mock_io.info.assert_called_with(
+        f"No Scheduled Jobs currently deployed for test-app in the test-env environment."
+    )

--- a/tests/platform_helper/providers/test_service_provider.py
+++ b/tests/platform_helper/providers/test_service_provider.py
@@ -43,6 +43,18 @@ def test_list_services():
     assert Service("backend-1", "Backend Service") in services
 
 
+@mock_aws
+def test_list_services_given_no_matching_parameters():
+    client = boto3.client("ssm", region_name="eu-west-2")
+
+    for param in MOCK_SERVICE_PARAMS:
+        client.put_parameter(**param)
+
+    service_repository = ServiceRepository(ParameterStore(client, True))
+    services = service_repository.list_services("my-other-app", "my-env")
+    assert len(services) == 0
+
+
 @pytest.mark.parametrize(
     "type",
     [
@@ -76,3 +88,12 @@ def test_list_jobs():
     services = service_repository.list_jobs("my-app", "my-env")
     assert len(services) == 1
     assert Service("job-1", "Scheduled Job") in services
+
+
+@mock_aws
+def test_list_jobs_given_empty_parameter_store():
+    client = boto3.client("ssm", region_name="eu-west-2")
+
+    service_repository = ServiceRepository(ParameterStore(client, True))
+    services = service_repository.list_jobs("my-app", "my-env")
+    assert len(services) == 0

--- a/tests/platform_helper/providers/test_service_provider.py
+++ b/tests/platform_helper/providers/test_service_provider.py
@@ -54,3 +54,15 @@ def test_list_services_by_type():
     services = service_repository.list_services("my-app", "my-env", service_type)
     assert len(services) == 1
     assert Service("job-1", "Scheduled Job") in services
+    
+@mock_aws
+def test_list_jobs():
+    client = boto3.client("ssm", region_name="eu-west-2")
+
+    for param in MOCK_SERVICE_PARAMS:
+        client.put_parameter(**param)
+
+    service_repository = ServiceRepository(ParameterStore(client, True))
+    services = service_repository.list_jobs("my-app", "my-env")
+    assert len(services) == 1
+    assert Service("job-1", "Scheduled Job") in services

--- a/tests/platform_helper/providers/test_service_provider.py
+++ b/tests/platform_helper/providers/test_service_provider.py
@@ -1,0 +1,39 @@
+import json
+
+import boto3
+from moto import mock_aws
+
+from dbt_platform_helper.providers.parameter_store import ParameterStore
+from dbt_platform_helper.providers.service import Service, ServiceRepository
+
+MOCK_SERVICE_PARAMS = [
+    {
+        "Name": f"/platform/applications/my-app/environments/my-env/services/job-1",
+        "Value": json.dumps({"name": "job-1", "type": "Scheduled Job"}),
+        "Type": 'String',
+    },
+    {
+        "Name": f"/platform/applications/my-app/environments/my-env/services/service-1",
+        "Value": json.dumps({"name": "service-1", "type": "Load Balanced Web Service"}),
+        "Type": 'String',
+    },
+    {
+        "Name": f"/platform/applications/my-app/environments/my-env/services/backend-1",
+        "Value": json.dumps({"name": "backend-1", "type": "Backend Service"}),
+        "Type": 'String',
+    }
+]
+
+
+@mock_aws
+def test_list_services():
+    client = boto3.client("ssm", region_name="eu-west-2")
+    
+    for param in MOCK_SERVICE_PARAMS:
+        client.put_parameter(**param)
+    
+    
+    service_repository = ServiceRepository(ParameterStore(client, True))
+    services = service_repository.list_services("my-app", "my-env")
+    assert len(services) == 3
+    # assert Service("job-1","Load Balanced Web Service") in services

--- a/tests/platform_helper/providers/test_service_provider.py
+++ b/tests/platform_helper/providers/test_service_provider.py
@@ -54,7 +54,8 @@ def test_list_services_by_type():
     services = service_repository.list_services("my-app", "my-env", service_type)
     assert len(services) == 1
     assert Service("job-1", "Scheduled Job") in services
-    
+
+
 @mock_aws
 def test_list_jobs():
     client = boto3.client("ssm", region_name="eu-west-2")

--- a/tests/platform_helper/providers/test_service_provider.py
+++ b/tests/platform_helper/providers/test_service_provider.py
@@ -5,7 +5,8 @@ from moto import mock_aws
 
 from dbt_platform_helper.entities.service import ServiceType
 from dbt_platform_helper.providers.parameter_store import ParameterStore
-from dbt_platform_helper.providers.service import Service, ServiceRepository
+from dbt_platform_helper.providers.service import Service
+from dbt_platform_helper.providers.service import ServiceRepository
 
 MOCK_SERVICE_PARAMS = [
     {
@@ -36,10 +37,11 @@ def test_list_services():
     service_repository = ServiceRepository(ParameterStore(client, True))
     services = service_repository.list_services("my-app", "my-env")
     assert len(services) == 3
-    assert Service("job-1","Scheduled Job") in services
-    assert Service("service-1","Load Balanced Web Service") in services
-    assert Service("backend-1","Backend Service") in services
-    
+    assert Service("job-1", "Scheduled Job") in services
+    assert Service("service-1", "Load Balanced Web Service") in services
+    assert Service("backend-1", "Backend Service") in services
+
+
 @mock_aws
 def test_list_services_by_type():
     client = boto3.client("ssm", region_name="eu-west-2")
@@ -51,4 +53,4 @@ def test_list_services_by_type():
     service_type = ServiceType("Scheduled Job")
     services = service_repository.list_services("my-app", "my-env", service_type)
     assert len(services) == 1
-    assert Service("job-1","Scheduled Job") in services
+    assert Service("job-1", "Scheduled Job") in services

--- a/tests/platform_helper/providers/test_service_provider.py
+++ b/tests/platform_helper/providers/test_service_provider.py
@@ -1,6 +1,7 @@
 import json
 
 import boto3
+import pytest
 from moto import mock_aws
 
 from dbt_platform_helper.entities.service import ServiceType
@@ -42,18 +43,26 @@ def test_list_services():
     assert Service("backend-1", "Backend Service") in services
 
 
+@pytest.mark.parametrize(
+    "type",
+    [
+        "Scheduled Job",
+        "Load Balanced Web Service",
+        "Backend Service",
+    ],
+)
 @mock_aws
-def test_list_services_by_type():
+def test_list_services_by_type(type):
     client = boto3.client("ssm", region_name="eu-west-2")
 
     for param in MOCK_SERVICE_PARAMS:
         client.put_parameter(**param)
 
     service_repository = ServiceRepository(ParameterStore(client, True))
-    service_type = ServiceType("Scheduled Job")
+    service_type = ServiceType(type)
     services = service_repository.list_services("my-app", "my-env", service_type)
     assert len(services) == 1
-    assert Service("job-1", "Scheduled Job") in services
+    assert services[0].kind == type
 
 
 @mock_aws

--- a/tests/platform_helper/providers/test_service_provider.py
+++ b/tests/platform_helper/providers/test_service_provider.py
@@ -3,6 +3,7 @@ import json
 import boto3
 from moto import mock_aws
 
+from dbt_platform_helper.entities.service import ServiceType
 from dbt_platform_helper.providers.parameter_store import ParameterStore
 from dbt_platform_helper.providers.service import Service, ServiceRepository
 
@@ -10,30 +11,44 @@ MOCK_SERVICE_PARAMS = [
     {
         "Name": f"/platform/applications/my-app/environments/my-env/services/job-1",
         "Value": json.dumps({"name": "job-1", "type": "Scheduled Job"}),
-        "Type": 'String',
+        "Type": "String",
     },
     {
         "Name": f"/platform/applications/my-app/environments/my-env/services/service-1",
         "Value": json.dumps({"name": "service-1", "type": "Load Balanced Web Service"}),
-        "Type": 'String',
+        "Type": "String",
     },
     {
         "Name": f"/platform/applications/my-app/environments/my-env/services/backend-1",
         "Value": json.dumps({"name": "backend-1", "type": "Backend Service"}),
-        "Type": 'String',
-    }
+        "Type": "String",
+    },
 ]
 
 
 @mock_aws
 def test_list_services():
     client = boto3.client("ssm", region_name="eu-west-2")
-    
+
     for param in MOCK_SERVICE_PARAMS:
         client.put_parameter(**param)
-    
-    
+
     service_repository = ServiceRepository(ParameterStore(client, True))
     services = service_repository.list_services("my-app", "my-env")
     assert len(services) == 3
-    # assert Service("job-1","Load Balanced Web Service") in services
+    assert Service("job-1","Scheduled Job") in services
+    assert Service("service-1","Load Balanced Web Service") in services
+    assert Service("backend-1","Backend Service") in services
+    
+@mock_aws
+def test_list_services_by_type():
+    client = boto3.client("ssm", region_name="eu-west-2")
+
+    for param in MOCK_SERVICE_PARAMS:
+        client.put_parameter(**param)
+
+    service_repository = ServiceRepository(ParameterStore(client, True))
+    service_type = ServiceType("Scheduled Job")
+    services = service_repository.list_services("my-app", "my-env", service_type)
+    assert len(services) == 1
+    assert Service("job-1","Scheduled Job") in services

--- a/tests/platform_helper/test_command_job.py
+++ b/tests/platform_helper/test_command_job.py
@@ -99,7 +99,7 @@ def test_job_list(
     """Test that given an app, env and job name strings, the job run command
     calls run with app, env and job name."""
 
-    mock_job_manager_object.return_value
+    mock_job_manager_instance = mock_job_manager_object.return_value
 
     result = CliRunner().invoke(
         ls,
@@ -108,8 +108,5 @@ def test_job_list(
 
     assert result.exit_code == 0
 
-    # mock_application.assert_called_once_with(app="test-application", env="development")
-    # mock_step_functions.assert_called_once()
-    # mock_job_manager_instance.start_execution.assert_called_once_with(
-    #     "test-application", "development", "test-job", True
-    # )
+    mock_application.assert_called_once_with(app="test-application", env="development")
+    mock_job_manager_instance.list_jobs.assert_called_once_with("test-application", "development")

--- a/tests/platform_helper/test_command_job.py
+++ b/tests/platform_helper/test_command_job.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -110,3 +111,31 @@ def test_job_list(
 
     mock_application.assert_called_once_with(app="test-application", env="development")
     mock_job_manager_instance.list_jobs.assert_called_once_with("test-application", "development")
+
+
+@patch("dbt_platform_helper.commands.job.JobManager")
+@patch("dbt_platform_helper.commands.job.StepFunctions")
+@patch("dbt_platform_helper.commands.job.load_application")
+@patch("dbt_platform_helper.commands.job.ServiceRepository")
+@patch("dbt_platform_helper.commands.job.ClickIOProvider")
+def test_job_list_raises_given_wrong_environment(
+    mock_io, mock_service_repository, mock_application, mock_step_functions, mock_job_manager_object
+):
+    """Test that given an app, env and job name strings, the job run command
+    calls run with app, env and job name."""
+    mock_application_instance = Mock()
+    mock_application_instance.environments = {"development": {}}
+
+    mock_application.return_value = mock_application_instance
+
+    mock_io_instance = Mock()
+    mock_io.return_value = mock_io_instance
+
+    result = CliRunner().invoke(
+        ls,
+        ["--app", "test-application", "--env", "wrong-environment"],
+    )
+
+    mock_io_instance.abort_with_error.assert_called_with(
+        'The environment "wrong-environment" either does not exist or has not been deployed for the application test-application.'
+    )

--- a/tests/platform_helper/test_command_job.py
+++ b/tests/platform_helper/test_command_job.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from dbt_platform_helper.commands.job import run
+from dbt_platform_helper.commands.job import ls
 from dbt_platform_helper.platform_exception import PlatformException
 
 
@@ -86,3 +87,27 @@ def test_job_run_with_optional_follow(
     mock_job_manager_instance.start_execution.assert_called_once_with(
         "test-application", "development", "test-job", True
     )
+    
+@patch("dbt_platform_helper.commands.job.JobManager")
+@patch("dbt_platform_helper.commands.job.StepFunctions")
+@patch("dbt_platform_helper.commands.job.load_application")
+def test_job_list(
+    mock_application, mock_step_functions, mock_job_manager_object
+):
+    """Test that given an app, env and job name strings, the job run command
+    calls run with app, env and job name."""
+
+    mock_job_manager_instance = mock_job_manager_object.return_value
+
+    result = CliRunner().invoke(
+        ls,
+        ["--app", "test-application", "--env", "development"],
+    )
+
+    assert result.exit_code == 0
+
+    # mock_application.assert_called_once_with(app="test-application", env="development")
+    # mock_step_functions.assert_called_once()
+    # mock_job_manager_instance.start_execution.assert_called_once_with(
+    #     "test-application", "development", "test-job", True
+    # )

--- a/tests/platform_helper/test_command_job.py
+++ b/tests/platform_helper/test_command_job.py
@@ -97,8 +97,8 @@ def test_job_run_with_optional_follow(
 def test_job_list(
     mock_service_repository, mock_application, mock_step_functions, mock_job_manager_object
 ):
-    """Test that given an app, env and job name strings, the job run command
-    calls run with app, env and job name."""
+    """Test that given an app and env strings, the job ls command calls
+    list_jobs with app and env parameters."""
 
     mock_job_manager_instance = mock_job_manager_object.return_value
 
@@ -116,8 +116,8 @@ def test_job_list(
 @patch("dbt_platform_helper.commands.job.load_application")
 @patch("dbt_platform_helper.commands.job.ClickIOProvider")
 def test_job_list_raises_given_wrong_environment(mock_io, mock_application):
-    """Test that given an app, env and job name strings, the job run command
-    calls run with app, env and job name."""
+    """Test that given an app but the wrong env, an exception message is
+    displayed."""
     mock_application_instance = Mock()
     mock_application_instance.environments = {"development": {}}
 

--- a/tests/platform_helper/test_command_job.py
+++ b/tests/platform_helper/test_command_job.py
@@ -2,8 +2,8 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
-from dbt_platform_helper.commands.job import run
 from dbt_platform_helper.commands.job import ls
+from dbt_platform_helper.commands.job import run
 from dbt_platform_helper.platform_exception import PlatformException
 
 
@@ -87,17 +87,19 @@ def test_job_run_with_optional_follow(
     mock_job_manager_instance.start_execution.assert_called_once_with(
         "test-application", "development", "test-job", True
     )
-    
+
+
 @patch("dbt_platform_helper.commands.job.JobManager")
 @patch("dbt_platform_helper.commands.job.StepFunctions")
 @patch("dbt_platform_helper.commands.job.load_application")
+@patch("dbt_platform_helper.commands.job.ServiceRepository")
 def test_job_list(
-    mock_application, mock_step_functions, mock_job_manager_object
+    mock_service_repository, mock_application, mock_step_functions, mock_job_manager_object
 ):
     """Test that given an app, env and job name strings, the job run command
     calls run with app, env and job name."""
 
-    mock_job_manager_instance = mock_job_manager_object.return_value
+    mock_job_manager_object.return_value
 
     result = CliRunner().invoke(
         ls,

--- a/tests/platform_helper/test_command_job.py
+++ b/tests/platform_helper/test_command_job.py
@@ -113,14 +113,9 @@ def test_job_list(
     mock_job_manager_instance.list_jobs.assert_called_once_with("test-application", "development")
 
 
-@patch("dbt_platform_helper.commands.job.JobManager")
-@patch("dbt_platform_helper.commands.job.StepFunctions")
 @patch("dbt_platform_helper.commands.job.load_application")
-@patch("dbt_platform_helper.commands.job.ServiceRepository")
 @patch("dbt_platform_helper.commands.job.ClickIOProvider")
-def test_job_list_raises_given_wrong_environment(
-    mock_io, mock_service_repository, mock_application, mock_step_functions, mock_job_manager_object
-):
+def test_job_list_raises_given_wrong_environment(mock_io, mock_application):
     """Test that given an app, env and job name strings, the job run command
     calls run with app, env and job name."""
     mock_application_instance = Mock()


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-3023.

We know that some users made use of the `copilot job ls` command.  Since we are deprecating all copilot commands from the platform, we provide a `platform-helper` alternative:

`platform-helper job ls --app demodjango --env dev`

This command returns a list of scheduled jobs currently deployed to a given application and environment

The implementation includes a ServiceRepository which can also be used to return all services deployed on the platform, or services by type.  This means we can easily extend the `platform-helper service` commands with `ls` functionality too.  (Follow on PR).

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present