### PR TITLE
chore: Reverts CodeBase image builds failing to pull code...(DBTP-2763) (#1446)

### DIFF
--- a/terraform/codebase-pipelines/codebuild.tf
+++ b/terraform/codebase-pipelines/codebuild.tf
@@ -76,10 +76,6 @@ resource "aws_codebuild_project" "codebase_image_build" {
     git_submodules_config {
       fetch_submodules = false
     }
-    auth {
-      resource = data.external.codestar_connections.result["ConnectionArn"]
-      type     = "CODECONNECTIONS"
-    }
   }
 
   tags = local.tags

--- a/terraform/codebase-pipelines/tests/unit.tftest.hcl
+++ b/terraform/codebase-pipelines/tests/unit.tftest.hcl
@@ -5,7 +5,7 @@ override_data {
 
   values = {
     result = {
-      ConnectionArn = "arn:aws:codeconnections:eu-west-2:aws:2"
+      ConnectionArn = "ConnectionArn"
     }
   }
 }
@@ -526,13 +526,6 @@ run "test_codebuild_images" {
   assert {
     condition     = one(aws_codebuild_project.codebase_image_build[""].source).location == "https://github.com/my-repository.git"
     error_message = "Should be: 'https://github.com/my-repository.git'"
-  }
-  assert {
-    condition = one(one(aws_codebuild_project.codebase_image_build[""].source).auth) == {
-      resource : "arn:aws:codeconnections:eu-west-2:aws:2",
-      type : "CODECONNECTIONS"
-    }
-    error_message = "Should have CODECONNECTIONS auth block with: arn:aws:codeconnections:eu-west-2:aws:2"
   }
   assert {
     condition     = length(regexall(".*/work/cli build.*", aws_codebuild_project.codebase_image_build[""].source[0].buildspec)) > 0
@@ -1452,8 +1445,8 @@ run "test_codebuild_deploy" {
     error_message = "Should be: CODESTAR_CONNECTION_ARN"
   }
   assert {
-    condition     = aws_codebuild_project.codebase_deploy[""].environment[0].environment_variable[1].value == "arn:aws:codeconnections:eu-west-2:aws:2"
-    error_message = "Should be: arn:aws:codeconnections:eu-west-2:aws:2"
+    condition     = aws_codebuild_project.codebase_deploy[""].environment[0].environment_variable[1].value == "ConnectionArn"
+    error_message = "Should be: ConnectionArn"
   }
 
   assert {
@@ -1547,8 +1540,8 @@ run "test_main_pipeline" {
     error_message = "Should be: main"
   }
   assert {
-    condition     = aws_codepipeline.codebase_pipeline[0].stage[0].action[0].configuration.ConnectionArn == "arn:aws:codeconnections:eu-west-2:aws:2"
-    error_message = "Should be: arn:aws:codeconnections:eu-west-2:aws:2"
+    condition     = aws_codepipeline.codebase_pipeline[0].stage[0].action[0].configuration.ConnectionArn == "ConnectionArn"
+    error_message = "Should be: ConnectionArn"
   }
 
   # Deploy dev environment stage
@@ -1849,8 +1842,8 @@ run "test_manual_release_pipeline" {
     error_message = "Should be: main"
   }
   assert {
-    condition     = aws_codepipeline.manual_release_pipeline.stage[0].action[0].configuration.ConnectionArn == "arn:aws:codeconnections:eu-west-2:aws:2"
-    error_message = "Should be: arn:aws:codeconnections:eu-west-2:aws:2"
+    condition     = aws_codepipeline.manual_release_pipeline.stage[0].action[0].configuration.ConnectionArn == "ConnectionArn"
+    error_message = "Should be: ConnectionArn"
   }
 
   # Deploy stage


### PR DESCRIPTION
...in rare circumstances (DBTP-2763) (#1446)

Addresses https://uktrade.atlassian.net/browse/DBTP-2763.

Reverting due to `api error OAuthProviderException` encountered when trying to UpdateProject via terraform which seems to be an AWS OAuth peculiarity requiring further investigation and an AWS support ticket.


---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present