### PR TITLE
feat: Switch Redis 7.1 to Valkey 7.2 in non-prod (DBTP-2873)

### DIFF
--- a/terraform/elasticache-redis/locals.tf
+++ b/terraform/elasticache-redis/locals.tf
@@ -1,5 +1,6 @@
 locals {
   redis_engine_version_map = {
+    "7.2" = "valkey7"
     "7.1" = "redis7"
     "7.0" = "redis7"
     "6.2" = "redis6.x"
@@ -12,6 +13,10 @@ locals {
     copilot-application = var.application
     copilot-environment = var.environment
   }
+
+  switch_to_valkey = !(var.environment == "hotfix" || var.environment == "prod")
+  engine           = var.config.engine == "7.1" && local.switch_to_valkey ? "valkey" : "redis"
+  engine_version   = var.config.engine == "7.1" && local.switch_to_valkey ? "7.2" : var.config.engine
 
   central_log_group_arns        = jsondecode(data.aws_ssm_parameter.log-destination-arn.value)
   central_log_group_destination = var.environment == "prod" ? local.central_log_group_arns["prod"] : local.central_log_group_arns["dev"]

--- a/terraform/elasticache-redis/main.tf
+++ b/terraform/elasticache-redis/main.tf
@@ -22,12 +22,12 @@ resource "aws_elasticache_replication_group" "redis" {
   # checkov:skip=CKV_AWS_191:Potential cascading impact on Celery. Requires further analysis - DBTP-1216
   replication_group_id       = "${var.name}-${var.environment}"
   description                = "${var.name}-${var.environment}-redis-cluster"
-  engine                     = "redis"
-  engine_version             = var.config.engine
+  engine                     = local.engine
+  engine_version             = local.engine_version
   node_type                  = coalesce(var.config.instance, "cache.t4g.micro")
   num_node_groups            = 1
   replicas_per_node_group    = coalesce(var.config.replicas, 1)
-  parameter_group_name       = "default.${local.redis_engine_version_map[var.config.engine]}"
+  parameter_group_name       = "default.${local.redis_engine_version_map[local.engine_version]}"
   port                       = 6379
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true

--- a/terraform/elasticache-redis/tests/unit.tftest.hcl
+++ b/terraform/elasticache-redis/tests/unit.tftest.hcl
@@ -112,6 +112,11 @@ run "aws_elasticache_replication_group_unit_test" {
   }
 
   assert {
+    condition     = aws_elasticache_replication_group.redis.parameter_group_name == "default.redis6.x"
+    error_message = "Invalid config for aws_elasticache_replication_group parameter_group_name"
+  }
+
+  assert {
     condition     = aws_elasticache_replication_group.redis.num_node_groups == 1
     error_message = "Invalid config for aws_elasticache_replication_group num_node_groups"
   }
@@ -167,10 +172,11 @@ run "aws_elasticache_replication_group_unit_test" {
   }
 }
 
-run "aws_elasticache_replication_group_unit_test2" {
+run "aws_elasticache_replication_group_unit_7_1_dev" {
   command = plan
 
   variables {
+    environment = "dev"
     config = {
       "engine"                     = "7.1",
       "plan"                       = "small",
@@ -182,15 +188,20 @@ run "aws_elasticache_replication_group_unit_test2" {
     }
   }
 
-  ### Test aws_elasticache_replication_group resource ###
+  ### Development 7.1 redis are being migrated to valkey
   assert {
-    condition     = aws_elasticache_replication_group.redis.engine == "redis"
+    condition     = aws_elasticache_replication_group.redis.engine == "valkey"
     error_message = "Invalid config for aws_elasticache_replication_group engine"
   }
 
   assert {
-    condition     = aws_elasticache_replication_group.redis.engine_version == "7.1"
+    condition     = aws_elasticache_replication_group.redis.engine_version == "7.2"
     error_message = "Invalid config for aws_elasticache_replication_group engine_version"
+  }
+
+  assert {
+    condition     = aws_elasticache_replication_group.redis.parameter_group_name == "default.valkey7"
+    error_message = "Invalid config for aws_elasticache_replication_group parameter_group_name"
   }
 
   assert {
@@ -229,6 +240,40 @@ run "aws_elasticache_replication_group_unit_test2" {
     error_message = "Invalid config for aws_elasticache_replication_group multi_az_enabled"
   }
 }
+
+run "aws_elasticache_replication_group_unit_7_1_prod" {
+  command = plan
+
+  variables {
+    environment = "prod"
+    config = {
+      "engine"                     = "7.1",
+      "plan"                       = "small",
+      "instance"                   = "test-instance",
+      "replicas"                   = 2,
+      "apply_immediately"          = true,
+      "automatic_failover_enabled" = true,
+      "multi_az_enabled"           = true,
+    }
+  }
+
+  ### Prod redis aren't being upgraded to valkey immediately
+  assert {
+    condition     = aws_elasticache_replication_group.redis.engine == "redis"
+    error_message = "Invalid config for aws_elasticache_replication_group engine"
+  }
+
+  assert {
+    condition     = aws_elasticache_replication_group.redis.engine_version == "7.1"
+    error_message = "Invalid config for aws_elasticache_replication_group engine_version"
+  }
+
+  assert {
+    condition     = aws_elasticache_replication_group.redis.parameter_group_name == "default.redis7"
+    error_message = "Invalid config for aws_elasticache_replication_group parameter_group_name"
+  }
+}
+
 
 run "aws_security_group_unit_test" {
   command = plan


### PR DESCRIPTION
Any environment apart from hotfix or prod is upgraded to valkey.

Signed-off-by: DBT pre-commit check

Addresses https://uktrade.atlassian.net/browse/DBTP-2873

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present