### PR TITLE
fix: Remove deleted principal from origin-verify secret's IAM policy (DBTP-2268)

### DIFF
--- a/terraform/application-load-balancer/secret_manager.tf
+++ b/terraform/application-load-balancer/secret_manager.tf
@@ -7,34 +7,6 @@ resource "aws_secretsmanager_secret" "origin-verify-secret" {
   tags                    = local.tags
 }
 
-data "aws_iam_policy_document" "secret_manager_policy" {
-  for_each = toset(local.cdn_enabled ? [""] : [])
-  statement {
-    sid    = "AllowAssumedRoleToAccessSecret"
-    effect = "Allow"
-
-    principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${var.dns_account_id}:role/environment-pipeline-assumed-role"
-      ]
-    }
-
-    actions = [
-      "secretsmanager:GetSecretValue",
-      "secretsmanager:DescribeSecret"
-    ]
-
-    resources = [aws_secretsmanager_secret.origin-verify-secret[""].arn]
-  }
-}
-
-resource "aws_secretsmanager_secret_policy" "secret_policy" {
-  for_each   = toset(local.cdn_enabled ? [""] : [])
-  secret_arn = aws_secretsmanager_secret.origin-verify-secret[""].arn
-  policy     = data.aws_iam_policy_document.secret_manager_policy[""].json
-}
-
 resource "aws_kms_key" "origin_verify_secret_key" {
   for_each                = toset(local.cdn_enabled ? [""] : [])
   description             = "KMS key for ${var.application}-${var.environment}-origin-verify-header-secret"

--- a/terraform/application-load-balancer/tests/unit.tftest.hcl
+++ b/terraform/application-load-balancer/tests/unit.tftest.hcl
@@ -912,11 +912,6 @@ run "waf_and_rotate_lambda_no_cdn_domains" {
   }
 
   assert {
-    condition     = length(aws_secretsmanager_secret_policy.secret_policy) == 0
-    error_message = "No secret should be created"
-  }
-
-  assert {
     condition     = length(aws_kms_key.origin_verify_secret_key) == 0
     error_message = "No secret should be created"
   }
@@ -977,11 +972,6 @@ run "waf_and_rotate_lambda_cdn_domains_disabled" {
   assert {
     condition     = length(aws_secretsmanager_secret.origin-verify-secret) == 0
     error_message = "Resource should not be created"
-  }
-
-  assert {
-    condition     = length(aws_secretsmanager_secret_policy.secret_policy) == 0
-    error_message = "No secret should be created"
   }
 
   assert {


### PR DESCRIPTION
We want to delete the `environment-pipeline-assumed-role` role in the dev/live accounts, but it's still referenced as a principal in the IAM policy attached to the ALB's x-origin-verify secret.

AWS doesn't let you create or update an IAM policy that refers to a nonexistent principal, so when we tried deleting this role, all apps' environment terraform runs started failing with errors like this:

```
╷
│ Error: putting Secrets Manager Secret (arn:aws:secretsmanager:eu-west-2:563763463626:secret:demodjango-daveg-origin-verify-header-secret-UaKcLJ) policy: operation error Secrets Manager: PutResourcePolicy, https response error StatusCode: 400, RequestID: e671892f-293b-40ce-afc4-e8b2921e41a0, MalformedPolicyDocumentException: This resource policy contains an unsupported principal.
│ 
│   with module.extensions.module.alb["demodjango-alb"].aws_secretsmanager_secret_policy.secret_policy[""],
│   on .terraform/modules/extensions/terraform/application-load-balancer/secret_manager.tf line 32, in resource "aws_secretsmanager_secret_policy" "secret_policy":
│   32: resource "aws_secretsmanager_secret_policy" "secret_policy" {
│ 
╵
```

To my understanding, this IAM policy isn't needed. There's no reason why environment terraform should need to read the secret value, and there's certainly no reason why it should need to assume a role in the DNS account in order to read it.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [x] If the work includes user interface changes, before and after screenshots included in description
- [x] Includes any applicable changes to the documentation in this code base
- [x] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [x] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing
  - pull-request-end-to-end-tests execution ID: 0081d3df-1261-49ac-98a2-e7adf650da20

## Reviewer Checklist

- [x] I have reviewed the PR and ensured no secret values are present