### PR TITLE
fix: Handle multi-command entrypoints in migrate command (off-ticket)

### DIFF
--- a/dbt_platform_helper/domain/service.py
+++ b/dbt_platform_helper/domain/service.py
@@ -499,7 +499,7 @@ class ServiceManager:
 
                 if "entrypoint" in service_manifest:
                     if isinstance(service_manifest["entrypoint"], str):
-                        service_manifest["entrypoint"] = [service_manifest["entrypoint"]]
+                        service_manifest["entrypoint"] = service_manifest["entrypoint"].split()
 
                 if "alias" in service_manifest.get("http", {}):
                     if isinstance(service_manifest["http"]["alias"], str):

--- a/tests/platform_helper/domain/test_service.py
+++ b/tests/platform_helper/domain/test_service.py
@@ -1112,6 +1112,34 @@ environments:
     assert service_config == expected_service_config
 
 
+def test_migrate_scheduled_job_handles_multi_string_entrypoint(
+    copilot_scheduled_job_manifest, expected_scheduled_job_config
+):
+    path = copilot_scheduled_job_manifest(
+        {"entrypoint": "launcher python manage.py some_management_command"}
+    )
+
+    expected_service_config = expected_scheduled_job_config(
+        {
+            "entrypoint": [
+                "launcher",
+                "python",
+                "manage.py",
+                "some_management_command",
+            ]
+        }
+    )
+
+    os.chdir(path)
+    service_manager = ServiceManager()
+    service_manager.migrate_copilot_manifests()
+
+    with open(path / "services/my-scheduled-service/service-config.yml") as f:
+        service_config = yaml.safe_load(f)
+
+    assert service_config == expected_service_config
+
+
 @pytest.mark.parametrize(
     "timeout_string,expected",
     [("1h", 3600), ("60m", 3600)],


### PR DESCRIPTION
Each entrypoint command needs to become its own string within a list for the new `service-config.yml` format.

---
## Checklist:

### Title:
- [X] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [X] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present