### PR TITLE
fix: Use random string for lambda name (DBTP-2960)

### DIFF
--- a/terraform/opensearch/lambda.tf
+++ b/terraform/opensearch/lambda.tf
@@ -114,7 +114,12 @@ resource "aws_lambda_function" "lambda" {
     subnet_ids         = data.aws_subnets.private-subnets.ids
   }
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    {
+      name = local.name
+    }
+  )
 }
 
 resource "aws_lambda_invocation" "create-users" {

--- a/terraform/opensearch/lambda.tf
+++ b/terraform/opensearch/lambda.tf
@@ -87,11 +87,19 @@ data "archive_file" "lambda" {
   ]
 }
 
+resource "random_string" "lambda_suffix" {
+  length    = 6
+  min_lower = 6
+  special   = false
+  lower     = true
+}
+
+
 resource "aws_lambda_function" "lambda" {
   # checkov:skip=CKV_AWS_272:Code signing is not currently in use
   # checkov:skip=CKV_AWS_116:Dead letter queue not required due to the nature of this function
   filename                       = data.archive_file.lambda.output_path
-  function_name                  = "${var.application}-${var.environment}-${local.name}-opensearch-create-users"
+  function_name                  = substr("${var.application}-${var.environment}-opensearch-create-users-${random_string.lambda_suffix.result}", 0, 64)
   role                           = aws_iam_role.lambda-execution-role.arn
   handler                        = "manage_users.handler"
   runtime                        = "python3.12"


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-2960.

lambda naming is limited to 64 characters but adding application, environment and opensearch name adds up and can exceed the limit so instead attach a random string to the end.

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present