### PR TITLE
fix: Pass the correct PH version when building the platform-deploy-tools image (off-ticket) 

### DIFF
--- a/buildspec.pypi.yml
+++ b/buildspec.pypi.yml
@@ -18,7 +18,6 @@ phases:
       - echo -e "\nInstalling dependencies"
       - pip install poetry
       - poetry install
-      - pip install dbt-platform-helper
 
   build:
     commands:
@@ -28,7 +27,7 @@ phases:
   post_build:
     commands:
       - |
-        PLATFORM_HELPER_VERSION="$(pip show dbt-platform-helper | awk '/^Version:/ {print $2}')"
+        PLATFORM_HELPER_VERSION="$(poetry version -s)"
         aws codebuild start-build \
           --project-name build-platform-deploy-tools \
           --environment-variables-override \


### PR DESCRIPTION


---
## Checklist:

### Title:
- [X] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [X] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present