### PR TITLE
fix: Prevent setting null values in the version tracker SSM parameter (off-ticket)

### DIFF
--- a/dbt_platform_helper/domain/versioning.py
+++ b/dbt_platform_helper/domain/versioning.py
@@ -170,7 +170,7 @@ class PlatformHelperVersioning:
         platform_helper_env_override = self.environment_variable_provider.get(
             PLATFORM_HELPER_VERSION_OVERRIDE_KEY
         )
-        if platform_helper_env_override:
+        if platform_helper_env_override and platform_helper_env_override != "NONE":
             return platform_helper_env_override
 
         return self.get_default_version()

--- a/tests/platform_helper/domain/test_versioning.py
+++ b/tests/platform_helper/domain/test_versioning.py
@@ -415,8 +415,9 @@ class TestPlatformHelperVersioningCodebasePipelinesVersioning:
         result = PlatformHelperVersioning(**mocks.params()).get_template_version()
         assert result == "platform_helper_env_override"
 
-    def test_get_template_version_default_fallback_when_no_overrides(
-        self, platform_config_for_env_pipelines
+    @pytest.mark.parametrize("platform_helper_env_override", [None, "NONE"])
+    def test_get_template_version_default_fallback_when_no_valid_overrides(
+        self, platform_config_for_env_pipelines, platform_helper_env_override
     ):
         platform_config_for_env_pipelines["default_versions"] = {"platform-helper": "1.1.1"}
 
@@ -425,7 +426,9 @@ class TestPlatformHelperVersioningCodebasePipelinesVersioning:
             platform_config_for_env_pipelines
         )
         mocks.mock_platform_helper_version_override = None
-        mocks.mock_environment_variable_provider[PLATFORM_HELPER_VERSION_OVERRIDE_KEY] = None
+        mocks.mock_environment_variable_provider[PLATFORM_HELPER_VERSION_OVERRIDE_KEY] = (
+            platform_helper_env_override
+        )
 
         result = PlatformHelperVersioning(**mocks.params()).get_template_version()
         assert result == "1.1.1"


### PR DESCRIPTION
This fix prevents setting the value of the environment [version tracker SSM parameter](https://github.com/uktrade/platform-tools/blob/c555baee9de0593e05c6555e26a38a3e06eb0d34/terraform/version-tracker/main.tf#L1)  as `NONE` for applications not enrolled in automatic platform upgrades.

This is currently an issue because we set the default value of the [PLATFORM_HELPER_VERSION_OVERRIDE](https://github.com/uktrade/platform-tools/blob/c555baee9de0593e05c6555e26a38a3e06eb0d34/terraform/environment-pipelines/codepipeline.tf#L24-L31) env variable in environment pipelines as `NONE`.

---
## Checklist:

### Title:
- [X] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [X] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present