### PR TITLE
feat: Allow overriding the default key policy for statefile-backend (SR-4918)

### DIFF
--- a/terraform/statefile-backend/main.tf
+++ b/terraform/statefile-backend/main.tf
@@ -48,7 +48,7 @@ resource "aws_kms_key" "terraform-bucket-key" {
   # checkov:skip=CKV_AWS_7:We are not currently rotating the keys
   description = "This key is used to encrypt bucket objects"
 
-  policy = jsonencode({
+  policy = var.custom_key_policy != null ? var.custom_key_policy : jsonencode({
     Id = "key-default-1"
     Statement = [
       {

--- a/terraform/statefile-backend/tests/unit.tftest.hcl
+++ b/terraform/statefile-backend/tests/unit.tftest.hcl
@@ -133,3 +133,15 @@ run "aws_dynamodb_table_unit_test" {
     error_message = "The 'LockID' key must be of type string ('S')"
   }
 }
+
+run "aws_custom_kms_key_policy" {
+  command = plan
+  variables {
+    custom_key_policy = "{ \"key\" : \"custom\" }"
+  }
+
+  assert {
+    condition     = aws_kms_key.terraform-bucket-key.policy == "{ \"key\" : \"custom\" }"
+    error_message = "Custom key policy should be set for kms key"
+  }
+}

--- a/terraform/statefile-backend/variables.tf
+++ b/terraform/statefile-backend/variables.tf
@@ -2,3 +2,9 @@ variable "aws_account_name" {
   default = null
   type    = string
 }
+
+variable "custom_key_policy" {
+  default     = null
+  type        = string
+  description = "Used to override the default key policy on the KMS key that encrypts the state file in cases it is required."
+}


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

Addresses https://uktrade.atlassian.net/browse/SR-4918.

---
## Checklist:

### Title:
- [X] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [X] Link to ticket included (unless it's a quick out of ticket thing)
- [X] Includes tests (or an explanation for why it doesn't)
- [X] If the work includes user interface changes, before and after screenshots included in description
- [X] Includes any applicable changes to the documentation in this code base
- [X] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [X] [Run the end to end tests for this branch](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests) and confirm that they are passing

## Reviewer Checklist

- [X] I have reviewed the PR and ensured no secret values are present