### PR TITLE
fix: Fix resource creation order when creating an opensearch extension (off-ticket)

### DIFF
--- a/terraform/opensearch/conduit.tf
+++ b/terraform/opensearch/conduit.tf
@@ -148,7 +148,12 @@ resource "aws_cloudwatch_log_group" "conduit-logs" {
   retention_in_days = 7
   tags              = local.tags
   kms_key_id        = aws_kms_key.cloudwatch_log_group_kms_key.arn
-
+  depends_on = [
+    # When creating a log group, AWS validates that the referenced KMS key's
+    # IAM policy allows it to be used by CloudWatch. So we need to ensure we've
+    # attached the policy to the key before trying to create the log group.
+    aws_kms_key_policy.opensearch_to_cloudwatch,
+  ]
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "conduit-logs-filter" {

--- a/terraform/opensearch/lambda.tf
+++ b/terraform/opensearch/lambda.tf
@@ -120,6 +120,14 @@ resource "aws_lambda_function" "lambda" {
       name = local.name
     }
   )
+
+  depends_on = [
+    # When creating a Lambda function, AWS validates that the execution role
+    # has fundamental permissions like ec2:CreateNetworkInterface. So we need
+    # to ensure we've attached the policy to the role before trying to create
+    # the lambda.
+    aws_iam_role_policy.lambda-execution-role-policy,
+  ]
 }
 
 resource "aws_lambda_invocation" "create-users" {

--- a/terraform/opensearch/main.tf
+++ b/terraform/opensearch/main.tf
@@ -39,6 +39,12 @@ resource "aws_cloudwatch_log_group" "opensearch_log_group_index_slow_logs" {
   retention_in_days = coalesce(var.config.index_slow_log_retention_in_days, 7)
   kms_key_id        = aws_kms_key.cloudwatch_log_group_kms_key.arn
   tags              = local.tags
+  depends_on = [
+    # When creating a log group, AWS validates that the referenced KMS key's
+    # IAM policy allows it to be used by CloudWatch. So we need to ensure we've
+    # attached the policy to the key before trying to create the log group.
+    aws_kms_key_policy.opensearch_to_cloudwatch,
+  ]
 }
 
 resource "aws_cloudwatch_log_group" "opensearch_log_group_search_slow_logs" {
@@ -46,6 +52,9 @@ resource "aws_cloudwatch_log_group" "opensearch_log_group_search_slow_logs" {
   retention_in_days = coalesce(var.config.search_slow_log_retention_in_days, 7)
   kms_key_id        = aws_kms_key.cloudwatch_log_group_kms_key.arn
   tags              = local.tags
+  depends_on = [
+    aws_kms_key_policy.opensearch_to_cloudwatch,
+  ]
 }
 
 resource "aws_cloudwatch_log_group" "opensearch_log_group_es_application_logs" {
@@ -53,6 +62,9 @@ resource "aws_cloudwatch_log_group" "opensearch_log_group_es_application_logs" {
   retention_in_days = coalesce(var.config.es_app_log_retention_in_days, 7)
   kms_key_id        = aws_kms_key.cloudwatch_log_group_kms_key.arn
   tags              = local.tags
+  depends_on = [
+    aws_kms_key_policy.opensearch_to_cloudwatch,
+  ]
 }
 
 resource "aws_cloudwatch_log_group" "opensearch_log_group_audit_logs" {
@@ -60,6 +72,9 @@ resource "aws_cloudwatch_log_group" "opensearch_log_group_audit_logs" {
   retention_in_days = coalesce(var.config.audit_log_retention_in_days, 7)
   kms_key_id        = aws_kms_key.cloudwatch_log_group_kms_key.arn
   tags              = local.tags
+  depends_on = [
+    aws_kms_key_policy.opensearch_to_cloudwatch,
+  ]
 }
 
 resource "aws_security_group" "opensearch-security-group" {


### PR DESCRIPTION
I noticed this when creating a new demodjango environment (which has an opensearch extension right off the bat).

When applying environment terraform for the first time, I hit two errors:

* Failed to create the manage-users lambda function, because at this time the lambda's execution role didn't have the required ec2:CreateNetworkInterface permission. This was because terraform tried to create the lambda function before it had attached the IAM policy (which contains ec2:CreateNetworkInterface) to the role.
* Failed to create the CloudWatch log groups, because at this time the KMS key that they were configured to use didn't have permission to be used by CloudWatch. This was because terraform tried to create the log groups before it had attached the KMS key's IAM policy to the key.

This PR fixes both issues by adding `depends_on` directives to tell Terraform that the IAM policies need to be created & attached before the lambda function / log groups can be created.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [x] If the work includes user interface changes, before and after screenshots included in description
- [x] Includes any applicable changes to the documentation in this code base
- [x] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [x] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing
  - https://763451185160-gf65u6pc.eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/pull-request-end-to-end-tests/executions/6d068c1b-fe6f-4658-a6ba-8c56b2bacf3e/visualization?region=eu-west-2

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present