### PR TITLE
feat: Use new bucket for non-production ALB logs (SR-2696)

### DIFF
--- a/terraform/application-load-balancer/main.tf
+++ b/terraform/application-load-balancer/main.tf
@@ -52,7 +52,7 @@ resource "aws_lb" "this" {
     aws_security_group.alb-security-group["https"].id
   ]
   access_logs {
-    bucket  = var.environment == "prod" ? "dbt-access-logs-production" : "dbt-access-logs-non-production"
+    bucket  = var.environment == "prod" ? "dbt-access-logs-production" : "alb-access-logs-non-prod-812359060647-eu-west-2-an"
     prefix  = "${var.application}/${var.environment}"
     enabled = true
   }

--- a/terraform/application-load-balancer/tests/unit.tftest.hcl
+++ b/terraform/application-load-balancer/tests/unit.tftest.hcl
@@ -146,9 +146,9 @@ run "aws_lb_unit_test" {
   assert {
     condition = (
       (var.environment == "prod" && aws_lb.this.access_logs[0].bucket == "dbt-access-logs-production") ||
-      (var.environment != "prod" && aws_lb.this.access_logs[0].bucket == "dbt-access-logs-non-production")
+      (var.environment != "prod" && aws_lb.this.access_logs[0].bucket == "alb-access-logs-non-prod-812359060647-eu-west-2-an")
     )
-    error_message = "ALB access_logs bucket must be dbt-access-logs-production or dbt-access-logs-non-production"
+    error_message = "ALB access_logs bucket must be dbt-access-logs-production or alb-access-logs-non-prod-812359060647-eu-west-2-an"
   }
 
   assert {


### PR DESCRIPTION
As part of a general effort to refactor the various logging components maintained by SRE, we have created buckets for ALB logs.

In the first instance, we will be updating the bucket for non-production logs. Once we are happy that the infrastructure and parsing is working as expected, we will then make the equivalent change to non production.

<https://uktrade.atlassian.net/browse/SR-2696>

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [x] I have reviewed the PR and ensured no secret values are present