### PR TITLE
fix: Duplicate resource error when multiple codebases with pre/post deploy stage (Off-ticket)

### DIFF
--- a/terraform/codebase-pipelines/iam.tf
+++ b/terraform/codebase-pipelines/iam.tf
@@ -207,7 +207,7 @@ data "aws_iam_policy_document" "custom_codebuild_scheduled_job_permissions" {
 
 resource "aws_iam_policy" "custom_codebuild_scheduled_job_permissions" {
   for_each = toset(local.has_custom_pre_deploy || local.has_custom_post_deploy ? [""] : [])
-  name     = "run-scheduled-jobs"
+  name     = "${var.application}-${var.codebase}-run-scheduled-jobs"
   policy   = data.aws_iam_policy_document.custom_codebuild_scheduled_job_permissions.json
 }
 

--- a/terraform/codebase-pipelines/tests/unit.tftest.hcl
+++ b/terraform/codebase-pipelines/tests/unit.tftest.hcl
@@ -724,8 +724,8 @@ run "test_custom_pre_deploy" {
   }
 
   assert {
-    condition     = aws_iam_policy.custom_codebuild_scheduled_job_permissions[""].name == "run-scheduled-jobs"
-    error_message = "Should be: 'run-scheduled-jobs'"
+    condition     = aws_iam_policy.custom_codebuild_scheduled_job_permissions[""].name == "my-app-my-codebase-run-scheduled-jobs"
+    error_message = "Should be: 'my-app-my-codebase-run-scheduled-jobs'"
   }
 
   assert {
@@ -773,8 +773,8 @@ run "test_custom_post_deploy" {
   }
 
   assert {
-    condition     = aws_iam_policy.custom_codebuild_scheduled_job_permissions[""].name == "run-scheduled-jobs"
-    error_message = "Should be: 'run-scheduled-jobs'"
+    condition     = aws_iam_policy.custom_codebuild_scheduled_job_permissions[""].name == "my-app-my-codebase-run-scheduled-jobs"
+    error_message = "Should be: 'my-app-my-codebase-run-scheduled-jobs'"
   }
 
   assert {


### PR DESCRIPTION
Fixes the following TF apply error:

```Error: creating IAM Policy (run-scheduled-jobs): operation error IAM: CreatePolicy, https response error StatusCode: 409, RequestID: 293100be-7c48-475e-94fe-560b3c1d7a19, EntityAlreadyExists: A policy called run-scheduled-jobs already exists. Duplicate names are not allowed.```

This error occurs only **IF** there is more than one `codebase_pipeline` defined in `platform-config.yml` **AND** there is a custom post or pre deploy stage configured in the deploy repo (`/custom-build/pre-deploy.sh` or `/custom-build/post-deploy.sh` exists).

The `run-scheduled-job` policy name needs to be prefixed with the unique codebase name to avoid hitting the above duplicate resource error on TF apply.


---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present