### PR TITLE
chore: Remove UpdateSchedule permission temporarily (off-ticket)

### DIFF
--- a/terraform/extensions/iam.tf
+++ b/terraform/extensions/iam.tf
@@ -719,7 +719,6 @@ data "aws_iam_policy_document" "eventbridge_scheduler_access" {
     effect = "Allow"
     actions = [
       "scheduler:CreateSchedule",
-      "scheduler:UpdateSchedule",
       "scheduler:GetSchedule",
       "scheduler:TagResource"
     ]


### PR DESCRIPTION
Temporarily removes the `UpdateSchedule` permission. A new PR re-adding this permission will be raised with the type as `fix` so that it can be included in the [15.30.1](https://github.com/uktrade/platform-tools/pull/1482) patch release.

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present