### PR TITLE
fix: Custom codebuild stage permissions for de-copilotted scheduled jobs (DBTP-2384)

### DIFF
--- a/terraform/codebase-pipelines/iam.tf
+++ b/terraform/codebase-pipelines/iam.tf
@@ -198,8 +198,8 @@ data "aws_iam_policy_document" "custom_codebuild_scheduled_job_permissions" {
       "states:DescribeExecution"
     ]
     resources = [
-      "arn:aws:states:eu-west-2:816069161783:stateMachine:psd-*-sfn",
-      "arn:aws:states:eu-west-2:816069161783:execution:psd-*-sfn*"
+      "arn:aws:states:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.application}-*-sfn",
+      "arn:aws:states:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:execution:${var.application}-*-sfn*"
     ]
   }
 }

--- a/terraform/codebase-pipelines/iam.tf
+++ b/terraform/codebase-pipelines/iam.tf
@@ -172,6 +172,44 @@ resource "aws_iam_role" "codebase_deploy_pipeline" {
   tags               = local.tags
 }
 
+
+data "aws_iam_policy_document" "custom_codebuild_scheduled_job_permissions" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:ListAccountAliases",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "ListDeployedServices"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParametersByPath",
+    ]
+    resources = ["arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter/platform/applications/${var.application}/environments/*/services/*"]
+  }
+
+  statement {
+    sid    = "ExecuteScheduledJobs"
+    effect = "Allow"
+    actions = [
+      "states:StartExecution",
+      "states:DescribeExecution"
+    ]
+    resources = [
+      "arn:aws:states:eu-west-2:816069161783:stateMachine:psd-*-sfn",
+      "arn:aws:states:eu-west-2:816069161783:execution:psd-*-sfn*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "custom_codebuild_scheduled_job_permissions" {
+  name   = "run-scheduled-jobs"
+  role   = aws_iam_role.codebase_deploy.name
+  policy = data.aws_iam_policy_document.custom_codebuild_scheduled_job_permissions.json
+}
+
 data "aws_iam_policy_document" "assume_codepipeline_role" {
   statement {
     effect = "Allow"

--- a/terraform/codebase-pipelines/iam.tf
+++ b/terraform/codebase-pipelines/iam.tf
@@ -204,10 +204,16 @@ data "aws_iam_policy_document" "custom_codebuild_scheduled_job_permissions" {
   }
 }
 
-resource "aws_iam_role_policy" "custom_codebuild_scheduled_job_permissions" {
-  name   = "run-scheduled-jobs"
-  role   = aws_iam_role.codebase_deploy.name
-  policy = data.aws_iam_policy_document.custom_codebuild_scheduled_job_permissions.json
+resource "aws_iam_policy" "custom_codebuild_scheduled_job_permissions" {
+  for_each = toset(local.has_custom_pre_deploy || local.has_custom_post_deploy ? [""] : [])
+  name     = "run-scheduled-jobs"
+  policy   = data.aws_iam_policy_document.custom_codebuild_scheduled_job_permissions.json
+}
+
+resource "aws_iam_role_policy_attachment" "custom_codebuild_scheduled_job_permissions" {
+  for_each   = toset(local.has_custom_pre_deploy || local.has_custom_post_deploy ? [""] : [])
+  role       = aws_iam_role.codebase_deploy.name
+  policy_arn = aws_iam_policy.custom_codebuild_scheduled_job_permissions[""].arn
 }
 
 data "aws_iam_policy_document" "assume_codepipeline_role" {

--- a/terraform/codebase-pipelines/iam.tf
+++ b/terraform/codebase-pipelines/iam.tf
@@ -182,7 +182,7 @@ data "aws_iam_policy_document" "custom_codebuild_scheduled_job_permissions" {
     resources = ["*"]
   }
 
-    statement {
+  statement {
     sid    = "ListDeployedServices"
     effect = "Allow"
     actions = [

--- a/terraform/codebase-pipelines/iam.tf
+++ b/terraform/codebase-pipelines/iam.tf
@@ -181,7 +181,8 @@ data "aws_iam_policy_document" "custom_codebuild_scheduled_job_permissions" {
     ]
     resources = ["*"]
   }
-  statement {
+
+    statement {
     sid    = "ListDeployedServices"
     effect = "Allow"
     actions = [

--- a/terraform/codebase-pipelines/tests/unit.tftest.hcl
+++ b/terraform/codebase-pipelines/tests/unit.tftest.hcl
@@ -722,6 +722,16 @@ run "test_custom_pre_deploy" {
     condition     = aws_codepipeline.manual_release_pipeline.stage[1].action[0].name == "custom-pre-deploy"
     error_message = "Should be: custom-pre-deploy"
   }
+
+  assert {
+    condition     = aws_iam_policy.custom_codebuild_scheduled_job_permissions[""].name == "run-scheduled-jobs"
+    error_message = "Should be: 'run-scheduled-jobs'"
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.custom_codebuild_scheduled_job_permissions[""].role == aws_iam_role.codebase_deploy.name
+    error_message = "Should be attached to codebase_deploy role"
+  }
 }
 
 
@@ -760,6 +770,16 @@ run "test_custom_post_deploy" {
   assert {
     condition     = aws_codepipeline.manual_release_pipeline.stage[1].action[3].name == "custom-post-deploy"
     error_message = "Should be: custom-post-deploy"
+  }
+
+  assert {
+    condition     = aws_iam_policy.custom_codebuild_scheduled_job_permissions[""].name == "run-scheduled-jobs"
+    error_message = "Should be: 'run-scheduled-jobs'"
+  }
+  
+  assert {
+    condition     = aws_iam_role_policy_attachment.custom_codebuild_scheduled_job_permissions[""].role == aws_iam_role.codebase_deploy.name
+    error_message = "Should be attached to codebase_deploy role"
   }
 
 }
@@ -1136,6 +1156,11 @@ run "test_iam" {
   assert {
     condition     = aws_iam_role_policy.env_manager_access.policy == "{\"Sid\": \"AssumeEnvManagerAccess\"}"
     error_message = "Should be: {\"Sid\": \"AssumeEnvManagerAccess\"}"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.custom_codebuild_scheduled_job_permissions) == 0
+    error_message = "Should not be attached to codebase_deploy role without custom steps"
   }
 }
 

--- a/terraform/codebase-pipelines/tests/unit.tftest.hcl
+++ b/terraform/codebase-pipelines/tests/unit.tftest.hcl
@@ -156,6 +156,14 @@ override_data {
   }
 }
 
+override_data {
+  target = data.aws_iam_policy_document.custom_codebuild_scheduled_job_permissions
+  values = {
+    json = "{\"Sid\": \"AllowScheduledJobs\"}"
+  }
+}
+
+
 variables {
   env_config = {
     "*" = {


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-2384.

Custom codebuild steps configured in the codebase pipelines must have permission to execute scheduled jobs.  After moving scheduled jobs to the managed-platform these additional permissions are required.

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present