### PR TITLE
fix: Add OIDC trust policy for prod deployments (DBTP-3054)

### DIFF
--- a/terraform/extensions/iam.tf
+++ b/terraform/extensions/iam.tf
@@ -20,7 +20,21 @@ data "aws_iam_policy_document" "assume_codebase_pipeline" {
         "arn:aws:iam::${local.pipeline_account_id}:role/${var.args.application}-*-codebase-pipeline",
         "arn:aws:iam::${local.pipeline_account_id}:role/${var.args.application}-*-codebase-pipeline-*",
         "arn:aws:iam::${local.pipeline_account_id}:role/${var.args.application}-*-codebase-*",
-        "arn:aws:iam::${local.pipeline_account_id}:role/github-oidc-${var.args.application}-repo-role"
+      ]
+      variable = "aws:PrincipalArn"
+    }
+    actions = ["sts:AssumeRole"]
+  }
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    condition {
+      test = "ArnLike"
+      values = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/github-oidc-${var.args.application}-repo-role"
       ]
       variable = "aws:PrincipalArn"
     }

--- a/terraform/extensions/tests/unit.tftest.hcl
+++ b/terraform/extensions/tests/unit.tftest.hcl
@@ -746,7 +746,12 @@ run "codebase_deploy_iam_test" {
       "arn:aws:iam::000123456789:role/test-application-*-codebase-pipeline",
       "arn:aws:iam::000123456789:role/test-application-*-codebase-pipeline-*",
       "arn:aws:iam::000123456789:role/test-application-*-codebase-*",
-      "arn:aws:iam::000123456789:role/github-oidc-test-application-repo-role"
+    ]
+    error_message = "Unexpected condition values"
+  }
+  assert {
+    condition = flatten([for el in data.aws_iam_policy_document.assume_codebase_pipeline.statement[1].condition : el.values][0]) == [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/github-oidc-test-application-repo-role"
     ]
     error_message = "Unexpected condition values"
   }


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-3054.

Each service has an OIDC role in their non-prod and prod accounts.  The roles have the same name in each account.  The policy should allow assume role from the deploy repo into the appropriate OIDC role for the current infrastructure deployment.  e.g. prod codebase pipeline role allows prod OIDC assume role and non-prod codebase pipeline role allows non-prod OIDC assume role. 

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [x] I have reviewed the PR and ensured no secret values are present