### PR TITLE
fix: Enable Paketo image build notifications by default (off-ticket)

### DIFF
--- a/terraform/codebase-pipelines/codebuild.tf
+++ b/terraform/codebase-pipelines/codebuild.tf
@@ -60,10 +60,10 @@ resource "aws_codebuild_project" "codebase_image_build" {
       }
     }
 
-    # Can be overridden as 'false' when an image build is triggered from GitHub Actions, since our GitHub workflows handle notifications differently
+    # Can be set to "false" for builds triggered by GitHub Actions, where notifications are handled by the GitHub workflow instead of CodeBuild
     environment_variable {
       name  = "NOTIFICATIONS_ENABLED"
-      value = true
+      value = "true"
     }
   }
 

--- a/terraform/codebase-pipelines/codebuild.tf
+++ b/terraform/codebase-pipelines/codebuild.tf
@@ -60,6 +60,7 @@ resource "aws_codebuild_project" "codebase_image_build" {
       }
     }
 
+    # Can be overridden as 'false' when an image build is triggered from GitHub Actions, since our GitHub workflows handle notifications differently
     environment_variable {
       name  = "NOTIFICATIONS_ENABLED"
       value = true

--- a/terraform/codebase-pipelines/codebuild.tf
+++ b/terraform/codebase-pipelines/codebuild.tf
@@ -62,7 +62,7 @@ resource "aws_codebuild_project" "codebase_image_build" {
 
     environment_variable {
       name  = "NOTIFICATIONS_ENABLED"
-      value = !local.github_actions_enabled
+      value = true
     }
   }
 

--- a/terraform/codebase-pipelines/tests/unit.tftest.hcl
+++ b/terraform/codebase-pipelines/tests/unit.tftest.hcl
@@ -2634,12 +2634,6 @@ run "test_disable_codepipeline_triggers" {
   }
 
   assert {
-    condition = one([for var in one(aws_codebuild_project.codebase_image_build[""].environment).environment_variable :
-    var.value if var.name == "NOTIFICATIONS_ENABLED"]) == "false"
-    error_message = "Should be: 'false'"
-  }
-
-  assert {
     condition     = aws_cloudwatch_event_rule.ecr_image_publish[0].state == "DISABLED"
     error_message = "Should be: 'DISABLED'"
   }


### PR DESCRIPTION
Addresses a bug from a platform requests, where disabling Paketo image build notifications via the `pipeline_mode` property in `platform-config.yml` was causing deployment issues due to skipping the creation of the Slack timestamp label.

This PR enables those notifications by default, Slack label gets populated, and instead we'll override `NOTIFICATIONS_ENABLED` when calling the image build CodeBuild project from GitHub Actions and set it as `false` that way.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present