### PR TITLE
fix: Disable image build notifications if using GitHub actions (DBTP-3071)

### DIFF
--- a/terraform/codebase-pipelines/buildspec-images.yml
+++ b/terraform/codebase-pipelines/buildspec-images.yml
@@ -25,7 +25,12 @@ phases:
         if [ -f .copilot/phases/build.sh ]; then 
           bash .copilot/phases/build.sh; 
         fi
-      - /work/cli build --publish --send-notifications
+      - |
+        if [ "${NOTIFICATIONS_ENABLED}" == "true" ]; then
+          /work/cli build --publish --send-notifications
+        else
+          /work/cli build --publish
+        fi
 
   post_build:
     commands:
@@ -34,7 +39,7 @@ phases:
           bash .copilot/phases/post_build.sh; 
         fi
         
-        if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ]; then
+        if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" && "${NOTIFICATIONS_ENABLED}" == "true" ]; then
           BUILD_ID_PREFIX=$(echo $CODEBUILD_BUILD_ID | cut -d':' -f1)
           echo "BUILD_ID_PREFIX - ${BUILD_ID_PREFIX}"
 

--- a/terraform/codebase-pipelines/buildspec-images.yml
+++ b/terraform/codebase-pipelines/buildspec-images.yml
@@ -39,7 +39,7 @@ phases:
           bash .copilot/phases/post_build.sh; 
         fi
         
-        if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" && "${NOTIFICATIONS_ENABLED}" == "true" ]; then
+        if [[ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" && "${NOTIFICATIONS_ENABLED}" == "true" ]]; then
           BUILD_ID_PREFIX=$(echo $CODEBUILD_BUILD_ID | cut -d':' -f1)
           echo "BUILD_ID_PREFIX - ${BUILD_ID_PREFIX}"
 

--- a/terraform/codebase-pipelines/codebuild.tf
+++ b/terraform/codebase-pipelines/codebuild.tf
@@ -59,6 +59,11 @@ resource "aws_codebuild_project" "codebase_image_build" {
         value = var.additional_ecr_repository
       }
     }
+
+    environment_variable {
+      name  = "NOTIFICATIONS_ENABLED"
+      value = !var.use_github_actions
+    }
   }
 
   logs_config {

--- a/terraform/codebase-pipelines/tests/unit.tftest.hcl
+++ b/terraform/codebase-pipelines/tests/unit.tftest.hcl
@@ -2601,11 +2601,6 @@ run "test_disable_codepipeline_triggers" {
   }
 
   assert {
-    condition     = aws_codebuild_webhook.codebuild_webhook == {}
-    error_message = "Should be: {}"
-  }
-
-  assert {
     condition = one([for var in one(aws_codebuild_project.codebase_image_build[""].environment).environment_variable :
     var.value if var.name == "NOTIFICATIONS_ENABLED"]) == "false"
     error_message = "Should be: 'false'"

--- a/terraform/codebase-pipelines/tests/unit.tftest.hcl
+++ b/terraform/codebase-pipelines/tests/unit.tftest.hcl
@@ -508,6 +508,11 @@ run "test_codebuild_images" {
     error_message = "Should be: '/fake/slack/channel'"
   }
   assert {
+    condition = one([for var in one(aws_codebuild_project.codebase_image_build[""].environment).environment_variable :
+    var.value if var.name == "NOTIFICATIONS_ENABLED"]) == "true"
+    error_message = "Should be: 'true'"
+  }
+  assert {
     condition = aws_codebuild_project.codebase_image_build[""].logs_config[0].cloudwatch_logs[
       0
     ].group_name == "codebuild/my-app-my-codebase-codebase-image-build/log-group"
@@ -2593,6 +2598,17 @@ run "test_disable_codepipeline_triggers" {
   assert {
     condition     = aws_codebuild_webhook.codebuild_webhook == {}
     error_message = "Should be: {}"
+  }
+
+  assert {
+    condition     = aws_codebuild_webhook.codebuild_webhook == {}
+    error_message = "Should be: {}"
+  }
+
+  assert {
+    condition = one([for var in one(aws_codebuild_project.codebase_image_build[""].environment).environment_variable :
+    var.value if var.name == "NOTIFICATIONS_ENABLED"]) == "false"
+    error_message = "Should be: 'false'"
   }
 
   assert {


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

Addresses https://uktrade.atlassian.net/browse/DBTP-3071

Prevent duplicate notifications when using GitHub actions deployment workflows.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [x] I have reviewed the PR and ensured no secret values are present