### PR TITLE
fix: Internal migrate-job command works without copilot tags (Off-ticket)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+  python: python3.12
 repos:
   - repo: https://github.com/psf/black
     rev: 24.2.0

--- a/dbt_platform_helper/domain/migrate_job.py
+++ b/dbt_platform_helper/domain/migrate_job.py
@@ -160,7 +160,6 @@ class ScheduleMigrator:
 
     def _get_old_schedule_name_by_name(self, name, env):
         rule_name_pattern = f"{self.application}-{env}-{name}-Rule"
-        print("Pattern: ", rule_name_pattern)
         matching_rules = []
         paginator = self.old_schedule_provider.client.get_paginator("list_rules")
         for page in paginator.paginate():

--- a/dbt_platform_helper/domain/migrate_job.py
+++ b/dbt_platform_helper/domain/migrate_job.py
@@ -148,8 +148,30 @@ class ScheduleMigrator:
         return f"{self.application}-{env}-{name}-schedule"
 
     def get_old_schedule_name(self, name, env):
-        return self._get_old_schedule_name_by_tag(name, env)
-    
+        for method in [self._get_old_schedule_name_by_tag, self._get_old_schedule_name_by_name]:
+            matching_rules = method(name, env)
+            if len(matching_rules) == 1:
+                return matching_rules[0].get("Name")
+            if len(matching_rules) > 1:
+                raise TooManyOldScheduledJobsFoundException(
+                    f"A unique job {name} could not be found in the {env} environment"
+                )
+        raise OldScheduleNotFoundException(f"{name} could not be found in the {env} environment")
+
+    def _strip_suffix(self, name):
+        return name.rsplit("-", 1)[0]
+
+    def _get_old_schedule_name_by_name(self, name, env):
+        rule_name_pattern = f"{self.application}-{env}-{name}-Rule"
+        print("Pattern: ", rule_name_pattern)
+        matching_rules = []
+        paginator = self.old_schedule_provider.client.get_paginator("list_rules")
+        for page in paginator.paginate():
+            for rule in page["Rules"]:
+                if self._strip_suffix(rule.get("Name", "")) == rule_name_pattern:
+                    matching_rules.append(rule)
+        return matching_rules
+
     def _get_old_schedule_name_by_tag(self, name, env):
         REQUIRED_TAGS = {
             "copilot-application": self.application,
@@ -170,13 +192,4 @@ class ScheduleMigrator:
                 if all(tags.get(k) == v for k, v in REQUIRED_TAGS.items()):
                     matching_rules.append(rule)
 
-        if len(matching_rules) == 1:
-            return matching_rules[0].get("Name")
-        if not matching_rules:
-            raise OldScheduleNotFoundException(
-                f"{name} could not be found in the {env} environment"
-            )
-        else:
-            raise TooManyOldScheduledJobsFoundException(
-                f"A unique job {name} could not be found in the {env} environment"
-            )
+        return matching_rules

--- a/dbt_platform_helper/domain/migrate_job.py
+++ b/dbt_platform_helper/domain/migrate_job.py
@@ -148,6 +148,9 @@ class ScheduleMigrator:
         return f"{self.application}-{env}-{name}-schedule"
 
     def get_old_schedule_name(self, name, env):
+        return self._get_old_schedule_name_by_tag(name, env)
+    
+    def _get_old_schedule_name_by_tag(self, name, env):
         REQUIRED_TAGS = {
             "copilot-application": self.application,
             "copilot-environment": env,

--- a/dbt_platform_helper/domain/migrate_job.py
+++ b/dbt_platform_helper/domain/migrate_job.py
@@ -158,9 +158,6 @@ class ScheduleMigrator:
                 )
         raise OldScheduleNotFoundException(f"{name} could not be found in the {env} environment")
 
-    def _strip_suffix(self, name):
-        return name.rsplit("-", 1)[0]
-
     def _get_old_schedule_name_by_name(self, name, env):
         rule_name_pattern = f"{self.application}-{env}-{name}-Rule"
         print("Pattern: ", rule_name_pattern)
@@ -168,7 +165,7 @@ class ScheduleMigrator:
         paginator = self.old_schedule_provider.client.get_paginator("list_rules")
         for page in paginator.paginate():
             for rule in page["Rules"]:
-                if self._strip_suffix(rule.get("Name", "")) == rule_name_pattern:
+                if rule.get("Name", "").rsplit("-", 1)[0] == rule_name_pattern:
                     matching_rules.append(rule)
         return matching_rules
 

--- a/tests/platform_helper/domain/test_migrate_job.py
+++ b/tests/platform_helper/domain/test_migrate_job.py
@@ -12,11 +12,6 @@ from dbt_platform_helper.domain.migrate_job import ScheduleMigrator
 from dbt_platform_helper.domain.migrate_job import TooManyOldScheduledJobsFoundException
 
 
-def test__strip_prefix_and_suffix():
-    full_name = "app-env-job-Rule-weroitueworitu"
-    assert ScheduleMigrator("app", Mock(), Mock())._strip_suffix(full_name) == "app-env-job-Rule"
-
-
 def test_get_new_schedule_name():
     result = ScheduleMigrator("demodjango", Mock(), Mock()).get_new_schedule_name(
         "my-enabled-rule", "dev"
@@ -26,7 +21,7 @@ def test_get_new_schedule_name():
 
 
 @mock_aws
-def test_get_old_schedule_name():
+def test_get_old_schedule_name_with_tags():
     client = boto3.client("events", region_name="eu-west-2")
     test_rule = "my-job-XYZ"
     client.put_rule(
@@ -47,7 +42,7 @@ def test_get_old_schedule_name():
 
 
 @mock_aws
-def test_get_old_schedule_name_without_copilot_tags():
+def test_get_old_schedule_name_by_name_and_without_tags():
     client = boto3.client("events", region_name="eu-west-2")
     test_rule = "test-app-dev-my-job-Rule-XYZ"
     client.put_rule(
@@ -65,13 +60,13 @@ def test_get_old_schedule_name_without_copilot_tags():
 @mock_aws
 def test_get_old_schedule_raises_if_tags_and_name_dont_match():
     client = boto3.client("events", region_name="eu-west-2")
-    test_rule = "my-job-XYZ"
+    test_rule = "unmatching-name-XYZ"
     client.put_rule(
         Name=test_rule,
         ScheduleExpression="rate(5 minutes)",
         State="DISABLED",
         Tags=[
-            {"Key": "copilot-application", "Value": "something else"},
+            {"Key": "copilot-application", "Value": "unmatching"},
             {"Key": "copilot-environment", "Value": "dev"},
             {"Key": "copilot-service", "Value": "my-job"},
         ],

--- a/tests/platform_helper/domain/test_migrate_job.py
+++ b/tests/platform_helper/domain/test_migrate_job.py
@@ -12,6 +12,11 @@ from dbt_platform_helper.domain.migrate_job import ScheduleMigrator
 from dbt_platform_helper.domain.migrate_job import TooManyOldScheduledJobsFoundException
 
 
+def test__strip_prefix_and_suffix():
+    full_name = "app-env-job-Rule-weroitueworitu"
+    assert ScheduleMigrator("app", Mock(), Mock())._strip_suffix(full_name) == "app-env-job-Rule"
+
+
 def test_get_new_schedule_name():
     result = ScheduleMigrator("demodjango", Mock(), Mock()).get_new_schedule_name(
         "my-enabled-rule", "dev"
@@ -42,7 +47,23 @@ def test_get_old_schedule_name():
 
 
 @mock_aws
-def test_get_old_schedule_raises_if_tags_dont_match():
+def test_get_old_schedule_name_without_copilot_tags():
+    client = boto3.client("events", region_name="eu-west-2")
+    test_rule = "test-app-dev-my-job-Rule-XYZ"
+    client.put_rule(
+        Name=test_rule,
+        ScheduleExpression="rate(5 minutes)",
+        State="ENABLED",
+    )
+    result = ScheduleMigrator(
+        "test-app", OldScheduleProvider(client), Mock()
+    ).get_old_schedule_name("my-job", "dev")
+
+    assert result == "test-app-dev-my-job-Rule-XYZ"
+
+
+@mock_aws
+def test_get_old_schedule_raises_if_tags_and_name_dont_match():
     client = boto3.client("events", region_name="eu-west-2")
     test_rule = "my-job-XYZ"
     client.put_rule(


### PR DESCRIPTION
The internal migrate-command job was relying on copilot tags on the schedule rule.  However we discovered that for some services this resource did not have tags.  Therefore we provide a fallback method which finds the rule based on naming.

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present