### PR TITLE
fix: Run PyPI release notification script with poetry (off-ticket)

### DIFF
--- a/publish_to_pypi.sh
+++ b/publish_to_pypi.sh
@@ -20,7 +20,7 @@ then
   python utils/check_pypi.py --max-attempts 20
   echo -e "\nSending slack notification"
   VERSION_NUMBER=($VERSION)
-  python utils/notify/publish_notification.py --publish-version ${VERSION_NUMBER[1]}
+  poetry run python utils/notify/publish_notification.py --publish-version ${VERSION_NUMBER[1]}
 else
   echo ${VERSION} of the package has already been published
 fi


### PR DESCRIPTION
A [previous PR](https://github.com/uktrade/platform-tools/pull/1481) simplified `buildspec.pypi.yml` by avoiding installing Platform Helper twice. It now only gets installed once via poetry, however that causes the notification script to fail [on this line](https://github.com/uktrade/platform-tools/blob/34a47a9814dc22c56c1ff0435c96b640fe33e640/utils/notify/publish_notification.py#L40) because the `platform-helper` package is not available globally anymore, it now only exists in the poetry virtual env. 

---
## Checklist:

### Title:
- [X] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [X] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present