### PR TITLE
ci: Group up Terraform Dependabot upgrades (off-ticket)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
       default-days: 7
     directories:
       - "/terraform/*/"
+    groups:
+      per-dependency:
+        group-by: dependency-name
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
When a new version of a dependency is made available, Dependabot will raise a PR for each directory that dependency is defined.

By using the grouping functionality this will reduce the number of PRs raised to just one per dependency.

Example list of AWS upgrades:
https://github.com/uktrade/platform-tools/pulls?q=is%3Apr+label%3Adependencies+label%3Aterraform+hashicorp%2Faws

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present