### PR TITLE
feat: Allow codebase pipelines without a list of services (DBTP-3184)

### DIFF
--- a/dbt_platform_helper/entities/platform_config_schema.py
+++ b/dbt_platform_helper/entities/platform_config_schema.py
@@ -149,7 +149,7 @@ class PlatformConfigSchema:
                 Optional("pipeline_mode"): str,
                 Optional("additional_ecr_repository"): str,
                 Optional("deploy_repository_branch"): str,
-                "services": [{str: [str]}],
+                Optional("services"): [{str: [str]}],
                 Optional("pipelines"): [
                     Or(
                         {

--- a/dbt_platform_helper/providers/terraform_manifest.py
+++ b/dbt_platform_helper/providers/terraform_manifest.py
@@ -326,7 +326,7 @@ class TerraformManifestProvider:
                 "additional_ecr_repository": '${lookup(each.value, "additional_ecr_repository", null)}',
                 "cache_invalidation": '${lookup(each.value, "cache_invalidation", null)}',
                 "pipelines": '${lookup(each.value, "pipelines", [])}',
-                "services": "${each.value.services}",
+                "services": '${lookup(each.value, "services", null)}',
                 "requires_image_build": '${lookup(each.value, "requires_image_build", true)}',
                 "slack_channel": '${lookup(each.value, "slack_channel", "/codebuild/slack_oauth_channel")}',
                 "pipeline_mode": '${lookup(each.value, "pipeline_mode", "aws_codepipeline")}',

--- a/terraform/codebase-pipelines/locals.tf
+++ b/terraform/codebase-pipelines/locals.tf
@@ -183,11 +183,11 @@ locals {
         }]
       )])
     }
-    if local.codepipeline_enabled
+    if local.codepipeline_enabled && var.services != null
   }
 
   manual_pipeline_actions_map = concat(
-    local.has_custom_pre_deploy ? [{
+    local.codepipeline_enabled && var.services != null && local.has_custom_pre_deploy ? [{
       name : "custom-pre-deploy",
       order : 1,
       configuration = {
@@ -235,8 +235,9 @@ locals {
           ]))
         }
       }] : [],
-    )]),
-    local.platform_deployment_enabled ? [{
+      ) if local.codepipeline_enabled && var.services != null
+    ]),
+    local.codepipeline_enabled && var.services != null && local.platform_deployment_enabled ? [{
       name : "update-alb-rules",
       order : max([for svc in local.service_order_list : svc.order]...) + 3,
       input_artifacts : ["tools_output"],
@@ -251,7 +252,7 @@ locals {
         ])
       }
     }] : [],
-    local.cache_invalidation_enabled ? [{
+    local.codepipeline_enabled && var.services != null && local.cache_invalidation_enabled ? [{
       name : "invalidate-cache",
       order : max([for svc in local.service_order_list : svc.order]...) + 3,
       configuration = {
@@ -263,7 +264,7 @@ locals {
         ])
       }
     }] : [],
-    local.has_custom_post_deploy ? [{
+    local.codepipeline_enabled && var.services != null && local.has_custom_post_deploy ? [{
       name : "custom-post-deploy",
       order : max([for svc in local.service_order_list : svc.order]...) + 4,
       configuration = {
@@ -281,11 +282,13 @@ locals {
     }
   })
 
-  services = sort(flatten([
-    for run_group in var.services : [for service in flatten(values(run_group)) : service]
-  ]))
+  services = local.codepipeline_enabled && var.services != null ? sort(flatten([
+    for run_group in var.services : [
+      for service in flatten(values(run_group)) : service
+    ]
+  ])) : []
 
-  service_order_list = flatten([
+  service_order_list = local.codepipeline_enabled && var.services != null ? flatten([
     for index, group in var.services : [
       for key, services in group : [
         for sorted_service in local.services : [
@@ -296,7 +299,7 @@ locals {
         ]
       ]
     ]
-  ])
+  ]) : []
 
   # Set to true if any environment contains a service-deployment-mode whose value is not 'copilot'
   platform_deployment_enabled = local.codepipeline_enabled && anytrue([for env in local.base_env_config : true if env.service_deployment_mode != "copilot"])

--- a/terraform/codebase-pipelines/ssm.tf
+++ b/terraform/codebase-pipelines/ssm.tf
@@ -10,6 +10,7 @@ resource "aws_ssm_parameter" "codebase_config" {
     "deploy_repository_branch" : var.deploy_repository_branch,
     "additional_ecr_repository" : var.additional_ecr_repository,
     "slack_channel" : var.slack_channel,
+    "pipeline_mode" : var.pipeline_mode,
     "requires_image_build" : var.requires_image_build,
     "services" : var.services,
     "pipelines" : var.pipelines

--- a/terraform/codebase-pipelines/variables.tf
+++ b/terraform/codebase-pipelines/variables.tf
@@ -74,7 +74,14 @@ variable "pipelines" {
 }
 
 variable "services" {
-  type = any
+  type     = any
+  nullable = true
+  default  = null
+
+  validation {
+    condition     = var.services != null || var.pipeline_mode == "github_actions"
+    error_message = "Unless pipeline_mode is set to 'github_actions', you must define either a list of services or a list of run groups, each containing a list of services."
+  }
 }
 
 variable "slack_channel" {

--- a/tests/platform_helper/providers/test_terraform_manifest.py
+++ b/tests/platform_helper/providers/test_terraform_manifest.py
@@ -97,7 +97,7 @@ def test_generate_codebase_pipeline_config_creates_file(
         == '${lookup(each.value, "additional_ecr_repository", null)}'
     )
     assert codebase_pipelines_module["pipelines"] == '${lookup(each.value, "pipelines", [])}'
-    assert codebase_pipelines_module["services"] == "${each.value.services}"
+    assert codebase_pipelines_module["services"] == '${lookup(each.value, "services", null)}'
     assert (
         codebase_pipelines_module["requires_image_build"]
         == '${lookup(each.value, "requires_image_build", true)}'


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-3184.

Allows you to configure a codebase in `platform-config.yml` without a list of services when `pipeline_mode` is set to `github_actions`. Useful for those who migrate their CI/CD pipelines from AWS CodePipeline to GitHub Actions. 

For example, instead of:

```yaml
codebase-pipelines:
  hello-world:
    repository: uktrade/hello-world
    services:
    - run_group_1:
      - hello-world
```

You can now simplify that config:
```yaml
codebase-pipelines:
  hello-world:
    repository: uktrade/hello-world
    pipeline_mode: github_actions
```

---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present